### PR TITLE
feat(swarm): enable knowledge search in planner via Agent mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,8 +74,8 @@ require (
 	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
-	github.com/go-git/go-billy/v5 v5.6.2 // indirect
-	github.com/go-git/go-git/v5 v5.16.5 // indirect
+	github.com/go-git/go-billy/v5 v5.8.0 // indirect
+	github.com/go-git/go-git/v5 v5.17.1 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.3 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -141,12 +141,12 @@ github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxI
 github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 h1:+zs/tPmkDkHx3U66DAb0lQFJrpS6731Oaa12ikc+DiI=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376/go.mod h1:an3vInlBmSxCcxctByoQdvwPiA7DTK7jaaFDBTtu0ic=
-github.com/go-git/go-billy/v5 v5.6.2 h1:6Q86EsPXMa7c3YZ3aLAQsMA0VlWmy43r6FHqa/UNbRM=
-github.com/go-git/go-billy/v5 v5.6.2/go.mod h1:rcFC2rAsp/erv7CMz9GczHcuD0D32fWzH+MJAU+jaUU=
+github.com/go-git/go-billy/v5 v5.8.0 h1:I8hjc3LbBlXTtVuFNJuwYuMiHvQJDq1AT6u4DwDzZG0=
+github.com/go-git/go-billy/v5 v5.8.0/go.mod h1:RpvI/rw4Vr5QA+Z60c6d6LXH0rYJo0uD5SqfmrrheCY=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMje31YglSBqCdIqdhKBW8lokaMrL3uTkpGYlE2OOT4=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
-github.com/go-git/go-git/v5 v5.16.5 h1:mdkuqblwr57kVfXri5TTH+nMFLNUxIj9Z7F5ykFbw5s=
-github.com/go-git/go-git/v5 v5.16.5/go.mod h1:QOMLpNf1qxuSY4StA/ArOdfFR2TrKEjJiye2kel2m+M=
+github.com/go-git/go-git/v5 v5.17.1 h1:WnljyxIzSj9BRRUlnmAU35ohDsjRK0EKmL0evDqi5Jk=
+github.com/go-git/go-git/v5 v5.17.1/go.mod h1:pW/VmeqkanRFqR6AljLcs7EA7FbZaN5MQqO7oZADXpo=
 github.com/go-jose/go-jose/v4 v4.1.3 h1:CVLmWDhDVRa6Mi/IgCgaopNosCaHz7zrMeF9MlZRkrs=
 github.com/go-jose/go-jose/v4 v4.1.3/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/pkg/usecase/chat/swarm/export_test.go
+++ b/pkg/usecase/chat/swarm/export_test.go
@@ -8,9 +8,11 @@ import (
 	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	"github.com/secmon-lab/warren/pkg/domain/model/hitl"
+	knowledgeModel "github.com/secmon-lab/warren/pkg/domain/model/knowledge"
 	slackModel "github.com/secmon-lab/warren/pkg/domain/model/slack"
 	"github.com/secmon-lab/warren/pkg/domain/types"
 	hitlSvc "github.com/secmon-lab/warren/pkg/service/hitl"
+	svcknowledge "github.com/secmon-lab/warren/pkg/service/knowledge"
 )
 
 // NewBudgetTracker exposes newBudgetTracker for testing.
@@ -112,4 +114,9 @@ func ExecHandleQuestion(ctx context.Context, repo interfaces.Repository, present
 		Answer:   result.ResponseAnswer(),
 		Comment:  result.ResponseComment(),
 	}, nil
+}
+
+// FetchKnowledgeTags exposes fetchKnowledgeTags for testing.
+func FetchKnowledgeTags(ctx context.Context, svc *svcknowledge.Service) []*knowledgeModel.KnowledgeTag {
+	return fetchKnowledgeTags(ctx, svc)
 }

--- a/pkg/usecase/chat/swarm/plan.go
+++ b/pkg/usecase/chat/swarm/plan.go
@@ -98,13 +98,25 @@ func (c *SwarmChat) executePlannerAgent(ctx context.Context, planSession gollem.
 		return nil, err
 	}
 
-	// Sync agent's conversation history back to planning session
+	// Sync only the NEW messages from the agent back to the planning session.
+	// The agent was initialized with the existing planSession history, so we must
+	// skip those initial messages to avoid duplicating them.
 	agentHistory, err := agent.Session().History()
 	if err != nil {
 		logging.From(ctx).Warn("failed to get agent history after planning", "error", err)
 	} else if agentHistory != nil {
-		if err := planSession.AppendHistory(agentHistory); err != nil {
-			logging.From(ctx).Warn("failed to append agent history to planning session", "error", err)
+		initialLen := 0
+		if history != nil {
+			initialLen = len(history.Messages)
+		}
+		if len(agentHistory.Messages) > initialLen {
+			newHistory := &gollem.History{
+				Version:  agentHistory.Version,
+				Messages: agentHistory.Messages[initialLen:],
+			}
+			if err := planSession.AppendHistory(newHistory); err != nil {
+				logging.From(ctx).Warn("failed to append agent history to planning session", "error", err)
+			}
 		}
 	}
 

--- a/pkg/usecase/chat/swarm/plan.go
+++ b/pkg/usecase/chat/swarm/plan.go
@@ -7,11 +7,15 @@ import (
 	"github.com/m-mizutani/goerr/v2"
 	"github.com/m-mizutani/gollem"
 	"github.com/m-mizutani/gollem/trace"
+	"github.com/secmon-lab/warren/pkg/domain/types"
+	knowledgeTool "github.com/secmon-lab/warren/pkg/tool/knowledge"
 	"github.com/secmon-lab/warren/pkg/utils/logging"
 )
 
 // plan executes the planning phase and returns a structured plan.
-func (c *SwarmChat) plan(ctx context.Context, session gollem.Session, pc *planningContext) (*PlanResult, error) {
+// If a knowledge service is configured, the planner runs as a gollem Agent with
+// knowledge_search tool so it can look up prior findings before creating the plan.
+func (c *SwarmChat) plan(ctx context.Context, session gollem.Session, pc *planningContext, systemPrompt string) (*PlanResult, error) {
 	logger := logging.From(ctx)
 
 	// Generate planning prompt
@@ -29,13 +33,24 @@ func (c *SwarmChat) plan(ctx context.Context, session gollem.Session, pc *planni
 
 	logger.Debug("executing planning phase")
 
-	// Generate plan via LLM
-	resp, err := session.Generate(ctx, []gollem.Input{gollem.Text(planPrompt)})
+	var texts []string
+
+	if c.knowledgeService != nil {
+		// Agent mode: planner can call knowledge_search before generating the plan
+		texts, err = c.executePlannerAgent(ctx, session, systemPrompt, planPrompt, planSchema)
+	} else {
+		// Direct mode: generate plan JSON without tool calls
+		var resp *gollem.Response
+		resp, err = session.Generate(ctx, []gollem.Input{gollem.Text(planPrompt)})
+		if err == nil {
+			texts = resp.Texts
+		}
+	}
 	if err != nil {
 		return nil, goerr.Wrap(err, "failed to generate plan")
 	}
 
-	result, err := parsePlanResult(resp.Texts)
+	result, err := parsePlanResult(texts)
 	if err != nil {
 		return nil, err
 	}
@@ -45,6 +60,59 @@ func (c *SwarmChat) plan(ctx context.Context, session gollem.Session, pc *planni
 		"has_message", result.Message != "")
 
 	return result, nil
+}
+
+// executePlannerAgent runs the planner as a gollem Agent with knowledge tool,
+// then appends the agent's conversation history back to the planning session.
+func (c *SwarmChat) executePlannerAgent(ctx context.Context, planSession gollem.Session, systemPrompt string, userPrompt string, schema *gollem.Parameter) ([]string, error) {
+	// Build agent options
+	opts := []gollem.Option{
+		gollem.WithSystemPrompt(systemPrompt),
+		gollem.WithContentType(gollem.ContentTypeJSON),
+		gollem.WithResponseSchema(schema),
+		gollem.WithResponseMode(gollem.ResponseModeBlocking),
+	}
+
+	// Add knowledge tool
+	kt := knowledgeTool.New(c.knowledgeService, types.KnowledgeCategoryFact, knowledgeTool.ModeSearchOnly)
+	opts = append(opts, gollem.WithToolSets(kt))
+
+	// Carry over existing conversation history
+	history, err := planSession.History()
+	if err != nil {
+		return nil, goerr.Wrap(err, "failed to get planning session history")
+	}
+	if history != nil {
+		opts = append(opts, gollem.WithHistory(history))
+	}
+
+	// Add trace handler if available
+	handler := trace.HandlerFrom(ctx)
+	if handler != nil {
+		opts = append(opts, gollem.WithTrace(handler))
+	}
+
+	agent := gollem.New(c.llmClient, opts...)
+	resp, err := agent.Execute(ctx, gollem.Text(userPrompt))
+	if err != nil {
+		return nil, err
+	}
+
+	// Sync agent's conversation history back to planning session
+	agentHistory, err := agent.Session().History()
+	if err != nil {
+		logging.From(ctx).Warn("failed to get agent history after planning", "error", err)
+	} else if agentHistory != nil {
+		if err := planSession.AppendHistory(agentHistory); err != nil {
+			logging.From(ctx).Warn("failed to append agent history to planning session", "error", err)
+		}
+	}
+
+	if resp == nil || resp.IsEmpty() {
+		return nil, nil
+	}
+
+	return resp.Texts, nil
 }
 
 // replan evaluates completed results and determines next steps.
@@ -66,33 +134,45 @@ func (c *SwarmChat) replan(ctx context.Context, session gollem.Session, pc *plan
 
 	logger.Debug("executing replan phase", "phase", currentPhase)
 
-	// Switch session to replan schema for this call
-	replanSession, err := c.llmClient.NewSession(ctx,
-		gollem.WithSessionContentType(gollem.ContentTypeJSON),
-		gollem.WithSessionResponseSchema(replanSchema),
-		gollem.WithSessionSystemPrompt(systemPrompt),
-	)
-	if err != nil {
-		return nil, goerr.Wrap(err, "failed to create replan session")
-	}
+	var texts []string
 
-	// Copy history from planning session
-	history, err := session.History()
-	if err != nil {
-		return nil, goerr.Wrap(err, "failed to get history from planning session")
-	}
-	if history != nil {
-		if err := replanSession.AppendHistory(history); err != nil {
-			logger.Warn("failed to append history to replan session", "error", err)
+	if c.knowledgeService != nil {
+		// Agent mode: replan with knowledge search
+		texts, err = c.executePlannerAgent(ctx, session, systemPrompt, replanPrompt, replanSchema)
+	} else {
+		// Direct mode: create a replan session and generate
+		var replanSession gollem.Session
+		replanSession, err = c.llmClient.NewSession(ctx,
+			gollem.WithSessionContentType(gollem.ContentTypeJSON),
+			gollem.WithSessionResponseSchema(replanSchema),
+			gollem.WithSessionSystemPrompt(systemPrompt),
+		)
+		if err != nil {
+			return nil, goerr.Wrap(err, "failed to create replan session")
+		}
+
+		// Copy history from planning session
+		history, hErr := session.History()
+		if hErr != nil {
+			return nil, goerr.Wrap(hErr, "failed to get history from planning session")
+		}
+		if history != nil {
+			if aErr := replanSession.AppendHistory(history); aErr != nil {
+				logger.Warn("failed to append history to replan session", "error", aErr)
+			}
+		}
+
+		var resp *gollem.Response
+		resp, err = replanSession.Generate(ctx, []gollem.Input{gollem.Text(replanPrompt)})
+		if err == nil {
+			texts = resp.Texts
 		}
 	}
-
-	resp, err := replanSession.Generate(ctx, []gollem.Input{gollem.Text(replanPrompt)})
 	if err != nil {
 		return nil, goerr.Wrap(err, "failed to generate replan")
 	}
 
-	result, err := parseReplanResult(resp.Texts)
+	result, err := parseReplanResult(texts)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/usecase/chat/swarm/plan_test.go
+++ b/pkg/usecase/chat/swarm/plan_test.go
@@ -1,0 +1,143 @@
+package swarm_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/m-mizutani/gollem"
+	"github.com/m-mizutani/gt"
+	"github.com/secmon-lab/warren/pkg/domain/mock"
+	chatModel "github.com/secmon-lab/warren/pkg/domain/model/chat"
+	"github.com/secmon-lab/warren/pkg/repository"
+	svcknowledge "github.com/secmon-lab/warren/pkg/service/knowledge"
+	"github.com/secmon-lab/warren/pkg/usecase/chat/swarm"
+)
+
+func TestSwarmChat_PlanWithKnowledgeService(t *testing.T) {
+	ctx := setupTestContext(t)
+	repo := repository.NewMemory()
+	testTicket := setupTicketAndAlert(t, ctx, repo)
+
+	embeddingMock := &mock.EmbeddingClientMock{
+		EmbeddingsFunc: func(ctx context.Context, texts []string, dimensionality int) ([][]float32, error) {
+			result := make([][]float32, len(texts))
+			for i := range texts {
+				result[i] = make([]float32, dimensionality)
+			}
+			return result, nil
+		},
+	}
+	knowledgeSvc := svcknowledge.New(repo, embeddingMock)
+
+	// The mock LLM must handle multiple NewSession calls:
+	// 1. The planner agent creates its own session internally (for plan)
+	// 2. The replan/final phases also create sessions
+	// The planner agent may call knowledge_search, then return a plan JSON.
+	var mu sync.Mutex
+	sessionCount := 0
+
+	mockLLM := &mock.LLMClientMock{
+		NewSessionFunc: func(ctx context.Context, opts ...gollem.SessionOption) (gollem.Session, error) {
+			mu.Lock()
+			sessionCount++
+			sc := sessionCount
+			mu.Unlock()
+
+			ssn := newMockSession()
+			ssn.GenerateFunc = func(ctx context.Context, input []gollem.Input, opts ...gollem.GenerateOption) (*gollem.Response, error) {
+				// The agent's first session (plan) should return a direct plan
+				// (without function calls, since no knowledge entries exist).
+				if sc == 1 {
+					// This is the planSession created by executeSwarm (not used in agent mode)
+					return &gollem.Response{
+						Texts: []string{`{"message": "Direct response.", "tasks": []}`},
+					}, nil
+				}
+				// Agent-created session
+				return &gollem.Response{
+					Texts: []string{`{"message": "Analyzed with knowledge.", "tasks": []}`},
+				}, nil
+			}
+			return ssn, nil
+		},
+	}
+
+	chatUC := swarm.New(repo, mockLLM, newMockPolicyClient(t),
+		swarm.WithKnowledgeService(knowledgeSvc),
+		swarm.WithNoAuthorization(true),
+	)
+
+	err := chatUC.Execute(ctx, "Analyze this alert", chatModel.ChatContext{Ticket: testTicket})
+	gt.NoError(t, err)
+
+	// Verify that multiple sessions were created (planSession + agent's internal session)
+	mu.Lock()
+	gt.N(t, sessionCount).Greater(1)
+	mu.Unlock()
+}
+
+func TestSwarmChat_PlanWithoutKnowledgeService(t *testing.T) {
+	// This tests the fallback path (no knowledge service) still works.
+	// Existing TestSwarmChat_DirectResponse already covers this, but this
+	// explicitly verifies only one session is created.
+	ctx := setupTestContext(t)
+	repo := repository.NewMemory()
+	testTicket := setupTicketAndAlert(t, ctx, repo)
+
+	var mu sync.Mutex
+	sessionCount := 0
+
+	mockLLM := &mock.LLMClientMock{
+		NewSessionFunc: func(ctx context.Context, opts ...gollem.SessionOption) (gollem.Session, error) {
+			mu.Lock()
+			sessionCount++
+			mu.Unlock()
+
+			ssn := newMockSession()
+			ssn.GenerateFunc = func(ctx context.Context, input []gollem.Input, opts ...gollem.GenerateOption) (*gollem.Response, error) {
+				return &gollem.Response{
+					Texts: []string{`{"message": "Direct response.", "tasks": []}`},
+				}, nil
+			}
+			return ssn, nil
+		},
+	}
+
+	chatUC := swarm.New(repo, mockLLM, newMockPolicyClient(t),
+		swarm.WithNoAuthorization(true),
+	)
+
+	err := chatUC.Execute(ctx, "Analyze this alert", chatModel.ChatContext{Ticket: testTicket})
+	gt.NoError(t, err)
+
+	// Without knowledge service, only one session should be created (planSession).
+	mu.Lock()
+	gt.V(t, sessionCount).Equal(1)
+	mu.Unlock()
+}
+
+func TestFetchKnowledgeTags_NilService(t *testing.T) {
+	ctx := setupTestContext(t)
+	tags := swarm.FetchKnowledgeTags(ctx, nil)
+	gt.V(t, tags).Nil()
+}
+
+func TestFetchKnowledgeTags_WithService(t *testing.T) {
+	ctx := setupTestContext(t)
+	repo := repository.NewMemory()
+	embeddingMock := &mock.EmbeddingClientMock{
+		EmbeddingsFunc: func(ctx context.Context, texts []string, dimensionality int) ([][]float32, error) {
+			return make([][]float32, len(texts)), nil
+		},
+	}
+	knowledgeSvc := svcknowledge.New(repo, embeddingMock)
+
+	// Create a tag
+	_, err := knowledgeSvc.CreateTag(ctx, "test-tag", "A test tag")
+	gt.NoError(t, err)
+
+	tags := swarm.FetchKnowledgeTags(ctx, knowledgeSvc)
+	gt.A(t, tags).Length(1)
+	gt.V(t, tags[0].Name).Equal("test-tag")
+}

--- a/pkg/usecase/chat/swarm/prompt.go
+++ b/pkg/usecase/chat/swarm/prompt.go
@@ -11,6 +11,7 @@ import (
 	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	"github.com/secmon-lab/warren/pkg/domain/model/alert"
+	knowledgeModel "github.com/secmon-lab/warren/pkg/domain/model/knowledge"
 	"github.com/secmon-lab/warren/pkg/domain/model/lang"
 	"github.com/secmon-lab/warren/pkg/domain/model/prompt"
 	model "github.com/secmon-lab/warren/pkg/domain/model/slack"
@@ -40,15 +41,16 @@ var finalPromptTemplate string
 
 // planningContext holds the shared context for planning operations.
 type planningContext struct {
-	message        string
-	ticket         *ticket.Ticket
-	alerts         []*alert.Alert
-	tools          []interfaces.ToolSet
-	userPrompt     string
-	lang           lang.Lang
-	requesterID    string
-	threadComments []ticket.Comment
-	slackHistory   []model.HistoryMessage
+	message          string
+	ticket           *ticket.Ticket
+	alerts           []*alert.Alert
+	tools            []interfaces.ToolSet
+	userPrompt       string
+	lang             lang.Lang
+	requesterID      string
+	threadComments   []ticket.Comment
+	slackHistory     []model.HistoryMessage
+	knowledgeService *svcknowledge.Service
 }
 
 // generateSystemPrompt generates the shared system prompt containing static context.
@@ -66,6 +68,7 @@ func generateSystemPrompt(ctx context.Context, pc *planningContext) (string, err
 		"thread_comments":   pc.threadComments,
 		"topic":             pc.ticket.Topic,
 		"history_messages":  pc.slackHistory,
+		"knowledge_tags":    fetchKnowledgeTags(ctx, pc.knowledgeService),
 	})
 }
 
@@ -118,12 +121,13 @@ func generateFinalPrompt(ctx context.Context, pc *planningContext, allResults []
 
 // ticketlessPlanningContext holds the shared context for ticketless planning operations.
 type ticketlessPlanningContext struct {
-	message     string
-	tools       []interfaces.ToolSet
-	userPrompt  string
-	lang        lang.Lang
-	requesterID string
-	history     []model.HistoryMessage
+	message          string
+	tools            []interfaces.ToolSet
+	userPrompt       string
+	lang             lang.Lang
+	requesterID      string
+	history          []model.HistoryMessage
+	knowledgeService *svcknowledge.Service
 }
 
 // generateTicketlessSystemPrompt generates the system prompt for ticketless chat.
@@ -134,6 +138,7 @@ func generateTicketlessSystemPrompt(ctx context.Context, pc *ticketlessPlanningC
 		"user_prompt":       pc.userPrompt,
 		"lang":              pc.lang,
 		"requester_id":      pc.requesterID,
+		"knowledge_tags":    fetchKnowledgeTags(ctx, pc.knowledgeService),
 	})
 }
 
@@ -222,6 +227,20 @@ func formatCompletedResults(allResults []*phaseResult) string {
 		return "(no results yet)"
 	}
 	return b.String()
+}
+
+// fetchKnowledgeTags retrieves all knowledge tags for embedding in the planner prompt.
+// Returns nil if the knowledge service is not configured or an error occurs.
+func fetchKnowledgeTags(ctx context.Context, svc *svcknowledge.Service) []*knowledgeModel.KnowledgeTag {
+	if svc == nil {
+		return nil
+	}
+	tags, err := svc.ListTags(ctx)
+	if err != nil {
+		logging.From(ctx).Warn("failed to list knowledge tags for planning", "error", err)
+		return nil
+	}
+	return tags
 }
 
 // Schema definitions for structured LLM responses.

--- a/pkg/usecase/chat/swarm/prompt/plan.md
+++ b/pkg/usecase/chat/swarm/prompt/plan.md
@@ -9,7 +9,7 @@ Create an execution plan for the following user request.
 2. **Parallel execution**: ALL tasks in a phase are executed simultaneously in parallel. Tasks CANNOT depend on each other within the same phase.
 3. **Sequential dependencies**: If a task depends on the result of another task, put the dependent task in a later phase (via replan).
 4. **Replan opportunity**: After each phase completes, you will see all task results and can add new tasks, adjust the approach, or finish.
-5. **Direct response**: If the question can be answered immediately without any tool usage, set tasks to an empty array and put your answer in the message field.
+5. **Direct response**: If the question can be answered from your existing context or from knowledge search results alone, set tasks to an empty array and put your answer in the message field. Do not create tasks when no additional tool execution is needed.
 6. **Message required**: Always include a message — it will be shown to the user as an initial response before tasks begin.
 7. **Tool assignment**: Each task must specify which ToolSet names it needs. Only specified ToolSets will be available to that task.
 8. **Clear purpose**: Each task must have a clear, specific purpose. The description should be detailed enough for an independent agent to execute it.

--- a/pkg/usecase/chat/swarm/prompt/system.md
+++ b/pkg/usecase/chat/swarm/prompt/system.md
@@ -55,16 +55,18 @@ The following recent messages from the Slack channel provide additional context:
 {{ end }}
 {{ end }}
 ## Knowledge Base
+{{ if .knowledge_tags }}
+Use `knowledge_search` to search for relevant prior knowledge before planning. The knowledge base may contain known false positive patterns, infrastructure details, previously observed behaviors, and investigation techniques.
 
-Before starting your investigation, **search the knowledge base** using `knowledge_search` for relevant prior knowledge. Use `knowledge_tag_list` first to see available tags, then search with relevant tags and keywords from the alert (e.g., IP addresses, domain names, process names, service names).
+If the search results alone are sufficient to answer the user's question, respond directly in the `message` field without creating any tasks (set `tasks` to an empty array).
 
-The knowledge base may contain:
-- Known false positive patterns and their conditions
-- Infrastructure details (server roles, IP ranges, scheduled jobs)
-- Previously observed behaviors for specific hosts or processes
-- Investigation techniques and tool usage tips
-
-Incorporate any relevant knowledge into your analysis to avoid redundant investigation and leverage past findings.
+### Available Tags
+{{ range .knowledge_tags }}- `{{ .ID }}`: {{ .Name }}{{ if .Description }} — {{ .Description }}{{ end }}
+{{ end }}
+Specify at least one tag when searching. Use tags and keywords from the alert (e.g., IP addresses, domain names, process names, service names).
+{{ else }}
+No knowledge base is configured.
+{{ end }}
 
 ## Available Tools
 {{ .tools_description }}

--- a/pkg/usecase/chat/swarm/prompt/ticketless_system.md
+++ b/pkg/usecase/chat/swarm/prompt/ticketless_system.md
@@ -39,8 +39,16 @@ The following messages provide context from the Slack channel:
 {{- end }}
 
 ## Knowledge Base
+{{ if .knowledge_tags }}
+Use `knowledge_search` to search for relevant prior knowledge before planning. If the search results alone are sufficient to answer the user's question, respond directly in the `message` field without creating any tasks.
 
-Before starting your work, **search the knowledge base** using `knowledge_search` for relevant prior knowledge. Use `knowledge_tag_list` first to see available tags, then search with relevant tags and keywords from the user's question.
+### Available Tags
+{{ range .knowledge_tags }}- `{{ .ID }}`: {{ .Name }}{{ if .Description }} — {{ .Description }}{{ end }}
+{{ end }}
+Specify at least one tag when searching.
+{{ else }}
+No knowledge base is configured.
+{{ end }}
 
 ## Available Tools
 {{ .tools_description }}

--- a/pkg/usecase/chat/swarm/swarm.go
+++ b/pkg/usecase/chat/swarm/swarm.go
@@ -238,27 +238,29 @@ func (c *SwarmChat) executeSwarm(ctx context.Context, ssn *session.Session, mess
 
 	// Build planning context from ChatContext
 	planCtx := &planningContext{
-		message:        message,
-		ticket:         target,
-		alerts:         chatCtx.Alerts,
-		tools:          c.tools,
-		userPrompt:     c.userSystemPrompt,
-		lang:           lang.From(ctx),
-		requesterID:    string(types.UserID(user.FromContext(ctx))),
-		threadComments: chatCtx.ThreadComments,
-		slackHistory:   chatCtx.SlackHistory,
+		message:          message,
+		ticket:           target,
+		alerts:           chatCtx.Alerts,
+		tools:            c.tools,
+		userPrompt:       c.userSystemPrompt,
+		lang:             lang.From(ctx),
+		requesterID:      string(types.UserID(user.FromContext(ctx))),
+		threadComments:   chatCtx.ThreadComments,
+		slackHistory:     chatCtx.SlackHistory,
+		knowledgeService: c.knowledgeService,
 	}
 
 	// Generate system prompt once (shared across plan/replan/final sessions)
 	var systemPrompt string
 	if ticketless {
 		tlpc := &ticketlessPlanningContext{
-			message:     message,
-			tools:       c.tools,
-			userPrompt:  c.userSystemPrompt,
-			lang:        lang.From(ctx),
-			requesterID: string(types.UserID(user.FromContext(ctx))),
-			history:     chatCtx.SlackHistory,
+			message:          message,
+			tools:            c.tools,
+			userPrompt:       c.userSystemPrompt,
+			lang:             lang.From(ctx),
+			requesterID:      string(types.UserID(user.FromContext(ctx))),
+			history:          chatCtx.SlackHistory,
+			knowledgeService: c.knowledgeService,
 		}
 		var err error
 		systemPrompt, err = generateTicketlessSystemPrompt(ctx, tlpc)
@@ -289,7 +291,7 @@ func (c *SwarmChat) executeSwarm(ctx context.Context, ssn *session.Session, mess
 	}
 
 	// Planning phase
-	planResult, err := c.plan(ctx, planSession, planCtx)
+	planResult, err := c.plan(ctx, planSession, planCtx, systemPrompt)
 	if err != nil {
 		if abortErr := checkAborted(ctx, cleanupCtx, finalStatus); abortErr != nil {
 			return abortErr


### PR DESCRIPTION
## Summary
- Swarm plannerがJSON出力専用セッションでknowledge検索できなかった問題を修正
- `knowledgeService`が設定されている場合、plannerを`gollem.Agent`に変更し`knowledge_search`ツールを渡す
- タグ一覧（数十件）をsystem promptに事前埋め込みし、plannerが適切なタグで検索できるようにする

## Details
- `plan()`と`replan()`を`gollem.Agent`化（knowledge付き）。Agent実行後のhistoryを`planSession`に同期して後続フェーズで参照可能に
- `knowledgeService`がnilの場合は従来通り`Session.Generate`にフォールバック
- promptテンプレート更新: タグ一覧表示、`knowledge_tag_list`指示削除、knowledge検索だけで回答可能な場合の直接応答ガイダンス追加

## Test plan
- [x] `TestSwarmChat_PlanWithKnowledgeService` — Agent mode経由でplan生成
- [x] `TestSwarmChat_PlanWithoutKnowledgeService` — フォールバックパス
- [x] `TestFetchKnowledgeTags_NilService` / `TestFetchKnowledgeTags_WithService`
- [x] 既存swarmテスト全pass
- [x] `go vet` / `golangci-lint` / `gosec` クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)