### PR TITLE
perf(bigquery): raise row limit to 1000 and prevent pagination anti-pattern

### DIFF
--- a/pkg/agents/bigquery/prompt/base.md
+++ b/pkg/agents/bigquery/prompt/base.md
@@ -8,6 +8,7 @@ You are a BigQuery data analysis agent. Your role is to understand natural langu
 - Construct the minimum necessary queries to achieve the objective
 - Avoid exploratory queries unless data structure is unknown
 - Use schema information to build queries correctly on the first attempt
+- Results are limited to 1000 rows max. If your query returns more than 1000 rows, the results will be truncated
 
 ### Data Fidelity
 - Return query results in their raw form without interpretation
@@ -99,7 +100,8 @@ Use these field patterns to **identify relevant fields from the schema** when co
 ### Minimize Data Scanned
 - Filter on partitioned columns (typically timestamp fields)
 - Use WHERE clauses to reduce scanned data
-- Avoid SELECT * when specific fields suffice
+- NEVER use SELECT * — always specify only the columns you need
+- Select fewer columns to reduce scan cost (BigQuery is columnar storage — each column costs)
 
 ### Leverage Schema Knowledge
 - Reference nested fields correctly: `field.subfield`
@@ -110,6 +112,20 @@ Use these field patterns to **identify relevant fields from the schema** when co
 - Use COALESCE for nullable fields
 - Apply SAFE_CAST to prevent type errors
 - Consider time zone implications for timestamp comparisons
+
+## Anti-Patterns (MUST AVOID)
+
+### DO NOT paginate with OFFSET
+- NEVER use OFFSET to retrieve additional pages of results
+- If results are truncated (1000 rows), switch to COUNT/GROUP BY aggregation or add stricter WHERE filters
+
+### DO NOT use SELECT *
+- Always specify only the columns needed for analysis
+- Each additional column increases BigQuery scan cost
+
+### DO NOT retrieve raw data when aggregation suffices
+- If you only need counts, distributions, or trends, use COUNT/GROUP BY/DISTINCT directly
+- Only retrieve raw rows when individual record details are specifically required
 
 ## Response Format
 

--- a/pkg/agents/bigquery/tool.go
+++ b/pkg/agents/bigquery/tool.go
@@ -47,17 +47,17 @@ Available tables:%s
 
 Important guidelines:
 - Always specify the full table name as project.dataset.table
-- Use LIMIT to restrict the number of rows returned (results limited to 100 rows max)
+- Results are limited to 1000 rows max. Queries returning more than 1000 rows will be truncated
 - Scan size limit: %s (queries exceeding this will fail)
 - For time-based queries, use proper date/time functions and partitioning fields when available
-- Select only fields needed for the analysis to minimize scan size
+- Select only the fields needed for analysis to minimize scan size (DO NOT use SELECT *)
 - Use WHERE clauses to filter data efficiently
+- DO NOT use OFFSET for pagination. If results are truncated, use COUNT/GROUP BY to aggregate or add stricter WHERE filters
 
 Best practices:
 - Start with schema inspection if unfamiliar with table structure
-- Use COUNT(*) first to estimate result size before full SELECT
 - Apply time range filters to reduce scan size
-- Use LIMIT even for aggregated queries to prevent excessive results`,
+- Use LIMIT to restrict rows appropriately`,
 				tableDescriptions,
 				humanize.Bytes(t.config.ScanSizeLimit),
 			),
@@ -261,9 +261,9 @@ func (t *internalTool) executeQuery(ctx context.Context, args map[string]any) (m
 	}
 	log.Debug("Result iterator created", "job_id", job.ID(), "schema_fields", len(it.Schema))
 
-	// Collect rows (limit to 100 rows)
+	// Collect rows (limit to 1000 rows as a safety cap)
 	var rows []map[string]any
-	limit := 100
+	limit := 1000
 	log.Debug("Collecting rows", "limit", limit)
 	for len(rows) < limit {
 		var row []bigquery.Value
@@ -294,14 +294,20 @@ func (t *internalTool) executeQuery(ctx context.Context, args map[string]any) (m
 	msg.Trace(ctx, "✅ Query completed: %d rows retrieved, scan size: %s (query_id: %s)",
 		len(rows), humanize.Bytes(uint64(totalBytes)), queryID)
 
+	hasMore := len(rows) >= limit
+	note := "Query completed successfully."
+	if hasMore {
+		note = fmt.Sprintf("Limited to %d rows. There are more results. Do NOT paginate with OFFSET. Instead, use COUNT/GROUP BY to aggregate the data, or add more specific WHERE filters to narrow the results.", limit)
+	}
+
 	return map[string]any{
 		"query_id":         queryID,
 		"rows":             rows,
 		"total_rows":       len(rows),
 		"bytes_processed":  totalBytes,
 		"execution_status": "completed",
-		"has_more":         len(rows) >= limit,
-		"note":             fmt.Sprintf("Limited to %d rows. Query completed successfully.", limit),
+		"has_more":         hasMore,
+		"note":             note,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary
- Go側のBQクエリ結果行数制限を100→1000に緩和（安全弁として維持）
- `has_more: true` 時のレスポンスにOFFSETページネーション禁止・集計への切り替えガイダンスを追加
- system promptにAnti-Patternsセクション追加（OFFSET禁止、SELECT * 禁止、不要な生データ取得禁止）

## Background
トレース分析により、「Google Driveのダウンロードログを確認して」という指示に対してBQクエリが11回実行されていた（期待: 1-3回）。主因はGo側の100行ハードリミットにより、LLMがOFFSET付きページネーションで同じクエリを繰り返していたこと。実際の結果は122件で、制限が1000であれば1回のクエリで完結していた。

## Test plan
- [x] `go test ./pkg/agents/bigquery/...` pass
- [x] `go vet ./...` pass
- [x] `golangci-lint run ./pkg/agents/bigquery/...` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)