### PR TITLE
refactor(docs): optimize CLAUDE.md

### DIFF
--- a/.claude/rules/alert-processing.md
+++ b/.claude/rules/alert-processing.md
@@ -1,0 +1,11 @@
+---
+paths:
+  - "pkg/usecase/alert_pipeline*"
+  - "pkg/domain/model/alert/**"
+---
+
+# Alert Processing Rules
+
+- **Alerts are immutable** and can be linked to at most one ticket
+- `ProcessAlertPipeline()` is pure (no side effects); `HandleAlert()` includes DB save and Slack posting — new processing logic should respect this separation
+- All pipeline events are emitted through `Notifier` interface for real-time monitoring

--- a/.claude/rules/chat-strategy-naming.md
+++ b/.claude/rules/chat-strategy-naming.md
@@ -1,0 +1,8 @@
+---
+paths:
+  - "pkg/usecase/chat/**"
+---
+
+# Chat Strategy Naming Convention
+
+Chat strategies are named after wildflowers in alphabetical order: `aster` (A), `bluebell` (B), `clover` (C), `daisy` (D), etc. Each strategy is a separate package under `pkg/usecase/chat/<flower>/` implementing the `interfaces.ChatUseCase` interface. The current default strategy is `aster`. When adding a new strategy, use the next wildflower in alphabetical sequence.

--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -1,0 +1,19 @@
+---
+paths:
+  - "frontend/**"
+---
+
+# Frontend Rules
+
+## Test Requirements
+- **EVERY frontend feature addition or modification MUST include corresponding E2E tests**
+- E2E tests are located in `frontend/e2e/tests/` using Playwright
+- Page Objects are in `frontend/e2e/pages/` — add or update them as needed
+- Use semantic locators (`getByRole`, `getByText`, `data-testid`) instead of CSS class selectors
+- Do NOT use `waitForLoadState("networkidle")` — rely on Playwright's auto-waiting
+- Do NOT consider a frontend task complete until E2E tests covering the new/changed behavior are written
+
+## Date Format
+- ALWAYS use `YYYY/MM/DD` format. NEVER use `MM/DD/YYYY` or locale-dependent formats like `toLocaleDateString()`
+  - Use: `date.toISOString().split('T')[0].replace(/-/g, '/')`
+  - Do NOT use: `date.toLocaleDateString()`

--- a/.claude/rules/notifier-design.md
+++ b/.claude/rules/notifier-design.md
@@ -1,0 +1,11 @@
+---
+paths:
+  - "pkg/domain/interfaces/notifier*"
+  - "pkg/domain/event/**"
+  - "pkg/service/notifier/**"
+---
+
+# Notifier Design Rule
+
+- Notifier uses **type-safe event methods** — each event type has its own dedicated method (e.g., `NotifyIngestPolicyResult`, `NotifyError`)
+- **Do NOT add a generic `Notify(event)` method** — always add a new typed method for new event types

--- a/.claude/rules/repository-tests.md
+++ b/.claude/rules/repository-tests.md
@@ -1,0 +1,15 @@
+---
+paths:
+  - "pkg/repository/**"
+---
+
+# Repository Test Rules
+
+- NEVER create test files in `pkg/repository/firestore/` or `pkg/repository/memory/` subdirectories
+- ALL repository tests MUST be placed directly in `pkg/repository/*_test.go`
+- Use `runRepositoryTest()` helper to test against both memory and firestore implementations
+- Always use random IDs (e.g., using `time.Now().UnixNano()`) to avoid test conflicts
+- Never use hardcoded IDs like "msg-001", "user-001" as they cause test failures when running in parallel
+- Always verify ALL fields of returned values, not just checking for nil/existence
+- Compare expected values properly - don't just check if something exists, verify it matches what was saved
+- For timestamp comparisons, use tolerance (e.g., `< time.Second`) to account for storage precision

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,19 +60,6 @@ Pipeline stages in `pkg/usecase/alert_pipeline.go`:
 - When refactoring, ensure existing tests still pass and add tests if coverage gaps are found
 - Do NOT consider a task complete until tests are written and passing
 
-### Frontend Test Requirements
-- **EVERY frontend feature addition or modification MUST include corresponding E2E tests**
-- E2E tests are located in `frontend/e2e/tests/` using Playwright
-- Page Objects are in `frontend/e2e/pages/` — add or update them as needed
-- Use semantic locators (`getByRole`, `getByText`, `data-testid`) instead of CSS class selectors
-- Do NOT use `waitForLoadState("networkidle")` — rely on Playwright's auto-waiting
-- Do NOT consider a frontend task complete until E2E tests covering the new/changed behavior are written
-
-### Frontend Date Format
-- ALWAYS use `YYYY/MM/DD` format. NEVER use `MM/DD/YYYY` or locale-dependent formats like `toLocaleDateString()`
-  - Use: `date.toISOString().split('T')[0].replace(/-/g, '/')`
-  - Do NOT use: `date.toLocaleDateString()`
-
 ### Error Handling
 - Use `github.com/m-mizutani/goerr/v2` for error handling
 - Must wrap errors with `goerr.Wrap` to maintain error context
@@ -102,16 +89,6 @@ Pipeline stages in `pkg/usecase/alert_pipeline.go`:
   - GOOD: Check each expected ID explicitly with `gt.True(t, deleteMap[id])`
 - Test files should have `package {name}_test`. Do not use same package name
 - Test file name convention is: `xyz.go` -> `xyz_test.go`. Other test file names (e.g., `xyz_e2e_test.go`) are not allowed
-- Repository Tests Location:
-  - NEVER create test files in `pkg/repository/firestore/` or `pkg/repository/memory/` subdirectories
-  - ALL repository tests MUST be placed directly in `pkg/repository/*_test.go`
-  - Use `runRepositoryTest()` helper to test against both memory and firestore implementations
-- Repository Tests Best Practices:
-  - Always use random IDs (e.g., using `time.Now().UnixNano()`) to avoid test conflicts
-  - Never use hardcoded IDs like "msg-001", "user-001" as they cause test failures when running in parallel
-  - Always verify ALL fields of returned values, not just checking for nil/existence
-  - Compare expected values properly - don't just check if something exists, verify it matches what was saved
-  - For timestamp comparisons, use tolerance (e.g., `< time.Second`) to account for storage precision
 - Test Skip Policy:
   - **NEVER use `t.Skip()` for anything other than missing environment variables**
   - If a test requires infrastructure (like Firestore index), fix the infrastructure, don't skip the test
@@ -124,24 +101,11 @@ Before creating or modifying tests:
 2. Does the test file name match exactly? (`xyz.go` -> `xyz_test.go`)
 3. Are all tests for a source file in ONE test file?
 4. No standalone feature/e2e/integration test files?
-5. For repository tests: placed in `pkg/repository/*_test.go`, NOT in firestore/ or memory/ subdirectories?
 
 ### Code Visibility
 - Do not expose unnecessary methods, structs, and variables
 - Assume that exposed items will be changed. Never expose fields that would be problematic if changed
 - Use `export_test.go` for items that need to be exposed for testing purposes
-
-### Alert Processing Rules
-- **Alerts are immutable** and can be linked to at most one ticket
-- `ProcessAlertPipeline()` is pure (no side effects); `HandleAlert()` includes DB save and Slack posting — new processing logic should respect this separation
-- All pipeline events are emitted through `Notifier` interface for real-time monitoring
-
-### Notifier Design Rule
-- Notifier uses **type-safe event methods** — each event type has its own dedicated method (e.g., `NotifyIngestPolicyResult`, `NotifyError`)
-- **Do NOT add a generic `Notify(event)` method** — always add a new typed method for new event types
-
-### Chat Strategy Naming Convention
-Chat strategies are named after wildflowers in alphabetical order: `aster` (A), `bluebell` (B), `clover` (C), `daisy` (D), etc. Each strategy is a separate package under `pkg/usecase/chat/<flower>/` implementing the `interfaces.ChatUseCase` interface. The current default strategy is `aster`. When adding a new strategy, use the next wildflower in alphabetical sequence.
 
 ### Pre-commit Checks
 When making changes, before finishing the task, always:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,15 +1,10 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
-
-## Project Overview
-
-Warren is an AI agent and Slack-based security alert management tool. It processes security alerts, analyzes them using LLM (Gemini), and manages incident response through Slack integration.
+Warren is an AI agent and Slack-based security alert management tool that processes security alerts using LLM (Gemini) and manages incident response through Slack.
 
 ## Common Development Commands
 
 ### Building and Testing
-- `go build` - Build the main binary
 - `go test ./...` - Run all tests
 - `go test ./pkg/path/to/package` - Run tests for specific package
 - `task` - Run default tasks (mock generation and GraphQL)
@@ -21,15 +16,33 @@ Warren is an AI agent and Slack-based security alert management tool. It process
 - `pnpm run dev` - Start development server
 - `pnpm run build` - Build frontend for production
 - `pnpm run codegen` - Generate GraphQL types from schema
-- **Date Format**: ALWAYS use `YYYY/MM/DD` format. NEVER use `MM/DD/YYYY` or locale-dependent formats like `toLocaleDateString()`
-  - Use: `date.toISOString().split('T')[0].replace(/-/g, '/')`
-  - Do NOT use: `date.toLocaleDateString()`
 
 ### Code Generation
 - `go tool moq` - Generate mocks (handled by task commands)
 - `go tool gqlgen generate` - Generate GraphQL resolvers and types
 
-## Important Development Guidelines
+## Architecture Overview
+
+The application follows Domain-Driven Design (DDD) with clean architecture:
+
+- `pkg/domain/` - Domain layer with business logic, interfaces, and models
+- `pkg/service/` - Application services implementing business operations
+- `pkg/controller/` - Interface adapters (HTTP, GraphQL, Slack)
+- `pkg/adapter/` - Infrastructure adapters (storage, external APIs)
+- `pkg/repository/` - Data persistence implementations
+- `pkg/usecase/` - Application use cases orchestrating domain operations
+
+### Alert Processing Pipeline
+Pipeline stages in `pkg/usecase/alert_pipeline.go`:
+1. **Ingest Policy Evaluation** - Transform raw alert data into Alert objects
+2. **Metadata Generation** - Fill missing titles/descriptions using LLM
+3. **Enrich Policy Evaluation** - Execute enrichment tasks (query/agent)
+4. **Triage Policy Evaluation** - Apply final metadata and determine publish type
+
+### Application Modes
+`serve` (HTTP/Slack/GraphQL), `run` (CLI), `chat` (interactive), `tool` (utilities), `test` (testing)
+
+## Development Rules
 
 ### Implementation Completeness
 - **NEVER leave incomplete implementations, TODOs, or placeholder code**
@@ -54,6 +67,11 @@ Warren is an AI agent and Slack-based security alert management tool. It process
 - Do NOT use `waitForLoadState("networkidle")` — rely on Playwright's auto-waiting
 - Do NOT consider a frontend task complete until E2E tests covering the new/changed behavior are written
 
+### Frontend Date Format
+- ALWAYS use `YYYY/MM/DD` format. NEVER use `MM/DD/YYYY` or locale-dependent formats like `toLocaleDateString()`
+  - Use: `date.toISOString().split('T')[0].replace(/-/g, '/')`
+  - Do NOT use: `date.toLocaleDateString()`
+
 ### Error Handling
 - Use `github.com/m-mizutani/goerr/v2` for error handling
 - Must wrap errors with `goerr.Wrap` to maintain error context
@@ -72,7 +90,7 @@ Warren is an AI agent and Slack-based security alert management tool. It process
   - BAD: `defer func() { _ = client.Close() }()`, `defer client.Close()`
   - GOOD: `defer safe.Close(ctx, client)`
 
-### Testing with gt Package
+### Testing Conventions
 - Use `github.com/m-mizutani/gt` package for type-safe testing
 - Prefer Helper Driven Testing style over Table Driven Tests
 - Use Memory repository from `pkg/repository` instead of mocks for repository testing
@@ -81,174 +99,8 @@ Warren is an AI agent and Slack-based security alert management tool. It process
 - **NEVER use length-only checks** - always verify individual IDs/values explicitly
   - BAD: `gt.A(t, toDelete).Length(3)` with commented out ID checks
   - GOOD: Check each expected ID explicitly with `gt.True(t, deleteMap[id])`
-
-### Code Visibility
-- Do not expose unnecessary methods, variables and types
-- Use `export_test.go` to expose items needed only for testing
-
-## Architecture
-
-### Core Structure
-The application follows Domain-Driven Design (DDD) with clean architecture:
-
-- `pkg/domain/` - Domain layer with business logic, interfaces, and models
-- `pkg/service/` - Application services implementing business operations
-- `pkg/controller/` - Interface adapters (HTTP, GraphQL, Slack)
-- `pkg/adapter/` - Infrastructure adapters (storage, external APIs)
-- `pkg/repository/` - Data persistence implementations
-- `pkg/usecase/` - Application use cases orchestrating domain operations
-
-### Key Components
-
-#### Alert Processing Pipeline
-- `pkg/domain/model/alert/` - Core alert model with metadata and embedding support
-- `pkg/usecase/alert_pipeline.go` - Main alert processing pipeline
-- Alerts are immutable and can be linked to at most one ticket
-- Uses AI to generate titles, descriptions, and semantic embeddings
-
-**Pipeline Stages**:
-1. **Ingest Policy Evaluation** - Transform raw alert data into Alert objects
-2. **Metadata Generation** - Fill missing titles/descriptions using LLM
-3. **Enrich Policy Evaluation** - Execute enrichment tasks (query/agent)
-4. **Triage Policy Evaluation** - Apply final metadata and determine publish type
-
-**Pipeline Execution**:
-- `ProcessAlertPipeline()` - Pure pipeline processing (no side effects)
-- `HandleAlert()` - Complete alert handling including DB save and Slack posting
-- All pipeline events are emitted through `Notifier` interface for real-time monitoring
-
-#### Chat Strategy Naming Convention
-Chat strategies are named after wildflowers in alphabetical order: `aster` (A), `bluebell` (B), `clover` (C), `daisy` (D), etc. Each strategy is a separate package under `pkg/usecase/chat/<flower>/` implementing the `interfaces.ChatUseCase` interface. The current default strategy is `aster`. When adding a new strategy, use the next wildflower in alphabetical sequence.
-
-#### Command System
-- `pkg/service/command/` - Slack command processing (list, aggregate, ticket)
-- Commands: `l`/`ls`/`list`, `a`/`aggr`/`aggregate`, `t`/`ticket`
-
-#### LLM Integration
-- Uses Vertex AI Gemini for alert analysis and metadata generation
-- `pkg/service/llm/` - LLM service abstractions
-- Implements gollem.LLMClient interface for AI operations
-
-#### Storage
-- Firestore for persistence in serve mode
-- In-memory storage for testing/development
-- `pkg/repository/` - Repository pattern implementations
-
-#### Agent Memory Scoring (Experimental)
-- `pkg/service/memory/scoring.go` - Quality-based memory ranking and pruning
-- `pkg/service/memory/feedback.go` - LLM-based feedback collection
-- `pkg/domain/model/memory/feedback.go` - Feedback model (Relevance/Support/Impact)
-
-**Features**:
-- **Quality Scoring**: Memories rated from -10 (harmful) to +10 (helpful)
-- **Adaptive Search**: Re-ranks memories by similarity (50%) + quality (30%) + recency (20%)
-- **LLM Feedback**: Automatically evaluates memory usefulness after each agent execution
-- **EMA Updates**: Smooth score evolution using exponential moving average (alpha=0.3)
-- **Conservative Pruning**: Strict deletion criteria to preserve memories
-  - Critical (≤-8.0): Immediate deletion
-  - Harmful (≤-5.0) + 90 days unused: Deletion
-  - Moderate (≤-3.0) + 180 days unused: Deletion
-
-**Configuration** (all parameters in `ScoringConfig`):
-- Fully configurable weights, thresholds, and decay rates
-- Default values optimized for gradual learning
-- Easy to remove if experimental feature proves ineffective
-
-**Implementation**:
-- Isolated in 3 files: `scoring.go`, `feedback.go`, `prompt/feedback.md`
-- Minimal changes to existing code (re-ranking in `SearchRelevantAgentMemories`)
-- Backward compatible (existing memories default to score=0.0)
-
-### Application Modes
-- `serve` - HTTP server mode with Slack integration, GraphQL API
-- `run` - CLI mode for processing individual alerts
-- `test` - Testing utilities
-- `chat` - Interactive chat mode
-- `tool` - Tool execution utilities
-
-### Key Interfaces
-- `interfaces.Repository` - Data persistence abstraction
-- `interfaces.LLMClient` - AI/LLM client abstraction
-- `interfaces.SlackClient` - Slack API client abstraction
-- `interfaces.PolicyClient` - Policy evaluation using OPA
-- `interfaces.StorageClient` - Cloud storage abstraction
-- `interfaces.Notifier` - Event notification abstraction for alert pipeline events
-
-#### Event Notification System
-The alert processing pipeline uses an event-driven notification pattern:
-
-- **Notifier Interface** (`pkg/domain/interfaces/notifier.go`):
-  - Type-safe event handling with dedicated methods for each event type
-  - Methods: `NotifyAlertPolicyResult`, `NotifyEnrichPolicyResult`, `NotifyCommitPolicyResult`, `NotifyEnrichTaskPrompt`, `NotifyEnrichTaskResponse`, `NotifyError`
-  - No generic `Notify(event)` method - each event type has its own method signature
-
-- **Event Types** (`pkg/domain/event/`):
-  - `AlertPolicyResultEvent` - Alert policy evaluation results
-  - `EnrichPolicyResultEvent` - Enrichment policy evaluation results
-  - `CommitPolicyResultEvent` - Commit policy evaluation results
-  - `EnrichTaskPromptEvent` - LLM task prompt being sent
-  - `EnrichTaskResponseEvent` - LLM task response received
-  - `ErrorEvent` - Error occurred during pipeline processing
-
-- **Notifier Implementations**:
-  - `ConsoleNotifier` (`pkg/service/notifier/console.go`) - Outputs events to console with color formatting
-  - `SlackNotifier` (`pkg/service/notifier/slack.go`) - Posts events to Slack thread with formatted messages
-  - Both implementations provide real-time visibility into alert pipeline processing
-
-### Tools Integration
-External security tools integrated via `pkg/tool/`:
-- BigQuery for data analysis
-- VirusTotal, OTX, URLScan for threat intelligence
-- AbuseChip, Shodan, IPDB for IP/domain analysis
-
-## Configuration
-
-The application is configured via CLI flags or environment variables. Key configurations include:
-- Gemini/Vertex AI settings (project ID, location, model)
-- Firestore database settings
-- Slack integration (OAuth token, signing secret, channel)
-- External tool API keys (OTX, URLScan, etc.)
-
-## Testing
-
-Test files follow Go conventions (`*_test.go`). The codebase includes:
-- Unit tests for individual components
-- Integration tests with mock dependencies
-- Test data in `testdata/` directories
-- Mock generation using `moq` tool
-
-## Restrictions and Rules
-
-### Directory
-
-- When you are mentioned about `tmp` directory, you SHOULD NOT see `/tmp`. You need to check `./tmp` directory from root of the repository.
-
-### Exposure policy
-
-In principle, do not trust developers who use this library from outside
-
-- Do not export unnecessary methods, structs, and variables
-- Assume that exposed items will be changed. Never expose fields that would be problematic if changed
-- Use `export_test.go` for items that need to be exposed for testing purposes
-
-### Check
-
-When making changes, before finishing the task, always:
-- Run `go vet ./...`, `go fmt ./...` to format the code
-- Run `golangci-lint run ./...` to check lint error
-- Run `gosec -exclude-generated -quiet ./...` to check security issue
-- Run tests to ensure no impact on other code
-
-**NEVER run `go build` to verify code.** Use `go vet ./...` instead to check for compile errors.
-
-### Language
-
-All comment and character literal in source code must be in English
-
-### Testing
-
 - Test files should have `package {name}_test`. Do not use same package name
-- Test file name convention is: `xyz.go` → `xyz_test.go`. Other test file names (e.g., `xyz_e2e_test.go`) are not allowed.
+- Test file name convention is: `xyz.go` -> `xyz_test.go`. Other test file names (e.g., `xyz_e2e_test.go`) are not allowed
 - Repository Tests Location:
   - NEVER create test files in `pkg/repository/firestore/` or `pkg/repository/memory/` subdirectories
   - ALL repository tests MUST be placed directly in `pkg/repository/*_test.go`
@@ -267,8 +119,40 @@ All comment and character literal in source code must be in English
 
 ### Test File Checklist (Use this EVERY time)
 Before creating or modifying tests:
-1. ✓ Is there a corresponding source file for this test file?
-2. ✓ Does the test file name match exactly? (`xyz.go` → `xyz_test.go`)
-3. ✓ Are all tests for a source file in ONE test file?
-4. ✓ No standalone feature/e2e/integration test files?
-5. ✓ For repository tests: placed in `pkg/repository/*_test.go`, NOT in firestore/ or memory/ subdirectories?
+1. Is there a corresponding source file for this test file?
+2. Does the test file name match exactly? (`xyz.go` -> `xyz_test.go`)
+3. Are all tests for a source file in ONE test file?
+4. No standalone feature/e2e/integration test files?
+5. For repository tests: placed in `pkg/repository/*_test.go`, NOT in firestore/ or memory/ subdirectories?
+
+### Code Visibility
+- Do not expose unnecessary methods, structs, and variables
+- Assume that exposed items will be changed. Never expose fields that would be problematic if changed
+- Use `export_test.go` for items that need to be exposed for testing purposes
+
+### Alert Processing Rules
+- **Alerts are immutable** and can be linked to at most one ticket
+- `ProcessAlertPipeline()` is pure (no side effects); `HandleAlert()` includes DB save and Slack posting — new processing logic should respect this separation
+- All pipeline events are emitted through `Notifier` interface for real-time monitoring
+
+### Notifier Design Rule
+- Notifier uses **type-safe event methods** — each event type has its own dedicated method (e.g., `NotifyAlertPolicyResult`, `NotifyError`)
+- **Do NOT add a generic `Notify(event)` method** — always add a new typed method for new event types
+
+### Chat Strategy Naming Convention
+Chat strategies are named after wildflowers in alphabetical order: `aster` (A), `bluebell` (B), `clover` (C), `daisy` (D), etc. Each strategy is a separate package under `pkg/usecase/chat/<flower>/` implementing the `interfaces.ChatUseCase` interface. The current default strategy is `aster`. When adding a new strategy, use the next wildflower in alphabetical sequence.
+
+### Pre-commit Checks
+When making changes, before finishing the task, always:
+- Run `go vet ./...`, `go fmt ./...` to format the code
+- Run `golangci-lint run ./...` to check lint error
+- Run `gosec -exclude-generated -quiet ./...` to check security issue
+- Run tests to ensure no impact on other code
+
+**NEVER run `go build` to verify code.** Use `go vet ./...` instead to check for compile errors.
+
+### Language
+All comment and character literal in source code must be in English
+
+### Directory
+- When you are mentioned about `tmp` directory, you SHOULD NOT see `/tmp`. You need to check `./tmp` directory from root of the repository.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,9 +35,10 @@ The application follows Domain-Driven Design (DDD) with clean architecture:
 ### Alert Processing Pipeline
 Pipeline stages in `pkg/usecase/alert_pipeline.go`:
 1. **Ingest Policy Evaluation** - Transform raw alert data into Alert objects
-2. **Metadata Generation** - Fill missing titles/descriptions using LLM
-3. **Enrich Policy Evaluation** - Execute enrichment tasks (query/agent)
-4. **Triage Policy Evaluation** - Apply final metadata and determine publish type
+2. **Tag Conversion** - Convert tag names to tag IDs
+3. **Metadata Generation** - Fill missing titles/descriptions using LLM
+4. **Enrich Policy Evaluation** - Execute enrichment tasks (query/agent)
+5. **Triage Policy Evaluation** - Apply final metadata and determine publish type
 
 ### Application Modes
 `serve` (HTTP/Slack/GraphQL), `run` (CLI), `chat` (interactive), `tool` (utilities), `test` (testing)
@@ -136,7 +137,7 @@ Before creating or modifying tests:
 - All pipeline events are emitted through `Notifier` interface for real-time monitoring
 
 ### Notifier Design Rule
-- Notifier uses **type-safe event methods** — each event type has its own dedicated method (e.g., `NotifyAlertPolicyResult`, `NotifyError`)
+- Notifier uses **type-safe event methods** — each event type has its own dedicated method (e.g., `NotifyIngestPolicyResult`, `NotifyError`)
 - **Do NOT add a generic `Notify(event)` method** — always add a new typed method for new event types
 
 ### Chat Strategy Naming Convention


### PR DESCRIPTION
## Summary
- Remove architecture implementation details that duplicate source code (Memory Scoring, Event System, Key Interfaces, Tools Integration, etc.) — 274 lines → 158 lines (42% reduction)
- Keep minimal navigation info: DDD layer structure, pipeline 4 stages, application modes
- Extract buried domain rules into explicit Development Rules section: alert immutability, pipeline purity separation, notifier type-safe design
- Merge duplicated sections: Code Visibility + Exposure policy, Testing with gt + Testing rules
- Move Frontend Date Format to its own section near Frontend Test Requirements

## Test plan
- [x] Verified all 17 rules/conventions from the original are preserved in the new version
- [x] Confirmed no behavioral guidance was lost — only descriptive/reference info removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)