### PR TITLE
feat(swarm): auto-include knowledge search for child agents

### DIFF
--- a/pkg/tool/knowledge/tool.go
+++ b/pkg/tool/knowledge/tool.go
@@ -24,6 +24,9 @@ const (
 	ModeReadOnly Mode = iota
 	// ModeReadWrite provides search + save + delete + tag management (for reflection agent).
 	ModeReadWrite
+	// ModeSearchOnly provides search only (for child task agent).
+	// Tag list is provided via prompt, so knowledge_tag_list is not needed.
+	ModeSearchOnly
 )
 
 // Tool provides knowledge_* tool commands for LLM agents.
@@ -72,7 +75,9 @@ func (x *Tool) Prompt(_ context.Context) (string, error) {
 	}
 
 	sb.WriteString("\n**IMPORTANT**: Before starting your work, use `knowledge_search` to check if relevant knowledge exists.\n")
-	sb.WriteString("Specify at least one tag when searching. Use `knowledge_tag_list` to see available tags.\n")
+	if x.mode != ModeSearchOnly {
+		sb.WriteString("Specify at least one tag when searching. Use `knowledge_tag_list` to see available tags.\n")
+	}
 	return sb.String(), nil
 }
 
@@ -92,24 +97,30 @@ const (
 )
 
 func (x *Tool) Specs(_ context.Context) ([]gollem.ToolSpec, error) {
-	specs := []gollem.ToolSpec{
-		{
-			Name:        cmdSearch,
-			Description: "Search for knowledge. Returns relevant entries matching the query, filtered by tags.",
-			Parameters: map[string]*gollem.Parameter{
-				"query": {
-					Type:        gollem.TypeString,
-					Description: "Natural language query to search for",
-					Required:    true,
-				},
-				"tags": {
-					Type:        gollem.TypeArray,
-					Items:       &gollem.Parameter{Type: gollem.TypeString},
-					Description: "Tag IDs to filter by (at least one required)",
-					Required:    true,
-				},
+	searchSpec := gollem.ToolSpec{
+		Name:        cmdSearch,
+		Description: "Search for knowledge. Returns relevant entries matching the query, filtered by tags.",
+		Parameters: map[string]*gollem.Parameter{
+			"query": {
+				Type:        gollem.TypeString,
+				Description: "Natural language query to search for",
+				Required:    true,
+			},
+			"tags": {
+				Type:        gollem.TypeArray,
+				Items:       &gollem.Parameter{Type: gollem.TypeString},
+				Description: "Tag IDs to filter by (at least one required)",
+				Required:    true,
 			},
 		},
+	}
+
+	if x.mode == ModeSearchOnly {
+		return []gollem.ToolSpec{searchSpec}, nil
+	}
+
+	specs := []gollem.ToolSpec{
+		searchSpec,
 		{
 			Name:        cmdTagList,
 			Description: "List all available knowledge tags with their IDs and descriptions.",

--- a/pkg/tool/knowledge/tool.go
+++ b/pkg/tool/knowledge/tool.go
@@ -39,7 +39,7 @@ type Tool struct {
 var _ interfaces.Tool = &Tool{}
 
 // New creates a new knowledge v2 tool.
-// category is fixed per agent phase (e.g., "fact" for root agent, "technique" for child agent).
+// category is fixed per use case (e.g., "fact" for investigation context, "technique" for analysis procedures).
 func New(svc *svcknowledge.Service, category types.KnowledgeCategory, mode Mode) *Tool {
 	return &Tool{
 		svc:      svc,

--- a/pkg/tool/knowledge/tool_test.go
+++ b/pkg/tool/knowledge/tool_test.go
@@ -1,0 +1,50 @@
+package knowledge_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/m-mizutani/gt"
+	"github.com/secmon-lab/warren/pkg/domain/types"
+	"github.com/secmon-lab/warren/pkg/repository"
+	svcknowledge "github.com/secmon-lab/warren/pkg/service/knowledge"
+	"github.com/secmon-lab/warren/pkg/tool/knowledge"
+)
+
+func newTestService() *svcknowledge.Service {
+	repo := repository.NewMemory()
+	return svcknowledge.New(repo, nil)
+}
+
+func TestModeSearchOnly_ReturnsOnlySearchSpec(t *testing.T) {
+	tool := knowledge.New(newTestService(), types.KnowledgeCategoryFact, knowledge.ModeSearchOnly)
+
+	specs, err := tool.Specs(t.Context())
+	gt.NoError(t, err)
+	gt.A(t, specs).Length(1)
+	gt.V(t, specs[0].Name).Equal("knowledge_search")
+}
+
+func TestModeReadOnly_ReturnsSearchAndTagList(t *testing.T) {
+	tool := knowledge.New(newTestService(), types.KnowledgeCategoryFact, knowledge.ModeReadOnly)
+
+	specs, err := tool.Specs(t.Context())
+	gt.NoError(t, err)
+	gt.A(t, specs).Length(2)
+
+	names := make(map[string]bool)
+	for _, s := range specs {
+		names[s.Name] = true
+	}
+	gt.True(t, names["knowledge_search"])
+	gt.True(t, names["knowledge_tag_list"])
+}
+
+func TestModeSearchOnly_PromptOmitsTagListInstruction(t *testing.T) {
+	tool := knowledge.New(newTestService(), types.KnowledgeCategoryFact, knowledge.ModeSearchOnly)
+
+	p, err := tool.Prompt(t.Context())
+	gt.NoError(t, err)
+	gt.True(t, strings.Contains(p, "knowledge_search"))
+	gt.True(t, !strings.Contains(p, "knowledge_tag_list"))
+}

--- a/pkg/usecase/chat/swarm/exec.go
+++ b/pkg/usecase/chat/swarm/exec.go
@@ -110,7 +110,7 @@ func (c *SwarmChat) executeTask(ctx context.Context, task TaskPlan, target *tick
 	msg.Trace(taskCtx, "Starting...")
 
 	// Generate task system prompt
-	taskPrompt, err := generateTaskPrompt(ctx, task)
+	taskPrompt, err := generateTaskPrompt(ctx, task, c.knowledgeService)
 	if err != nil {
 		result.Error = err
 		msg.Trace(taskCtx, "❌ Failed to generate prompt: %s", err.Error())
@@ -126,6 +126,13 @@ func (c *SwarmChat) executeTask(ctx context.Context, task TaskPlan, target *tick
 	baseAction := base.New(c.repository, target.ID, base.WithLLMClient(c.llmClient))
 	if filtered := filterToolSets(ctx, []gollem.ToolSet{baseAction}, task.Tools); len(filtered) > 0 {
 		filteredTools = append(filteredTools, baseAction)
+	}
+
+	// Always include knowledge tool (search-only) for child agents so they can
+	// leverage prior knowledge without requiring the root agent to plan it explicitly.
+	if c.knowledgeService != nil {
+		kt := knowledgeTool.New(c.knowledgeService, types.KnowledgeCategoryFact, knowledgeTool.ModeSearchOnly)
+		filteredTools = append(filteredTools, kt)
 	}
 
 	// Filter sub-agents for this task

--- a/pkg/usecase/chat/swarm/prompt.go
+++ b/pkg/usecase/chat/swarm/prompt.go
@@ -16,6 +16,8 @@ import (
 	"github.com/secmon-lab/warren/pkg/domain/model/prompt"
 	model "github.com/secmon-lab/warren/pkg/domain/model/slack"
 	"github.com/secmon-lab/warren/pkg/domain/model/ticket"
+	"github.com/secmon-lab/warren/pkg/utils/logging"
+	svcknowledge "github.com/secmon-lab/warren/pkg/service/knowledge"
 )
 
 //go:embed prompt/system.md
@@ -86,12 +88,24 @@ func generateReplanPrompt(ctx context.Context, pc *planningContext, allResults [
 }
 
 // generateTaskPrompt generates the system prompt for a task agent.
-func generateTaskPrompt(ctx context.Context, task TaskPlan) (string, error) {
-	return prompt.Generate(ctx, taskPromptTemplate, map[string]any{
+// If knowledgeSvc is non-nil, it fetches available tags and embeds them in the prompt.
+func generateTaskPrompt(ctx context.Context, task TaskPlan, knowledgeSvc *svcknowledge.Service) (string, error) {
+	data := map[string]any{
 		"title":               task.Title,
 		"description":         task.Description,
 		"acceptance_criteria": task.AcceptanceCriteria,
-	})
+	}
+
+	if knowledgeSvc != nil {
+		tags, err := knowledgeSvc.ListTags(ctx)
+		if err != nil {
+			logging.From(ctx).Warn("failed to list knowledge tags for task prompt", "error", err)
+		} else if len(tags) > 0 {
+			data["knowledge_tags"] = tags
+		}
+	}
+
+	return prompt.GenerateWithStruct(ctx, taskPromptTemplate, data)
 }
 
 // generateFinalPrompt generates the final response user message prompt.

--- a/pkg/usecase/chat/swarm/prompt/task.md
+++ b/pkg/usecase/chat/swarm/prompt/task.md
@@ -26,6 +26,17 @@ You are a security analysis task agent in the Warren system. Execute the assigne
 
 Your response MUST be raw data only. Just list what you found. No analysis, no structure, no assessment. The synthesis will be done by a separate agent.
 
+{{ if .knowledge_tags }}
+# Knowledge Base
+
+Before starting your investigation, **search the knowledge base** using `knowledge_search` for relevant prior knowledge. The knowledge base may contain known false positive patterns, infrastructure details, previously observed behaviors, and investigation tips.
+
+## Available Tags
+{{ range .knowledge_tags }}- `{{ .ID }}`: {{ .Name }}{{ if .Description }} — {{ .Description }}{{ end }}
+{{ end }}
+Search with relevant tags and keywords from the task (e.g., IP addresses, domain names, process names, service names).
+{{ end }}
+
 # Execution Guidelines
 
 - Execute the task completely using the available tools and sub-agents


### PR DESCRIPTION
## Summary
- Child task agents now automatically receive the `knowledge_search` tool (search-only mode) so they can leverage prior knowledge without the root agent explicitly planning it
- Available knowledge tags are embedded directly in the task prompt, eliminating the need for a `knowledge_tag_list` tool call
- Added `ModeSearchOnly` to knowledge tool that exposes only `knowledge_search`

## Test plan
- [x] `ModeSearchOnly` returns only `knowledge_search` spec
- [x] `ModeReadOnly` still returns both `knowledge_search` and `knowledge_tag_list`
- [x] `ModeSearchOnly` prompt omits `knowledge_tag_list` instruction
- [x] All existing swarm tests pass
- [x] `go vet`, `golangci-lint`, `gosec` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)