### PR TITLE
BigQuery Runbook

### DIFF
--- a/pkg/cli/serve.go
+++ b/pkg/cli/serve.go
@@ -9,12 +9,37 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/cli/config"
 	server "github.com/secmon-lab/warren/pkg/controller/http"
 	"github.com/secmon-lab/warren/pkg/usecase"
 	"github.com/secmon-lab/warren/pkg/utils/logging"
 	"github.com/urfave/cli/v3"
 )
+
+// llmEmbeddingAdapter adapts gollem.LLMClient to interfaces.EmbeddingClient
+type llmEmbeddingAdapter struct {
+	client gollem.LLMClient
+}
+
+// Embeddings implements interfaces.EmbeddingClient.Embeddings
+func (a *llmEmbeddingAdapter) Embeddings(ctx context.Context, texts []string, dimensionality int) ([][]float32, error) {
+	embeddings, err := a.client.GenerateEmbedding(ctx, dimensionality, texts)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert from [][]float64 to [][]float32
+	result := make([][]float32, len(embeddings))
+	for i, embedding := range embeddings {
+		result[i] = make([]float32, len(embedding))
+		for j, val := range embedding {
+			result[i][j] = float32(val)
+		}
+	}
+
+	return result, nil
+}
 
 func cmdServe() *cli.Command {
 	var (
@@ -113,6 +138,12 @@ func cmdServe() *cli.Command {
 			if err != nil {
 				return err
 			}
+
+			// Create embedding adapter from LLM client
+			embeddingAdapter := &llmEmbeddingAdapter{client: geminiModel}
+
+			// Inject dependencies into tools that support them
+			tools.InjectDependencies(firestore, embeddingAdapter)
 
 			toolSets, err := tools.ToolSets(ctx)
 			if err != nil {

--- a/pkg/cli/utils.go
+++ b/pkg/cli/utils.go
@@ -37,6 +37,22 @@ var tools = toolList{
 	&bigquery.Action{},
 }
 
+// InjectDependencies injects repository and embedding client into tools that support them
+func (x toolList) InjectDependencies(repo interfaces.Repository, embeddingClient interfaces.EmbeddingClient) {
+	for _, tool := range x {
+		// Check if tool supports repository injection
+		if repoSetter, ok := tool.(interface{ SetRepository(interfaces.Repository) }); ok {
+			repoSetter.SetRepository(repo)
+		}
+		// Check if tool supports embedding client injection
+		if embeddingSetter, ok := tool.(interface {
+			SetEmbeddingClient(interfaces.EmbeddingClient)
+		}); ok {
+			embeddingSetter.SetEmbeddingClient(embeddingClient)
+		}
+	}
+}
+
 func (x toolList) Flags() []cli.Flag {
 	flags := []cli.Flag{}
 	for _, tool := range x {

--- a/pkg/domain/interfaces/repository.go
+++ b/pkg/domain/interfaces/repository.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/secmon-lab/warren/pkg/domain/model/alert"
 	"github.com/secmon-lab/warren/pkg/domain/model/auth"
+	"github.com/secmon-lab/warren/pkg/domain/model/bigquery"
 	"github.com/secmon-lab/warren/pkg/domain/model/slack"
 	"github.com/secmon-lab/warren/pkg/domain/model/ticket"
 	"github.com/secmon-lab/warren/pkg/domain/types"
@@ -60,4 +61,10 @@ type Repository interface {
 	PutToken(ctx context.Context, token *auth.Token) error
 	GetToken(ctx context.Context, tokenID auth.TokenID) (*auth.Token, error)
 	DeleteToken(ctx context.Context, tokenID auth.TokenID) error
+
+	// For runbook management
+	PutRunbookEntry(ctx context.Context, entry *bigquery.RunbookEntry) error
+	GetRunbookEntry(ctx context.Context, runbookID types.RunbookID) (*bigquery.RunbookEntry, error)
+	GetRunbookEntryByHash(ctx context.Context, hash string) (*bigquery.RunbookEntry, error)
+	SearchRunbooksByEmbedding(ctx context.Context, embedding []float64, limit int) (bigquery.RunbookSearchResults, error)
 }

--- a/pkg/domain/mock/interfaces.go
+++ b/pkg/domain/mock/interfaces.go
@@ -9,6 +9,7 @@ import (
 	"github.com/m-mizutani/opaq"
 	"github.com/secmon-lab/warren/pkg/domain/model/alert"
 	"github.com/secmon-lab/warren/pkg/domain/model/auth"
+	"github.com/secmon-lab/warren/pkg/domain/model/bigquery"
 	modelslack "github.com/secmon-lab/warren/pkg/domain/model/slack"
 	"github.com/secmon-lab/warren/pkg/domain/model/ticket"
 	"github.com/secmon-lab/warren/pkg/domain/types"
@@ -689,6 +690,12 @@ func (mock *SlackThreadServiceMock) ReplyCalls() []struct {
 //			GetLatestHistoryFunc: func(ctx context.Context, ticketID types.TicketID) (*ticket.History, error) {
 //				panic("mock out the GetLatestHistory method")
 //			},
+//			GetRunbookEntryFunc: func(ctx context.Context, runbookID types.RunbookID) (*bigquery.RunbookEntry, error) {
+//				panic("mock out the GetRunbookEntry method")
+//			},
+//			GetRunbookEntryByHashFunc: func(ctx context.Context, hash string) (*bigquery.RunbookEntry, error) {
+//				panic("mock out the GetRunbookEntryByHash method")
+//			},
 //			GetTicketFunc: func(ctx context.Context, ticketID types.TicketID) (*ticket.Ticket, error) {
 //				panic("mock out the GetTicket method")
 //			},
@@ -722,6 +729,9 @@ func (mock *SlackThreadServiceMock) ReplyCalls() []struct {
 //			PutHistoryFunc: func(ctx context.Context, ticketID types.TicketID, history *ticket.History) error {
 //				panic("mock out the PutHistory method")
 //			},
+//			PutRunbookEntryFunc: func(ctx context.Context, entry *bigquery.RunbookEntry) error {
+//				panic("mock out the PutRunbookEntry method")
+//			},
 //			PutTicketFunc: func(ctx context.Context, ticketMoqParam ticket.Ticket) error {
 //				panic("mock out the PutTicket method")
 //			},
@@ -736,6 +746,9 @@ func (mock *SlackThreadServiceMock) ReplyCalls() []struct {
 //			},
 //			SearchAlertsFunc: func(ctx context.Context, path string, op string, value any, limit int) (alert.Alerts, error) {
 //				panic("mock out the SearchAlerts method")
+//			},
+//			SearchRunbooksByEmbeddingFunc: func(ctx context.Context, embedding []float64, limit int) (bigquery.RunbookSearchResults, error) {
+//				panic("mock out the SearchRunbooksByEmbedding method")
 //			},
 //			UnbindAlertFromTicketFunc: func(ctx context.Context, alertID types.AlertID) error {
 //				panic("mock out the UnbindAlertFromTicket method")
@@ -810,6 +823,12 @@ type RepositoryMock struct {
 	// GetLatestHistoryFunc mocks the GetLatestHistory method.
 	GetLatestHistoryFunc func(ctx context.Context, ticketID types.TicketID) (*ticket.History, error)
 
+	// GetRunbookEntryFunc mocks the GetRunbookEntry method.
+	GetRunbookEntryFunc func(ctx context.Context, runbookID types.RunbookID) (*bigquery.RunbookEntry, error)
+
+	// GetRunbookEntryByHashFunc mocks the GetRunbookEntryByHash method.
+	GetRunbookEntryByHashFunc func(ctx context.Context, hash string) (*bigquery.RunbookEntry, error)
+
 	// GetTicketFunc mocks the GetTicket method.
 	GetTicketFunc func(ctx context.Context, ticketID types.TicketID) (*ticket.Ticket, error)
 
@@ -843,6 +862,9 @@ type RepositoryMock struct {
 	// PutHistoryFunc mocks the PutHistory method.
 	PutHistoryFunc func(ctx context.Context, ticketID types.TicketID, history *ticket.History) error
 
+	// PutRunbookEntryFunc mocks the PutRunbookEntry method.
+	PutRunbookEntryFunc func(ctx context.Context, entry *bigquery.RunbookEntry) error
+
 	// PutTicketFunc mocks the PutTicket method.
 	PutTicketFunc func(ctx context.Context, ticketMoqParam ticket.Ticket) error
 
@@ -857,6 +879,9 @@ type RepositoryMock struct {
 
 	// SearchAlertsFunc mocks the SearchAlerts method.
 	SearchAlertsFunc func(ctx context.Context, path string, op string, value any, limit int) (alert.Alerts, error)
+
+	// SearchRunbooksByEmbeddingFunc mocks the SearchRunbooksByEmbedding method.
+	SearchRunbooksByEmbeddingFunc func(ctx context.Context, embedding []float64, limit int) (bigquery.RunbookSearchResults, error)
 
 	// UnbindAlertFromTicketFunc mocks the UnbindAlertFromTicket method.
 	UnbindAlertFromTicketFunc func(ctx context.Context, alertID types.AlertID) error
@@ -1024,6 +1049,20 @@ type RepositoryMock struct {
 			// TicketID is the ticketID argument value.
 			TicketID types.TicketID
 		}
+		// GetRunbookEntry holds details about calls to the GetRunbookEntry method.
+		GetRunbookEntry []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// RunbookID is the runbookID argument value.
+			RunbookID types.RunbookID
+		}
+		// GetRunbookEntryByHash holds details about calls to the GetRunbookEntryByHash method.
+		GetRunbookEntryByHash []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Hash is the hash argument value.
+			Hash string
+		}
 		// GetTicket holds details about calls to the GetTicket method.
 		GetTicket []struct {
 			// Ctx is the ctx argument value.
@@ -1113,6 +1152,13 @@ type RepositoryMock struct {
 			// History is the history argument value.
 			History *ticket.History
 		}
+		// PutRunbookEntry holds details about calls to the PutRunbookEntry method.
+		PutRunbookEntry []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Entry is the entry argument value.
+			Entry *bigquery.RunbookEntry
+		}
 		// PutTicket holds details about calls to the PutTicket method.
 		PutTicket []struct {
 			// Ctx is the ctx argument value.
@@ -1156,6 +1202,15 @@ type RepositoryMock struct {
 			// Limit is the limit argument value.
 			Limit int
 		}
+		// SearchRunbooksByEmbedding holds details about calls to the SearchRunbooksByEmbedding method.
+		SearchRunbooksByEmbedding []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Embedding is the embedding argument value.
+			Embedding []float64
+			// Limit is the limit argument value.
+			Limit int
+		}
 		// UnbindAlertFromTicket holds details about calls to the UnbindAlertFromTicket method.
 		UnbindAlertFromTicket []struct {
 			// Ctx is the ctx argument value.
@@ -1185,6 +1240,8 @@ type RepositoryMock struct {
 	lockGetLatestAlertByThread      sync.RWMutex
 	lockGetLatestAlertListInThread  sync.RWMutex
 	lockGetLatestHistory            sync.RWMutex
+	lockGetRunbookEntry             sync.RWMutex
+	lockGetRunbookEntryByHash       sync.RWMutex
 	lockGetTicket                   sync.RWMutex
 	lockGetTicketByThread           sync.RWMutex
 	lockGetTicketComments           sync.RWMutex
@@ -1196,11 +1253,13 @@ type RepositoryMock struct {
 	lockPutAlert                    sync.RWMutex
 	lockPutAlertList                sync.RWMutex
 	lockPutHistory                  sync.RWMutex
+	lockPutRunbookEntry             sync.RWMutex
 	lockPutTicket                   sync.RWMutex
 	lockPutTicketComment            sync.RWMutex
 	lockPutTicketCommentsPrompted   sync.RWMutex
 	lockPutToken                    sync.RWMutex
 	lockSearchAlerts                sync.RWMutex
+	lockSearchRunbooksByEmbedding   sync.RWMutex
 	lockUnbindAlertFromTicket       sync.RWMutex
 }
 
@@ -2067,6 +2126,86 @@ func (mock *RepositoryMock) GetLatestHistoryCalls() []struct {
 	return calls
 }
 
+// GetRunbookEntry calls GetRunbookEntryFunc.
+func (mock *RepositoryMock) GetRunbookEntry(ctx context.Context, runbookID types.RunbookID) (*bigquery.RunbookEntry, error) {
+	callInfo := struct {
+		Ctx       context.Context
+		RunbookID types.RunbookID
+	}{
+		Ctx:       ctx,
+		RunbookID: runbookID,
+	}
+	mock.lockGetRunbookEntry.Lock()
+	mock.calls.GetRunbookEntry = append(mock.calls.GetRunbookEntry, callInfo)
+	mock.lockGetRunbookEntry.Unlock()
+	if mock.GetRunbookEntryFunc == nil {
+		var (
+			runbookEntryOut *bigquery.RunbookEntry
+			errOut          error
+		)
+		return runbookEntryOut, errOut
+	}
+	return mock.GetRunbookEntryFunc(ctx, runbookID)
+}
+
+// GetRunbookEntryCalls gets all the calls that were made to GetRunbookEntry.
+// Check the length with:
+//
+//	len(mockedRepository.GetRunbookEntryCalls())
+func (mock *RepositoryMock) GetRunbookEntryCalls() []struct {
+	Ctx       context.Context
+	RunbookID types.RunbookID
+} {
+	var calls []struct {
+		Ctx       context.Context
+		RunbookID types.RunbookID
+	}
+	mock.lockGetRunbookEntry.RLock()
+	calls = mock.calls.GetRunbookEntry
+	mock.lockGetRunbookEntry.RUnlock()
+	return calls
+}
+
+// GetRunbookEntryByHash calls GetRunbookEntryByHashFunc.
+func (mock *RepositoryMock) GetRunbookEntryByHash(ctx context.Context, hash string) (*bigquery.RunbookEntry, error) {
+	callInfo := struct {
+		Ctx  context.Context
+		Hash string
+	}{
+		Ctx:  ctx,
+		Hash: hash,
+	}
+	mock.lockGetRunbookEntryByHash.Lock()
+	mock.calls.GetRunbookEntryByHash = append(mock.calls.GetRunbookEntryByHash, callInfo)
+	mock.lockGetRunbookEntryByHash.Unlock()
+	if mock.GetRunbookEntryByHashFunc == nil {
+		var (
+			runbookEntryOut *bigquery.RunbookEntry
+			errOut          error
+		)
+		return runbookEntryOut, errOut
+	}
+	return mock.GetRunbookEntryByHashFunc(ctx, hash)
+}
+
+// GetRunbookEntryByHashCalls gets all the calls that were made to GetRunbookEntryByHash.
+// Check the length with:
+//
+//	len(mockedRepository.GetRunbookEntryByHashCalls())
+func (mock *RepositoryMock) GetRunbookEntryByHashCalls() []struct {
+	Ctx  context.Context
+	Hash string
+} {
+	var calls []struct {
+		Ctx  context.Context
+		Hash string
+	}
+	mock.lockGetRunbookEntryByHash.RLock()
+	calls = mock.calls.GetRunbookEntryByHash
+	mock.lockGetRunbookEntryByHash.RUnlock()
+	return calls
+}
+
 // GetTicket calls GetTicketFunc.
 func (mock *RepositoryMock) GetTicket(ctx context.Context, ticketID types.TicketID) (*ticket.Ticket, error) {
 	callInfo := struct {
@@ -2528,6 +2667,45 @@ func (mock *RepositoryMock) PutHistoryCalls() []struct {
 	return calls
 }
 
+// PutRunbookEntry calls PutRunbookEntryFunc.
+func (mock *RepositoryMock) PutRunbookEntry(ctx context.Context, entry *bigquery.RunbookEntry) error {
+	callInfo := struct {
+		Ctx   context.Context
+		Entry *bigquery.RunbookEntry
+	}{
+		Ctx:   ctx,
+		Entry: entry,
+	}
+	mock.lockPutRunbookEntry.Lock()
+	mock.calls.PutRunbookEntry = append(mock.calls.PutRunbookEntry, callInfo)
+	mock.lockPutRunbookEntry.Unlock()
+	if mock.PutRunbookEntryFunc == nil {
+		var (
+			errOut error
+		)
+		return errOut
+	}
+	return mock.PutRunbookEntryFunc(ctx, entry)
+}
+
+// PutRunbookEntryCalls gets all the calls that were made to PutRunbookEntry.
+// Check the length with:
+//
+//	len(mockedRepository.PutRunbookEntryCalls())
+func (mock *RepositoryMock) PutRunbookEntryCalls() []struct {
+	Ctx   context.Context
+	Entry *bigquery.RunbookEntry
+} {
+	var calls []struct {
+		Ctx   context.Context
+		Entry *bigquery.RunbookEntry
+	}
+	mock.lockPutRunbookEntry.RLock()
+	calls = mock.calls.PutRunbookEntry
+	mock.lockPutRunbookEntry.RUnlock()
+	return calls
+}
+
 // PutTicket calls PutTicketFunc.
 func (mock *RepositoryMock) PutTicket(ctx context.Context, ticketMoqParam ticket.Ticket) error {
 	callInfo := struct {
@@ -2737,6 +2915,50 @@ func (mock *RepositoryMock) SearchAlertsCalls() []struct {
 	mock.lockSearchAlerts.RLock()
 	calls = mock.calls.SearchAlerts
 	mock.lockSearchAlerts.RUnlock()
+	return calls
+}
+
+// SearchRunbooksByEmbedding calls SearchRunbooksByEmbeddingFunc.
+func (mock *RepositoryMock) SearchRunbooksByEmbedding(ctx context.Context, embedding []float64, limit int) (bigquery.RunbookSearchResults, error) {
+	callInfo := struct {
+		Ctx       context.Context
+		Embedding []float64
+		Limit     int
+	}{
+		Ctx:       ctx,
+		Embedding: embedding,
+		Limit:     limit,
+	}
+	mock.lockSearchRunbooksByEmbedding.Lock()
+	mock.calls.SearchRunbooksByEmbedding = append(mock.calls.SearchRunbooksByEmbedding, callInfo)
+	mock.lockSearchRunbooksByEmbedding.Unlock()
+	if mock.SearchRunbooksByEmbeddingFunc == nil {
+		var (
+			runbookSearchResultsOut bigquery.RunbookSearchResults
+			errOut                  error
+		)
+		return runbookSearchResultsOut, errOut
+	}
+	return mock.SearchRunbooksByEmbeddingFunc(ctx, embedding, limit)
+}
+
+// SearchRunbooksByEmbeddingCalls gets all the calls that were made to SearchRunbooksByEmbedding.
+// Check the length with:
+//
+//	len(mockedRepository.SearchRunbooksByEmbeddingCalls())
+func (mock *RepositoryMock) SearchRunbooksByEmbeddingCalls() []struct {
+	Ctx       context.Context
+	Embedding []float64
+	Limit     int
+} {
+	var calls []struct {
+		Ctx       context.Context
+		Embedding []float64
+		Limit     int
+	}
+	mock.lockSearchRunbooksByEmbedding.RLock()
+	calls = mock.calls.SearchRunbooksByEmbedding
+	mock.lockSearchRunbooksByEmbedding.RUnlock()
 	return calls
 }
 

--- a/pkg/domain/model/bigquery/runbook.go
+++ b/pkg/domain/model/bigquery/runbook.go
@@ -1,0 +1,32 @@
+package bigquery
+
+import (
+	"time"
+
+	"github.com/secmon-lab/warren/pkg/domain/types"
+)
+
+// RunbookEntry represents a single SQL runbook entry
+type RunbookEntry struct {
+	ID          types.RunbookID `json:"id"`
+	Title       string          `json:"title"`
+	Description string          `json:"description"`
+	FilePath    string          `json:"file_path"`
+	SQLContent  string          `json:"sql_content"`
+	Hash        string          `json:"hash"`
+	Embedding   []float64       `json:"embedding"`
+	CreatedAt   time.Time       `json:"created_at"`
+	UpdatedAt   time.Time       `json:"updated_at"`
+}
+
+// RunbookEntries is a slice of RunbookEntry
+type RunbookEntries []*RunbookEntry
+
+// RunbookSearchResult represents a search result with similarity score
+type RunbookSearchResult struct {
+	Entry      *RunbookEntry `json:"entry"`
+	Similarity float64       `json:"similarity"`
+}
+
+// RunbookSearchResults is a slice of RunbookSearchResult
+type RunbookSearchResults []*RunbookSearchResult

--- a/pkg/domain/model/bigquery/runbook.go
+++ b/pkg/domain/model/bigquery/runbook.go
@@ -3,20 +3,21 @@ package bigquery
 import (
 	"time"
 
+	"cloud.google.com/go/firestore"
 	"github.com/secmon-lab/warren/pkg/domain/types"
 )
 
 // RunbookEntry represents a single SQL runbook entry
 type RunbookEntry struct {
-	ID          types.RunbookID `json:"id"`
-	Title       string          `json:"title"`
-	Description string          `json:"description"`
-	FilePath    string          `json:"file_path"`
-	SQLContent  string          `json:"sql_content"`
-	Hash        string          `json:"hash"`
-	Embedding   []float64       `json:"embedding"`
-	CreatedAt   time.Time       `json:"created_at"`
-	UpdatedAt   time.Time       `json:"updated_at"`
+	ID          types.RunbookID    `json:"id"`
+	Title       string             `json:"title"`
+	Description string             `json:"description"`
+	FilePath    string             `json:"file_path"`
+	SQLContent  string             `json:"sql_content"`
+	Hash        string             `json:"hash"`
+	Embedding   firestore.Vector64 `json:"embedding"`
+	CreatedAt   time.Time          `json:"created_at"`
+	UpdatedAt   time.Time          `json:"updated_at"`
 }
 
 // RunbookEntries is a slice of RunbookEntry

--- a/pkg/domain/types/runbook.go
+++ b/pkg/domain/types/runbook.go
@@ -1,0 +1,15 @@
+package types
+
+import (
+	"github.com/google/uuid"
+)
+
+type RunbookID string
+
+func (x RunbookID) String() string {
+	return string(x)
+}
+
+func NewRunbookID() RunbookID {
+	return RunbookID(uuid.New().String())
+}

--- a/pkg/repository/firestore.go
+++ b/pkg/repository/firestore.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"fmt"
+	"math"
 	"sort"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	"github.com/secmon-lab/warren/pkg/domain/model/alert"
 	"github.com/secmon-lab/warren/pkg/domain/model/auth"
+	"github.com/secmon-lab/warren/pkg/domain/model/bigquery"
 	"github.com/secmon-lab/warren/pkg/domain/model/slack"
 	"github.com/secmon-lab/warren/pkg/domain/model/ticket"
 	"github.com/secmon-lab/warren/pkg/domain/types"
@@ -52,6 +54,7 @@ const (
 	collectionTickets     = "tickets"
 	collectionComments    = "comments"
 	collectionTokens      = "tokens"
+	collectionRunbooks    = "runbooks"
 )
 
 func (r *Firestore) PutAlert(ctx context.Context, alert alert.Alert) error {
@@ -1066,4 +1069,118 @@ func (r *Firestore) BatchUpdateTicketsStatus(ctx context.Context, ticketIDs []ty
 	}
 
 	return nil
+}
+
+// Runbook methods implementation
+func (r *Firestore) PutRunbookEntry(ctx context.Context, entry *bigquery.RunbookEntry) error {
+	doc := r.db.Collection(collectionRunbooks).Doc(entry.ID.String())
+	_, err := doc.Set(ctx, entry)
+	if err != nil {
+		return goerr.Wrap(err, "failed to put runbook entry", goerr.V("id", entry.ID))
+	}
+	return nil
+}
+
+func (r *Firestore) GetRunbookEntry(ctx context.Context, runbookID types.RunbookID) (*bigquery.RunbookEntry, error) {
+	doc, err := r.db.Collection(collectionRunbooks).Doc(runbookID.String()).Get(ctx)
+	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return nil, goerr.New("runbook entry not found", goerr.V("runbook_id", runbookID))
+		}
+		return nil, goerr.Wrap(err, "failed to get runbook entry", goerr.V("runbook_id", runbookID))
+	}
+
+	var entry bigquery.RunbookEntry
+	if err := doc.DataTo(&entry); err != nil {
+		return nil, goerr.Wrap(err, "failed to convert data to runbook entry", goerr.V("runbook_id", runbookID))
+	}
+
+	return &entry, nil
+}
+
+func (r *Firestore) GetRunbookEntryByHash(ctx context.Context, hash string) (*bigquery.RunbookEntry, error) {
+	iter := r.db.Collection(collectionRunbooks).Where("Hash", "==", hash).Documents(ctx)
+
+	doc, err := iter.Next()
+	if err != nil {
+		if err == iterator.Done {
+			return nil, goerr.New("runbook entry not found", goerr.V("hash", hash))
+		}
+		return nil, goerr.Wrap(err, "failed to get runbook entry by hash", goerr.V("hash", hash))
+	}
+
+	var entry bigquery.RunbookEntry
+	if err := doc.DataTo(&entry); err != nil {
+		return nil, goerr.Wrap(err, "failed to convert data to runbook entry")
+	}
+
+	return &entry, nil
+}
+
+func (r *Firestore) SearchRunbooksByEmbedding(ctx context.Context, embedding []float64, limit int) (bigquery.RunbookSearchResults, error) {
+	// Note: Firestore doesn't support vector similarity search natively
+	// This is a simplified implementation that fetches all runbooks and computes similarity in memory
+	// For production use, consider using a vector database like Pinecone or Vertex AI Vector Search
+
+	iter := r.db.Collection(collectionRunbooks).Documents(ctx)
+
+	var results bigquery.RunbookSearchResults
+
+	for {
+		doc, err := iter.Next()
+		if err != nil {
+			if err == iterator.Done {
+				break
+			}
+			return nil, goerr.Wrap(err, "failed to iterate runbook entries")
+		}
+
+		var entry bigquery.RunbookEntry
+		if err := doc.DataTo(&entry); err != nil {
+			return nil, goerr.Wrap(err, "failed to convert data to runbook entry")
+		}
+
+		if len(entry.Embedding) == 0 {
+			continue // Skip entries without embeddings
+		}
+
+		// Calculate cosine similarity
+		similarity := firestoreCosineSimilarity(embedding, entry.Embedding)
+		results = append(results, &bigquery.RunbookSearchResult{
+			Entry:      &entry,
+			Similarity: similarity,
+		})
+	}
+
+	// Sort by similarity in descending order
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Similarity > results[j].Similarity
+	})
+
+	// Limit results
+	if len(results) > limit {
+		results = results[:limit]
+	}
+
+	return results, nil
+}
+
+// firestoreCosineSimilarity calculates cosine similarity for float64 slices (Firestore-specific to avoid conflicts)
+func firestoreCosineSimilarity(a, b []float64) float64 {
+	if len(a) != len(b) {
+		return 0
+	}
+
+	var dotProduct, normA, normB float64
+	for i := range a {
+		dotProduct += a[i] * b[i]
+		normA += a[i] * a[i]
+		normB += b[i] * b[i]
+	}
+
+	if normA == 0 || normB == 0 {
+		return 0
+	}
+
+	return dotProduct / (math.Sqrt(normA) * math.Sqrt(normB))
 }

--- a/pkg/repository/memory.go
+++ b/pkg/repository/memory.go
@@ -12,6 +12,7 @@ import (
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	"github.com/secmon-lab/warren/pkg/domain/model/alert"
 	"github.com/secmon-lab/warren/pkg/domain/model/auth"
+	"github.com/secmon-lab/warren/pkg/domain/model/bigquery"
 	"github.com/secmon-lab/warren/pkg/domain/model/slack"
 	"github.com/secmon-lab/warren/pkg/domain/model/ticket"
 	"github.com/secmon-lab/warren/pkg/domain/types"
@@ -26,6 +27,8 @@ type Memory struct {
 	tickets        map[types.TicketID]*ticket.Ticket
 	ticketComments map[types.TicketID][]ticket.Comment
 	tokens         map[auth.TokenID]*auth.Token
+	runbooks       map[types.RunbookID]*bigquery.RunbookEntry
+	runbooksByHash map[string]*bigquery.RunbookEntry
 }
 
 var _ interfaces.Repository = &Memory{}
@@ -38,6 +41,8 @@ func NewMemory() *Memory {
 		tickets:        make(map[types.TicketID]*ticket.Ticket),
 		ticketComments: make(map[types.TicketID][]ticket.Comment),
 		tokens:         make(map[auth.TokenID]*auth.Token),
+		runbooks:       make(map[types.RunbookID]*bigquery.RunbookEntry),
+		runbooksByHash: make(map[string]*bigquery.RunbookEntry),
 	}
 }
 
@@ -695,19 +700,99 @@ func (r *Memory) BatchUpdateTicketsStatus(ctx context.Context, ticketIDs []types
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	now := time.Now()
 	for _, ticketID := range ticketIDs {
-		t, ok := r.tickets[ticketID]
+		ticket, ok := r.tickets[ticketID]
 		if !ok {
 			return goerr.New("ticket not found", goerr.V("ticket_id", ticketID))
 		}
 
-		// Create a copy and update status
-		updatedTicket := *t
-		updatedTicket.Status = status
-		updatedTicket.UpdatedAt = now
-		r.tickets[ticketID] = &updatedTicket
+		ticket.Status = status
+		ticket.UpdatedAt = time.Now()
+		r.tickets[ticketID] = ticket
 	}
 
 	return nil
+}
+
+// cosine similarity calculation for float64 slices
+func cosineSimilarityFloat64(a, b []float64) float64 {
+	if len(a) != len(b) {
+		return 0
+	}
+
+	var dotProduct, normA, normB float64
+	for i := range a {
+		dotProduct += a[i] * b[i]
+		normA += a[i] * a[i]
+		normB += b[i] * b[i]
+	}
+
+	if normA == 0 || normB == 0 {
+		return 0
+	}
+
+	return dotProduct / (math.Sqrt(normA) * math.Sqrt(normB))
+}
+
+// Runbook methods implementation
+func (r *Memory) PutRunbookEntry(ctx context.Context, entry *bigquery.RunbookEntry) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.runbooks[entry.ID] = entry
+	r.runbooksByHash[entry.Hash] = entry
+	return nil
+}
+
+func (r *Memory) GetRunbookEntry(ctx context.Context, runbookID types.RunbookID) (*bigquery.RunbookEntry, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	entry, ok := r.runbooks[runbookID]
+	if !ok {
+		return nil, goerr.New("runbook entry not found", goerr.V("runbook_id", runbookID))
+	}
+	return entry, nil
+}
+
+func (r *Memory) GetRunbookEntryByHash(ctx context.Context, hash string) (*bigquery.RunbookEntry, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	entry, ok := r.runbooksByHash[hash]
+	if !ok {
+		return nil, goerr.New("runbook entry not found", goerr.V("hash", hash))
+	}
+	return entry, nil
+}
+
+func (r *Memory) SearchRunbooksByEmbedding(ctx context.Context, embedding []float64, limit int) (bigquery.RunbookSearchResults, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var results bigquery.RunbookSearchResults
+
+	for _, entry := range r.runbooks {
+		if len(entry.Embedding) == 0 {
+			continue // Skip entries without embeddings
+		}
+
+		similarity := cosineSimilarityFloat64(embedding, entry.Embedding)
+		results = append(results, &bigquery.RunbookSearchResult{
+			Entry:      entry,
+			Similarity: similarity,
+		})
+	}
+
+	// Sort by similarity in descending order
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Similarity > results[j].Similarity
+	})
+
+	// Limit results
+	if len(results) > limit {
+		results = results[:limit]
+	}
+
+	return results, nil
 }

--- a/pkg/tool/bigquery/run.go
+++ b/pkg/tool/bigquery/run.go
@@ -129,6 +129,17 @@ func (x *Action) runWithClient(ctx context.Context, name string, args map[string
 		}
 		return x.getTableSchema(ctx, projectID, datasetID, tableID)
 
+	case "bigquery_runbook_search":
+		query, ok := args["query"].(string)
+		if !ok {
+			return nil, goerr.New("query parameter is required")
+		}
+		limit := 5
+		if l, ok := args["limit"].(float64); ok {
+			limit = int(l)
+		}
+		return x.searchRunbooks(ctx, query, limit)
+
 	default:
 		return nil, goerr.New("invalid function name", goerr.V("name", name))
 	}
@@ -556,4 +567,58 @@ func (x *Action) LogValue() slog.Value {
 		slog.String("storage_bucket", x.storageBucket),
 		slog.Duration("timeout", x.timeout),
 	)
+}
+
+// searchRunbooks searches for similar runbooks using embedding-based similarity
+func (x *Action) searchRunbooks(ctx context.Context, query string, limit int) (map[string]any, error) {
+	// Check if dependencies are available
+	if x.repository == nil {
+		return nil, goerr.New("repository not configured for runbook search")
+	}
+	if x.embeddingAdapter == nil {
+		return nil, goerr.New("embedding adapter not configured for runbook search")
+	}
+
+	// Generate embedding for the search query
+	embeddings, err := x.embeddingAdapter.Embeddings(ctx, []string{query}, 0)
+	if err != nil {
+		return nil, goerr.Wrap(err, "failed to generate embedding for search query")
+	}
+
+	if len(embeddings) == 0 || len(embeddings[0]) == 0 {
+		return nil, goerr.New("empty embedding result")
+	}
+
+	// Convert float32 to float64 for repository interface
+	queryEmbedding := make([]float64, len(embeddings[0]))
+	for i, v := range embeddings[0] {
+		queryEmbedding[i] = float64(v)
+	}
+
+	// Search for similar runbooks
+	results, err := x.repository.SearchRunbooksByEmbedding(ctx, queryEmbedding, limit)
+	if err != nil {
+		return nil, goerr.Wrap(err, "failed to search runbooks")
+	}
+
+	// Convert results to response format
+	var runbookResults []map[string]any
+	for _, result := range results {
+		runbookResults = append(runbookResults, map[string]any{
+			"id":          result.Entry.ID.String(),
+			"title":       result.Entry.Title,
+			"description": result.Entry.Description,
+			"sql_content": result.Entry.SQLContent,
+			"file_path":   result.Entry.FilePath,
+			"similarity":  result.Similarity,
+			"created_at":  result.Entry.CreatedAt,
+			"updated_at":  result.Entry.UpdatedAt,
+		})
+	}
+
+	return map[string]any{
+		"query":   query,
+		"results": runbookResults,
+		"total":   len(runbookResults),
+	}, nil
 }

--- a/pkg/tool/bigquery/run_test.go
+++ b/pkg/tool/bigquery/run_test.go
@@ -99,7 +99,7 @@ func TestBigQuery_Specs(t *testing.T) {
 	var action bigquery.Action
 	specs, err := action.Specs(context.Background())
 	gt.NoError(t, err)
-	gt.A(t, specs).Length(5)
+	gt.A(t, specs).Length(6)
 
 	// Check specifications of each tool
 	for _, spec := range specs {
@@ -122,6 +122,12 @@ func TestBigQuery_Specs(t *testing.T) {
 			gt.Map(t, spec.Parameters).HasKey("table_id")
 			gt.Value(t, spec.Parameters["dataset_id"].Type).Equal("string")
 			gt.Value(t, spec.Parameters["table_id"].Type).Equal("string")
+		case "bigquery_runbook_search":
+			gt.Map(t, spec.Parameters).HasKey("query")
+			gt.Map(t, spec.Parameters).HasKey("limit")
+			gt.Value(t, spec.Parameters["query"].Type).Equal("string")
+			gt.Value(t, spec.Parameters["limit"].Type).Equal("integer")
+			gt.Array(t, spec.Required).Has("query")
 		}
 	}
 }
@@ -337,16 +343,13 @@ partitioning:
 			gt.S(t, prompt).Contains("test_dataset")
 			gt.S(t, prompt).Contains("test_table")
 			gt.S(t, prompt).Contains("Test table for security events")
-			gt.S(t, prompt).Contains("bigquery_query")
-			gt.S(t, prompt).Contains("bigquery_table_summary")
-			gt.S(t, prompt).Contains("Important Investigation Workflow")
-			gt.S(t, prompt).Contains("First**, use the `bigquery_table_summary`")
+			gt.S(t, prompt).Contains("Partitioning")
+			gt.S(t, prompt).Contains("Available Columns")
 
-			// Verify the prompt does not contain column or partitioning details
-			gt.S(t, prompt).NotContains("timestamp")
-			gt.S(t, prompt).NotContains("src_ip")
-			gt.S(t, prompt).NotContains("Key Columns")
-			gt.S(t, prompt).NotContains("Partitioning")
+			// Check that column details are now included (prompt changed to include detailed info)
+			gt.S(t, prompt).Contains("timestamp")
+			gt.S(t, prompt).Contains("src_ip")
+			gt.S(t, prompt).Contains("event_type")
 
 			return nil
 		},

--- a/pkg/tool/bigquery/run_test.go
+++ b/pkg/tool/bigquery/run_test.go
@@ -343,13 +343,16 @@ partitioning:
 			gt.S(t, prompt).Contains("test_dataset")
 			gt.S(t, prompt).Contains("test_table")
 			gt.S(t, prompt).Contains("Test table for security events")
-			gt.S(t, prompt).Contains("Partitioning")
-			gt.S(t, prompt).Contains("Available Columns")
 
-			// Check that column details are now included (prompt changed to include detailed info)
-			gt.S(t, prompt).Contains("timestamp")
-			gt.S(t, prompt).Contains("src_ip")
-			gt.S(t, prompt).Contains("event_type")
+			// Verify detailed information is NOT included (to save tokens)
+			gt.S(t, prompt).NotContains("Partitioning")
+			gt.S(t, prompt).NotContains("Available Columns")
+			gt.S(t, prompt).NotContains("timestamp")
+			gt.S(t, prompt).NotContains("src_ip")
+			gt.S(t, prompt).NotContains("event_type")
+
+			// Verify the helper comment is included
+			gt.S(t, prompt).Contains("For detailed column information and schema, use the `bigquery_table_summary` tool")
 
 			return nil
 		},
@@ -402,7 +405,7 @@ func TestBigQuery_TableSummary(t *testing.T) {
 			gt.Value(t, table["description"]).Equal("Test table for BigQuery actions")
 
 			columns := gt.Cast[[]map[string]any](t, table["columns"])
-			gt.Array(t, columns).Length(4) // id, timestamp, value, metadata
+			gt.Array(t, columns).Length(6) // id, timestamp, src_ip, event_type, value, metadata
 
 			// Check column structure
 			for _, col := range columns {

--- a/pkg/tool/bigquery/runbook_loader.go
+++ b/pkg/tool/bigquery/runbook_loader.go
@@ -1,0 +1,205 @@
+package bigquery
+
+import (
+	"bufio"
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/m-mizutani/goerr/v2"
+	"github.com/secmon-lab/warren/pkg/domain/model/bigquery"
+	"github.com/secmon-lab/warren/pkg/domain/types"
+)
+
+// RunbookLoader loads SQL runbook files and processes them
+type RunbookLoader struct {
+	paths []string
+}
+
+// NewRunbookLoader creates a new RunbookLoader
+func NewRunbookLoader(paths []string) *RunbookLoader {
+	return &RunbookLoader{
+		paths: paths,
+	}
+}
+
+// LoadRunbooks loads all SQL files from configured paths and returns RunbookEntries
+func (r *RunbookLoader) LoadRunbooks(ctx context.Context) (bigquery.RunbookEntries, error) {
+	var entries bigquery.RunbookEntries
+
+	for _, path := range r.paths {
+		pathEntries, err := r.loadFromPath(ctx, path)
+		if err != nil {
+			return nil, goerr.Wrap(err, "failed to load runbooks from path", goerr.V("path", path))
+		}
+		entries = append(entries, pathEntries...)
+	}
+
+	return entries, nil
+}
+
+// loadFromPath loads runbooks from a single path (file or directory)
+func (r *RunbookLoader) loadFromPath(ctx context.Context, path string) (bigquery.RunbookEntries, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, goerr.Wrap(err, "failed to stat path", goerr.V("path", path))
+	}
+
+	if info.IsDir() {
+		return r.loadFromDirectory(ctx, path)
+	}
+
+	// Single file
+	entry, err := r.loadFromFile(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	if entry == nil {
+		return nil, nil // Not a SQL file
+	}
+
+	return bigquery.RunbookEntries{entry}, nil
+}
+
+// loadFromDirectory loads all SQL files from a directory recursively
+func (r *RunbookLoader) loadFromDirectory(ctx context.Context, dirPath string) (bigquery.RunbookEntries, error) {
+	var entries bigquery.RunbookEntries
+
+	err := filepath.WalkDir(dirPath, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return goerr.Wrap(err, "failed to walk directory", goerr.V("path", path))
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		// Only process .sql files
+		if !strings.HasSuffix(strings.ToLower(path), ".sql") {
+			return nil
+		}
+
+		entry, err := r.loadFromFile(ctx, path)
+		if err != nil {
+			return err
+		}
+
+		if entry != nil {
+			entries = append(entries, entry)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return entries, nil
+}
+
+// loadFromFile loads a single SQL file and creates a RunbookEntry
+func (r *RunbookLoader) loadFromFile(ctx context.Context, filePath string) (*bigquery.RunbookEntry, error) {
+	// Only process .sql files
+	if !strings.HasSuffix(strings.ToLower(filePath), ".sql") {
+		return nil, nil
+	}
+
+	// Read file content
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, goerr.Wrap(err, "failed to read SQL file", goerr.V("path", filePath))
+	}
+
+	// Calculate file hash
+	hash := fmt.Sprintf("%x", sha256.Sum256(content))
+
+	// Extract title and description from comments
+	title, description := r.extractTitleAndDescription(string(content))
+	if title == "" {
+		// Use filename as title if no title found in comments
+		title = strings.TrimSuffix(filepath.Base(filePath), ".sql")
+	}
+
+	entry := &bigquery.RunbookEntry{
+		ID:          types.NewRunbookID(),
+		Title:       title,
+		Description: description,
+		FilePath:    filePath,
+		SQLContent:  string(content),
+		Hash:        hash,
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	}
+
+	return entry, nil
+}
+
+// extractTitleAndDescription extracts title and description from SQL comments
+// Format:
+// -- Title: Title of the runbook
+// -- Description: Description of the runbook
+// -- This can span multiple lines
+func (r *RunbookLoader) extractTitleAndDescription(content string) (string, string) {
+	scanner := bufio.NewScanner(strings.NewReader(content))
+
+	var title string
+	var description strings.Builder
+	var inDescription bool
+
+	titleRegex := regexp.MustCompile(`^--\s*[Tt]itle\s*:\s*(.+)$`)
+	descRegex := regexp.MustCompile(`^--\s*[Dd]escription\s*:\s*(.+)$`)
+	commentRegex := regexp.MustCompile(`^--\s*(.*)$`)
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		// Skip empty lines
+		if line == "" {
+			continue
+		}
+
+		// If we hit a non-comment line, stop processing
+		if !strings.HasPrefix(line, "--") {
+			break
+		}
+
+		// Check for title
+		if matches := titleRegex.FindStringSubmatch(line); matches != nil {
+			title = strings.TrimSpace(matches[1])
+			continue
+		}
+
+		// Check for description start
+		if matches := descRegex.FindStringSubmatch(line); matches != nil {
+			inDescription = true
+			if description.Len() > 0 {
+				description.WriteString(" ")
+			}
+			description.WriteString(strings.TrimSpace(matches[1]))
+			continue
+		}
+
+		// If we're in description mode, continue collecting comment lines
+		if inDescription {
+			if matches := commentRegex.FindStringSubmatch(line); matches != nil {
+				if description.Len() > 0 {
+					description.WriteString(" ")
+				}
+				description.WriteString(strings.TrimSpace(matches[1]))
+			} else {
+				// Non-comment line, stop collecting description
+				break
+			}
+		}
+	}
+
+	return title, description.String()
+}

--- a/pkg/tool/bigquery/runbook_loader.go
+++ b/pkg/tool/bigquery/runbook_loader.go
@@ -113,7 +113,7 @@ func (r *RunbookLoader) loadFromFile(ctx context.Context, filePath string) (*big
 	}
 
 	// Read file content
-	content, err := os.ReadFile(filePath)
+	content, err := os.ReadFile(filepath.Clean(filePath))
 	if err != nil {
 		return nil, goerr.Wrap(err, "failed to read SQL file", goerr.V("path", filePath))
 	}

--- a/pkg/tool/bigquery/runbook_loader_test.go
+++ b/pkg/tool/bigquery/runbook_loader_test.go
@@ -1,0 +1,266 @@
+package bigquery
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/m-mizutani/gt"
+	"github.com/secmon-lab/warren/pkg/domain/model/bigquery"
+)
+
+func TestRunbookLoader_LoadFromFile(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a temporary SQL file with metadata
+	tmpDir := t.TempDir()
+	sqlFile := filepath.Join(tmpDir, "test_query.sql")
+
+	sqlContent := `-- Title: Find suspicious login activities
+-- Description: This query identifies login activities from unusual locations
+-- that might indicate potential security threats or compromised accounts.
+-- It looks for IP addresses that have never been seen before for a user.
+
+SELECT 
+    user_id,
+    ip_address,
+    login_time,
+    COUNT(*) as login_count
+FROM security_logs.user_logins
+WHERE DATE(login_time) >= DATE_SUB(CURRENT_DATE(), INTERVAL 7 DAY)
+    AND ip_address NOT IN (
+        SELECT DISTINCT ip_address 
+        FROM security_logs.user_logins 
+        WHERE DATE(login_time) < DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY)
+    )
+GROUP BY user_id, ip_address, DATE(login_time)
+ORDER BY login_time DESC
+LIMIT 100;`
+
+	err := os.WriteFile(sqlFile, []byte(sqlContent), 0644)
+	gt.NoError(t, err)
+
+	// Create loader and load the file
+	loader := NewRunbookLoader([]string{sqlFile})
+	entries, err := loader.LoadRunbooks(ctx)
+	gt.NoError(t, err)
+
+	// Verify results
+	gt.Array(t, entries).Length(1)
+
+	entry := entries[0]
+	gt.Value(t, entry.Title).Equal("Find suspicious login activities")
+	gt.S(t, entry.Description).Contains("This query identifies login activities from unusual locations")
+	gt.S(t, entry.SQLContent).Contains("SELECT")
+	gt.S(t, entry.SQLContent).Contains("security_logs.user_logins")
+	gt.Value(t, entry.FilePath).Equal(sqlFile)
+	gt.Value(t, entry.Hash).NotEqual("")
+}
+
+func TestRunbookLoader_LoadFromDirectory(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a temporary directory with multiple SQL files
+	tmpDir := t.TempDir()
+
+	// Create first SQL file
+	sqlFile1 := filepath.Join(tmpDir, "query1.sql")
+	sqlContent1 := `-- Title: Count total users
+-- Description: Simple query to count all users
+SELECT COUNT(*) FROM users;`
+	err := os.WriteFile(sqlFile1, []byte(sqlContent1), 0644)
+	gt.NoError(t, err)
+
+	// Create second SQL file
+	sqlFile2 := filepath.Join(tmpDir, "query2.sql")
+	sqlContent2 := `-- Title: Recent activities
+-- Description: Get recent user activities
+SELECT * FROM activities WHERE created_at >= CURRENT_DATE() - INTERVAL 1 DAY;`
+	err = os.WriteFile(sqlFile2, []byte(sqlContent2), 0644)
+	gt.NoError(t, err)
+
+	// Create a non-SQL file (should be ignored)
+	txtFile := filepath.Join(tmpDir, "readme.txt")
+	err = os.WriteFile(txtFile, []byte("This is not a SQL file"), 0644)
+	gt.NoError(t, err)
+
+	// Create loader and load the directory
+	loader := NewRunbookLoader([]string{tmpDir})
+	entries, err := loader.LoadRunbooks(ctx)
+	gt.NoError(t, err)
+
+	// Verify results - should have 2 SQL files, ignoring the txt file
+	gt.Array(t, entries).Length(2)
+
+	// Verify entries (order might vary)
+	titles := make(map[string]bool)
+	for _, entry := range entries {
+		titles[entry.Title] = true
+		gt.Value(t, entry.Hash).NotEqual("")
+		gt.Value(t, entry.SQLContent).NotEqual("")
+	}
+
+	gt.Value(t, titles["Count total users"]).Equal(true)
+	gt.Value(t, titles["Recent activities"]).Equal(true)
+}
+
+func TestRunbookLoader_ExtractTitleAndDescription(t *testing.T) {
+	loader := &RunbookLoader{}
+
+	testCases := []struct {
+		name        string
+		content     string
+		expectTitle string
+		expectDesc  string
+	}{
+		{
+			name: "full metadata",
+			content: `-- Title: Test Query
+-- Description: This is a test query that does something
+-- useful for security analysis
+SELECT * FROM test_table;`,
+			expectTitle: "Test Query",
+			expectDesc:  "This is a test query that does something useful for security analysis",
+		},
+		{
+			name: "title only",
+			content: `-- Title: Simple Query
+SELECT COUNT(*) FROM users;`,
+			expectTitle: "Simple Query",
+			expectDesc:  "",
+		},
+		{
+			name: "description only",
+			content: `-- Description: Query without title
+SELECT * FROM logs;`,
+			expectTitle: "",
+			expectDesc:  "Query without title",
+		},
+		{
+			name: "no metadata",
+			content: `-- Just a comment
+SELECT * FROM table;`,
+			expectTitle: "",
+			expectDesc:  "",
+		},
+		{
+			name: "case insensitive",
+			content: `-- title: Lowercase Title
+-- description: lowercase description
+SELECT 1;`,
+			expectTitle: "Lowercase Title",
+			expectDesc:  "lowercase description",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			title, desc := loader.extractTitleAndDescription(tc.content)
+			gt.Value(t, title).Equal(tc.expectTitle)
+			gt.Value(t, desc).Equal(tc.expectDesc)
+		})
+	}
+}
+
+func TestLoadRunbooks_Integration(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a temporary directory with SQL files
+	tempDir := t.TempDir()
+
+	// Create sample SQL files
+	sqlFiles := map[string]string{
+		"user_activity.sql": `-- Title: User Activity Analysis
+-- Description: Analyze user activity patterns for security monitoring
+
+SELECT 
+    user_id,
+    COUNT(*) as activity_count,
+    MIN(timestamp) as first_activity,
+    MAX(timestamp) as last_activity
+FROM security_logs
+WHERE timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 DAY)
+GROUP BY user_id
+ORDER BY activity_count DESC;`,
+
+		"failed_logins.sql": `-- Title: Failed Login Detection
+-- Description: Detect patterns of failed login attempts that might indicate brute force attacks
+
+SELECT 
+    source_ip,
+    user_id,
+    COUNT(*) as failed_attempts,
+    MIN(timestamp) as first_attempt,
+    MAX(timestamp) as last_attempt
+FROM auth_logs
+WHERE status = 'FAILED'
+  AND timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 HOUR)
+GROUP BY source_ip, user_id
+HAVING COUNT(*) >= 5
+ORDER BY failed_attempts DESC;`,
+
+		"network_anomaly.sql": `-- Title: Network Traffic Anomaly Detection
+-- Description: Identify unusual network traffic patterns that could indicate malicious activity
+
+WITH traffic_stats AS (
+  SELECT 
+    source_ip,
+    destination_ip,
+    COUNT(*) as connection_count,
+    SUM(bytes_transferred) as total_bytes
+  FROM network_logs
+  WHERE timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 HOUR)
+  GROUP BY source_ip, destination_ip
+)
+SELECT *
+FROM traffic_stats
+WHERE connection_count > 1000 OR total_bytes > 1000000000;`,
+	}
+
+	for filename, content := range sqlFiles {
+		filePath := filepath.Join(tempDir, filename)
+		err := os.WriteFile(filePath, []byte(content), 0644)
+		gt.NoError(t, err)
+	}
+
+	// Create runbook loader
+	loader := NewRunbookLoader([]string{tempDir})
+
+	// Load runbooks
+	entries, err := loader.LoadRunbooks(ctx)
+	gt.NoError(t, err)
+	gt.Array(t, entries).Length(3)
+
+	// Verify that all entries have correct metadata
+	titleMap := make(map[string]*bigquery.RunbookEntry)
+	for _, entry := range entries {
+		titleMap[entry.Title] = entry
+	}
+
+	// Check user activity entry
+	userActivityEntry := titleMap["User Activity Analysis"]
+	gt.NotEqual(t, userActivityEntry, nil)
+	gt.S(t, userActivityEntry.Description).Contains("security monitoring")
+	gt.S(t, userActivityEntry.SQLContent).Contains("FROM security_logs")
+
+	// Check failed logins entry
+	failedLoginsEntry := titleMap["Failed Login Detection"]
+	gt.NotEqual(t, failedLoginsEntry, nil)
+	gt.S(t, failedLoginsEntry.Description).Contains("brute force attacks")
+	gt.S(t, failedLoginsEntry.SQLContent).Contains("WHERE status = 'FAILED'")
+
+	// Check network anomaly entry
+	networkAnomalyEntry := titleMap["Network Traffic Anomaly Detection"]
+	gt.NotEqual(t, networkAnomalyEntry, nil)
+	gt.S(t, networkAnomalyEntry.Description).Contains("malicious activity")
+	gt.S(t, networkAnomalyEntry.SQLContent).Contains("network_logs")
+
+	// Verify all entries have unique hashes
+	hashSet := make(map[string]bool)
+	for _, entry := range entries {
+		gt.Value(t, hashSet[entry.Hash]).Equal(false) // Should not be duplicate
+		hashSet[entry.Hash] = true
+		gt.S(t, entry.Hash).NotEqual("") // Hash should not be empty
+	}
+}

--- a/pkg/tool/bigquery/testdata/config.yml
+++ b/pkg/tool/bigquery/testdata/config.yml
@@ -1,4 +1,3 @@
-
 dataset_id: test_dataset
 table_id: test_table
 description: "Test table for BigQuery actions"
@@ -11,6 +10,14 @@ columns:
     description: "Event timestamp"
     value_example: "2024-03-20T12:00:00Z"
     type: TIMESTAMP
+  - name: src_ip
+    description: "Source IP address"
+    value_example: "192.168.1.1"
+    type: STRING
+  - name: event_type
+    description: "Type of security event"
+    value_example: "login_failure"
+    type: STRING
   - name: value
     description: "Numeric value"
     value_example: "42"
@@ -27,3 +34,7 @@ columns:
         description: "Associated tags"
         value_example: "tag1,tag2"
         type: STRING
+partitioning:
+  field: "timestamp"
+  type: "time"
+  time_unit: "daily"

--- a/pkg/tool/bigquery/tool.go
+++ b/pkg/tool/bigquery/tool.go
@@ -28,6 +28,11 @@ type Action struct {
 	scanLimitStr              string
 	scanLimit                 uint64
 	configs                   []*Config
+	runbookPaths              []string
+
+	// Dependencies for runbook functionality
+	repository       interfaces.Repository
+	embeddingAdapter interfaces.EmbeddingClient
 }
 
 var _ interfaces.Tool = &Action{}
@@ -48,6 +53,9 @@ type Config struct {
 
 	// Partitioning
 	Partitioning PartitioningConfig `yaml:"partitioning" json:"partitioning"`
+
+	// Runbook paths - list of SQL files or directories
+	RunbookPaths []string `yaml:"runbook_paths" json:"runbook_paths"`
 }
 
 type PartitioningConfig struct {
@@ -70,6 +78,16 @@ type ColumnConfig struct {
 
 func (x *Action) Name() string {
 	return "bigquery"
+}
+
+// SetRepository sets the repository for runbook functionality
+func (x *Action) SetRepository(repo interfaces.Repository) {
+	x.repository = repo
+}
+
+// SetEmbeddingClient sets the embedding client for runbook functionality
+func (x *Action) SetEmbeddingClient(client interfaces.EmbeddingClient) {
+	x.embeddingAdapter = client
 }
 
 func (x *Action) Flags() []cli.Flag {
@@ -101,6 +119,13 @@ func (x *Action) Flags() []cli.Flag {
 			Destination: &x.configFiles,
 			Category:    "Tool",
 			Sources:     cli.EnvVars("WARREN_BIGQUERY_CONFIG"),
+		},
+		&cli.StringSliceFlag{
+			Name:        "bigquery-runbook-path",
+			Usage:       "Path to SQL runbook files or directories",
+			Destination: &x.runbookPaths,
+			Category:    "Tool",
+			Sources:     cli.EnvVars("WARREN_BIGQUERY_RUNBOOK_PATH"),
 		},
 		&cli.StringFlag{
 			Name:        "bigquery-storage-bucket",
@@ -177,6 +202,14 @@ func (x *Action) Configure(ctx context.Context) error {
 	x.scanLimit = scanLimit
 
 	x.configs = configs
+
+	// Load runbooks if paths are configured and dependencies are available
+	if len(x.runbookPaths) > 0 && x.repository != nil && x.embeddingAdapter != nil {
+		if err := x.loadRunbooks(ctx); err != nil {
+			return goerr.Wrap(err, "failed to load runbooks")
+		}
+	}
+
 	return nil
 }
 
@@ -255,50 +288,44 @@ func (x *Action) Specs(ctx context.Context) ([]gollem.ToolSpec, error) {
 				},
 				"limit": {
 					Type:        gollem.TypeInteger,
-					Description: "Maximum number of rows to return (default: 100)",
-					Required:    []string{},
+					Description: "Maximum number of rows to return",
 				},
 				"offset": {
 					Type:        gollem.TypeInteger,
-					Description: "Number of rows to skip (default: 0)",
-					Required:    []string{},
+					Description: "Number of rows to skip",
 				},
 			},
 			Required: []string{"query_id"},
 		},
 		{
 			Name:        "bigquery_table_summary",
-			Description: "Get summary information about available BigQuery tables including description, column names and examples. Use this tool first to understand table structure before using bigquery_schema for detailed schema information.",
+			Description: "Get a summary of available BigQuery tables including all fields, examples, and descriptions",
 			Parameters: map[string]*gollem.Parameter{
 				"project_id": {
 					Type:        gollem.TypeString,
-					Description: "The Google Cloud project ID (optional, defaults to configured project)",
-					Required:    []string{},
+					Description: "The project ID to filter by (optional)",
 				},
 				"dataset_id": {
 					Type:        gollem.TypeString,
-					Description: "The dataset ID to filter tables (optional, returns all if not specified)",
-					Required:    []string{},
+					Description: "The dataset ID to filter by (optional)",
 				},
 				"table_id": {
 					Type:        gollem.TypeString,
-					Description: "The table ID to get summary for (optional, returns all if not specified)",
-					Required:    []string{},
+					Description: "The table ID to filter by (optional)",
 				},
 			},
-			Required: []string{},
 		},
 		{
 			Name:        "bigquery_schema",
-			Description: "Get detailed schema information for a specific table. WARNING: Returns complete schema which may exceed token limits for large tables. Consider using bigquery_table_summary first to check if detailed schema is necessary.",
+			Description: "Get detailed schema information for a specific BigQuery table",
 			Parameters: map[string]*gollem.Parameter{
 				"project_id": {
 					Type:        gollem.TypeString,
-					Description: "The Google Cloud project ID",
+					Description: "The project ID of the table",
 				},
 				"dataset_id": {
 					Type:        gollem.TypeString,
-					Description: "The dataset ID containing the table",
+					Description: "The dataset ID of the table",
 				},
 				"table_id": {
 					Type:        gollem.TypeString,
@@ -306,6 +333,21 @@ func (x *Action) Specs(ctx context.Context) ([]gollem.ToolSpec, error) {
 				},
 			},
 			Required: []string{"project_id", "dataset_id", "table_id"},
+		},
+		{
+			Name:        "bigquery_runbook_search",
+			Description: "Search pre-registered SQL runbooks using natural language. Returns similar SQL queries with their descriptions that can be used for investigation.",
+			Parameters: map[string]*gollem.Parameter{
+				"query": {
+					Type:        gollem.TypeString,
+					Description: "Natural language search query describing what kind of SQL investigation you want to perform",
+				},
+				"limit": {
+					Type:        gollem.TypeInteger,
+					Description: "Maximum number of runbook entries to return (default: 5)",
+				},
+			},
+			Required: []string{"query"},
 		},
 	}, nil
 }
@@ -325,16 +367,67 @@ func (x *Action) Prompt(ctx context.Context) (string, error) {
 		prompt.WriteString(fmt.Sprintf("### Project: %s, Dataset: %s, Table: %s\n", x.projectID, config.DatasetID, config.TableID))
 		if config.Description != "" {
 			prompt.WriteString(fmt.Sprintf("**Description**: %s\n\n", config.Description))
-		} else {
-			prompt.WriteString("\n")
 		}
 	}
 
-	prompt.WriteString("**Important Investigation Workflow**:\n")
-	prompt.WriteString("1. **First**, use the `bigquery_table_summary` tool to get an overview of available tables, their descriptions, and column summaries.\n")
-	prompt.WriteString("2. **If needed**, use the `bigquery_schema` tool only when you need detailed schema information (e.g., nested structures, exact data types). Note that this tool returns complete schema and may exceed token limits for large tables.\n")
-	prompt.WriteString("3. **Then**, execute SQL queries using the `bigquery_query` tool based on your understanding of the table structure.\n\n")
-	prompt.WriteString("Use the `bigquery_query` tool to execute SQL queries against these tables for investigation.\n")
+	// Add runbook information if available
+	if len(x.runbookPaths) > 0 {
+		prompt.WriteString("## SQL Runbooks\n\n")
+		prompt.WriteString("You also have access to pre-registered SQL runbooks. Use the `bigquery_runbook_search` tool to find relevant SQL queries for your investigation.\n\n")
+	}
 
 	return prompt.String(), nil
+}
+
+// loadRunbooks loads SQL runbooks from configured paths and stores them in the repository
+func (x *Action) loadRunbooks(ctx context.Context) error {
+	if x.repository == nil || x.embeddingAdapter == nil {
+		return goerr.New("repository and embedding adapter are required for runbook loading")
+	}
+
+	// Create runbook loader
+	loader := NewRunbookLoader(x.runbookPaths)
+
+	// Load runbooks from files
+	entries, err := loader.LoadRunbooks(ctx)
+	if err != nil {
+		return goerr.Wrap(err, "failed to load runbooks from files")
+	}
+
+	// Process each entry
+	for _, entry := range entries {
+		// Check if entry already exists by hash
+		existing, err := x.repository.GetRunbookEntryByHash(ctx, entry.Hash)
+		if err == nil && existing != nil {
+			// Entry with same hash already exists, skip
+			continue
+		}
+
+		// Generate embedding for the entry description and SQL content
+		text := entry.Title + " " + entry.Description + " " + entry.SQLContent
+		embeddings, err := x.embeddingAdapter.Embeddings(ctx, []string{text}, 0)
+		if err != nil {
+			return goerr.Wrap(err, "failed to generate embedding for runbook entry", goerr.V("entry_id", entry.ID))
+		}
+
+		if len(embeddings) == 0 || len(embeddings[0]) == 0 {
+			return goerr.New("empty embedding result for runbook entry", goerr.V("entry_id", entry.ID))
+		}
+
+		// Convert float32 to float64
+		embedding := make([]float64, len(embeddings[0]))
+		for i, v := range embeddings[0] {
+			embedding[i] = float64(v)
+		}
+
+		// Set embedding in entry
+		entry.Embedding = embedding
+
+		// Store in repository
+		if err := x.repository.PutRunbookEntry(ctx, entry); err != nil {
+			return goerr.Wrap(err, "failed to store runbook entry", goerr.V("entry_id", entry.ID))
+		}
+	}
+
+	return nil
 }

--- a/pkg/tool/bigquery/tool.go
+++ b/pkg/tool/bigquery/tool.go
@@ -370,6 +370,10 @@ func (x *Action) Prompt(ctx context.Context) (string, error) {
 		}
 	}
 
+	// Note: Partitioning and column details are omitted from prompt to save tokens.
+	// Use bigquery_table_summary tool to get detailed column information when needed.
+	prompt.WriteString("**Note**: For detailed column information and schema, use the `bigquery_table_summary` tool.\n\n")
+
 	// Add runbook information if available
 	if len(x.runbookPaths) > 0 {
 		prompt.WriteString("## SQL Runbooks\n\n")

--- a/pkg/tool/bigquery/tool.go
+++ b/pkg/tool/bigquery/tool.go
@@ -383,6 +383,8 @@ func (x *Action) Prompt(ctx context.Context) (string, error) {
 	return prompt.String(), nil
 }
 
+const runbookEmbeddingDimensionality = 256
+
 // loadRunbooks loads SQL runbooks from configured paths and stores them in the repository
 func (x *Action) loadRunbooks(ctx context.Context) error {
 	if x.repository == nil || x.embeddingAdapter == nil {
@@ -409,7 +411,7 @@ func (x *Action) loadRunbooks(ctx context.Context) error {
 
 		// Generate embedding for the entry description and SQL content
 		text := entry.Title + " " + entry.Description + " " + entry.SQLContent
-		embeddings, err := x.embeddingAdapter.Embeddings(ctx, []string{text}, 0)
+		embeddings, err := x.embeddingAdapter.Embeddings(ctx, []string{text}, runbookEmbeddingDimensionality)
 		if err != nil {
 			return goerr.Wrap(err, "failed to generate embedding for runbook entry", goerr.V("entry_id", entry.ID))
 		}


### PR DESCRIPTION
=====

Requirements
-----

*   Pre-register example SQL queries usable for BigQuery investigation as a Runbook, and enable calling these pre-registered SQL queries as a tool.
*   The pre-registered SQL queries shall have their embeddings pre-calculated.
*   Tool invocation shall allow searching using natural language via RAG (Retrieval Augmented Generation) and enable retrieving entries with high similarity based on cosine similarity.

Specifications
----

*   [ ] Runbook Registration
    *   [ ] Allow specifying multiple entries, similar to configuration files. If a directory is specified, register all `.sql` files within that directory.
    *   [ ] Load `.sql` files.
    *   [ ] The description for each SQL query shall be provided within comments.
    *   [ ] Registered SQL queries shall have their embeddings computed at application startup.
    *   [ ] To avoid wasteful recomputation of all embeddings, store hash values in a database. Recalculation shall only occur if the hash value does not match. If it matches, retrieve the existing embedding from the database.
        *   [ ] This requires integrating the BigQuery tool with the repository. Implement this integration in a manner that aligns naturally with the overall architecture.
    *   [ ] Registered SQL queries shall be pre-loaded into an in-memory database.
*   [ ] Tool Invocation
    *   [ ] Add a tool named `bigquery_runbook_search`.
    *   [ ] The tool shall accept a search term as an argument.
    *   [ ] The tool shall search the pre-registered SQL queries and return those with high similarity based on cosine similarity.