### PR TITLE
fix(test): align detect test OPA query path with server

### DIFF
--- a/pkg/domain/model/policy/testdata.go
+++ b/pkg/domain/model/policy/testdata.go
@@ -104,7 +104,7 @@ func test(ctx context.Context, queryFunc QueryFunc, testData *TestData, shouldDe
 				return nil
 			}
 
-			err := queryFunc(ctx, "data.ingest."+schema.String()+".alerts", testData, &resp, opaq.WithPrintHook(hook))
+			err := queryFunc(ctx, "data.ingest."+schema.String(), testData, &resp, opaq.WithPrintHook(hook))
 			if err != nil {
 				if errors.Is(err, opaq.ErrNoEvalResult) {
 					if shouldDetect {


### PR DESCRIPTION
## Summary
- `warren test` の detect テストで OPA クエリパスがサーバー側と不一致だったのを修正
- テスト側: `data.ingest.{schema}.alerts` → OPA が配列を直接返し `alert.QueryOutput` にデシリアライズ失敗
- サーバー側と同じ `data.ingest.{schema}` に修正し、`{"alerts": [...]}` が正しく返るように

## Test plan
- [x] `go vet ./pkg/domain/model/policy/...` パス
- [x] `go test ./pkg/domain/model/policy/...` パス
- [x] `golangci-lint run ./pkg/domain/model/policy/...` パス
- [x] `gosec -exclude-generated -quiet ./pkg/domain/model/policy/...` パス
- [ ] 実環境で `warren test -p ./images/warren/policy -d images/warren/test/detect` が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)