### PR TITLE
refactor(chat): extract common logic into chat.UseCase

### DIFF
--- a/pkg/cli/serve.go
+++ b/pkg/cli/serve.go
@@ -26,8 +26,10 @@ import (
 	"github.com/secmon-lab/warren/pkg/service/circuitbreaker"
 	svcknowledge "github.com/secmon-lab/warren/pkg/service/knowledge"
 	"github.com/secmon-lab/warren/pkg/service/prompt"
+	slackService "github.com/secmon-lab/warren/pkg/service/slack"
 	"github.com/secmon-lab/warren/pkg/service/tag"
 	"github.com/secmon-lab/warren/pkg/usecase"
+	chatuc "github.com/secmon-lab/warren/pkg/usecase/chat"
 	"github.com/secmon-lab/warren/pkg/usecase/chat/aster"
 	"github.com/secmon-lab/warren/pkg/usecase/chat/bluebell"
 	"github.com/secmon-lab/warren/pkg/utils/logging"
@@ -57,30 +59,30 @@ func generateFrontendURL(addr string) string {
 
 func cmdServe() *cli.Command {
 	var (
-		addr                 string
-		enableGraphQL        bool
-		enableGraphiQL       bool
-		noAuthorization      bool
-		disableHTTPLogger    bool
-		disableLLM           bool
-		strictAlert          bool
-		wsAllowedOrigins     []string
-		webUICfg             config.WebUI
-		policyCfg            config.Policy
-		genaiCfg             config.GenAI
-		sentryCfg            config.Sentry
-		slackCfg             config.Slack
-		llmCfg               config.LLMCfg
-		firestoreCfg         config.Firestore
-		storageCfg           config.Storage
-		mcpCfg               config.MCPConfig
-		asyncCfg             config.AsyncAlertHook
-		traceCfg             config.Trace
-		userSystemPromptCfg  config.UserSystemPrompt
-		strategyPromptsCfg config.StrategySystemPrompts
-		cbCfg                config.CircuitBreaker
-		chatStrategy         string
-		budgetStrategy       string
+		addr                string
+		enableGraphQL       bool
+		enableGraphiQL      bool
+		noAuthorization     bool
+		disableHTTPLogger   bool
+		disableLLM          bool
+		strictAlert         bool
+		wsAllowedOrigins    []string
+		webUICfg            config.WebUI
+		policyCfg           config.Policy
+		genaiCfg            config.GenAI
+		sentryCfg           config.Sentry
+		slackCfg            config.Slack
+		llmCfg              config.LLMCfg
+		firestoreCfg        config.Firestore
+		storageCfg          config.Storage
+		mcpCfg              config.MCPConfig
+		asyncCfg            config.AsyncAlertHook
+		traceCfg            config.Trace
+		userSystemPromptCfg config.UserSystemPrompt
+		strategyPromptsCfg  config.StrategySystemPrompts
+		cbCfg               config.CircuitBreaker
+		chatStrategy        string
+		budgetStrategy      string
 	)
 
 	flags := joinFlags(
@@ -412,14 +414,10 @@ func cmdServe() *cli.Command {
 				asterOpts := []aster.Option{
 					aster.WithTools(allTools),
 					aster.WithStorageClient(storageClient),
-					aster.WithNoAuthorization(noAuthorization),
 					aster.WithUserSystemPrompt(userSystemPrompt),
 				}
 				if slackSvc != nil {
 					asterOpts = append(asterOpts, aster.WithSlackService(slackSvc))
-				}
-				if webUICfg.GetFrontendURL() != "" {
-					asterOpts = append(asterOpts, aster.WithFrontendURL(webUICfg.GetFrontendURL()))
 				}
 				if storageCfg.IsConfigured() && storageCfg.Prefix() != "" {
 					asterOpts = append(asterOpts, aster.WithStoragePrefix(storageCfg.Prefix()))
@@ -444,8 +442,9 @@ func cmdServe() *cli.Command {
 				// Configure HITL tools that require human approval
 				asterOpts = append(asterOpts, aster.WithHITLTools([]string{"web_fetch"}))
 
-				asterChat := aster.New(repo, llmClient, policyClient, asterOpts...)
-				ucOptions = append(ucOptions, usecase.WithChatUseCase(asterChat))
+				asterStrategy := aster.New(repo, llmClient, asterOpts...)
+				commonOpts := buildChatUseCaseOpts(repo, policyClient, slackSvc, noAuthorization, webUICfg.GetFrontendURL())
+				ucOptions = append(ucOptions, usecase.WithChatUseCase(chatuc.NewUseCase(asterStrategy, commonOpts...)))
 				logging.From(ctx).Info("Chat strategy: aster")
 
 			case "bluebell":
@@ -468,16 +467,12 @@ func cmdServe() *cli.Command {
 				bluebellOpts := []bluebell.Option{
 					bluebell.WithTools(allTools),
 					bluebell.WithStorageClient(storageClient),
-					bluebell.WithNoAuthorization(noAuthorization),
 					bluebell.WithUserSystemPrompt(userSystemPrompt),
 					bluebell.WithKnowledgeService(knowledgeSvc),
 					bluebell.WithPromptEntries(promptEntries),
 				}
 				if slackSvc != nil {
 					bluebellOpts = append(bluebellOpts, bluebell.WithSlackService(slackSvc))
-				}
-				if webUICfg.GetFrontendURL() != "" {
-					bluebellOpts = append(bluebellOpts, bluebell.WithFrontendURL(webUICfg.GetFrontendURL()))
 				}
 				if storageCfg.IsConfigured() && storageCfg.Prefix() != "" {
 					bluebellOpts = append(bluebellOpts, bluebell.WithStoragePrefix(storageCfg.Prefix()))
@@ -498,11 +493,12 @@ func cmdServe() *cli.Command {
 
 				bluebellOpts = append(bluebellOpts, bluebell.WithHITLTools([]string{"web_fetch"}))
 
-				bluebellChat, err := bluebell.New(repo, llmClient, policyClient, bluebellOpts...)
+				bluebellStrategy, err := bluebell.New(repo, llmClient, bluebellOpts...)
 				if err != nil {
 					return goerr.Wrap(err, "failed to create bluebell chat strategy")
 				}
-				ucOptions = append(ucOptions, usecase.WithChatUseCase(bluebellChat))
+				commonOpts := buildChatUseCaseOpts(repo, policyClient, slackSvc, noAuthorization, webUICfg.GetFrontendURL())
+				ucOptions = append(ucOptions, usecase.WithChatUseCase(chatuc.NewUseCase(bluebellStrategy, commonOpts...)))
 				logging.From(ctx).Info("Chat strategy: bluebell",
 					"prompt_entries", len(promptEntries))
 
@@ -635,4 +631,20 @@ func cmdServe() *cli.Command {
 			}
 		},
 	}
+}
+
+// buildChatUseCaseOpts constructs the common options for chat.UseCase.
+func buildChatUseCaseOpts(repo interfaces.Repository, policyClient interfaces.PolicyClient, slackSvc *slackService.Service, noAuthz bool, frontendURL string) []chatuc.Option {
+	opts := []chatuc.Option{
+		chatuc.WithRepository(repo),
+		chatuc.WithPolicyClient(policyClient),
+		chatuc.WithNoAuthorization(noAuthz),
+	}
+	if slackSvc != nil {
+		opts = append(opts, chatuc.WithSlackService(slackSvc))
+	}
+	if frontendURL != "" {
+		opts = append(opts, chatuc.WithFrontendURL(frontendURL))
+	}
+	return opts
 }

--- a/pkg/usecase/chat/aster/aster.go
+++ b/pkg/usecase/chat/aster/aster.go
@@ -2,9 +2,7 @@ package aster
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"math/rand/v2"
 	"strings"
 	"time"
 
@@ -27,25 +25,20 @@ import (
 	"github.com/secmon-lab/warren/pkg/utils/logging"
 	"github.com/secmon-lab/warren/pkg/utils/msg"
 	"github.com/secmon-lab/warren/pkg/utils/request_id"
-	ssnutil "github.com/secmon-lab/warren/pkg/utils/session"
-	"github.com/secmon-lab/warren/pkg/utils/slackctx"
 	"github.com/secmon-lab/warren/pkg/utils/user"
 )
 
 const defaultMaxPhases = 10
 
-// AsterChat implements interfaces.ChatUseCase with parallel task execution.
+// AsterChat implements chat.Strategy with parallel task execution.
 type AsterChat struct {
 	repository          interfaces.Repository
 	llmClient           gollem.LLMClient
-	policyClient        interfaces.PolicyClient
 	storageClient       interfaces.StorageClient
 	slackService        *slackService.Service
 	knowledgeService    *svcknowledge.Service
 	tools               []interfaces.ToolSet
 	storagePrefix       string
-	noAuthorization     bool
-	frontendURL         string
 	userSystemPrompt    string
 	traceRepository     trace.Repository
 	maxPhases           int
@@ -75,16 +68,6 @@ func WithStorageClient(client interfaces.StorageClient) Option {
 // WithStoragePrefix sets the storage prefix for history paths.
 func WithStoragePrefix(prefix string) Option {
 	return func(c *AsterChat) { c.storagePrefix = prefix }
-}
-
-// WithNoAuthorization disables policy-based authorization checks.
-func WithNoAuthorization(noAuthz bool) Option {
-	return func(c *AsterChat) { c.noAuthorization = noAuthz }
-}
-
-// WithFrontendURL sets the frontend URL for session links.
-func WithFrontendURL(url string) Option {
-	return func(c *AsterChat) { c.frontendURL = url }
 }
 
 // WithUserSystemPrompt sets the user system prompt.
@@ -124,11 +107,10 @@ func WithHITLTools(tools []string) Option {
 }
 
 // New creates a new AsterChat with the given dependencies and options.
-func New(repo interfaces.Repository, llmClient gollem.LLMClient, policyClient interfaces.PolicyClient, opts ...Option) *AsterChat {
+func New(repo interfaces.Repository, llmClient gollem.LLMClient, opts ...Option) *AsterChat {
 	c := &AsterChat{
 		repository:          repo,
 		llmClient:           llmClient,
-		policyClient:        policyClient,
 		maxPhases:           defaultMaxPhases,
 		monitorPollInterval: 10 * time.Second,
 	}
@@ -139,56 +121,14 @@ func New(repo interfaces.Repository, llmClient gollem.LLMClient, policyClient in
 	return c
 }
 
-// Execute processes a chat message using parallel task execution.
-// The ChatContext must be pre-built by the caller with all necessary data.
-func (c *AsterChat) Execute(ctx context.Context, message string, chatCtx chatModel.ChatContext) error {
-	target := chatCtx.Ticket
-	logger := logging.From(ctx)
-	logger.Debug("aster execute: start",
-		"ticket_id", target.ID,
-		"request_id", request_id.FromContext(ctx),
-	)
-
-	// Phase 1: Session setup
-	ssn, ctx := c.createSession(ctx, target, message)
-	logger = logging.From(ctx) // refresh logger with session_id
-	logger.Debug("aster execute: session created", "session_id", ssn.ID)
-
-	// Phase 2: Message routing setup
-	ctx = c.setupMessageRouting(ctx, ssn, target)
-	logger.Debug("aster execute: message routing set up")
-
-	// Phase 3: Session status tracking
-	ctx = c.setupStatusCheck(ctx, ssn)
-
-	finalStatus := types.SessionStatusCompleted
-	defer c.finishSession(ctx, ssn, target, &finalStatus)
-
-	// Phase 4: Authorization
-	authorized, err := c.authorize(ctx, message)
-	if err != nil {
-		return err
-	}
-	if !authorized {
-		logger.Debug("aster execute: not authorized, returning")
-		return nil
-	}
-	logger.Debug("aster execute: authorized, starting execution")
-
-	// Phase 5: Main execution
-	if err := c.executeAster(ctx, ssn, message, &finalStatus, &chatCtx); err != nil {
-		// Session abort and context cancellation are expected outcomes
-		// when a user aborts the session, not errors to report.
-		if errors.Is(err, ErrSessionAborted) || errors.Is(err, context.Canceled) {
-			return nil
-		}
-		return err
-	}
-	return nil
+// Execute implements chat.Strategy. It receives a RunContext with a pre-initialized
+// Warren session and delegates to the aster execution loop.
+func (c *AsterChat) Execute(ctx context.Context, rc *chat.RunContext) error {
+	return c.executeAster(ctx, rc.Session, rc.Message, rc.ChatCtx)
 }
 
-// executeAster orchestrates the amber execution: plan → parallel exec → replan → loop → final response.
-func (c *AsterChat) executeAster(ctx context.Context, ssn *session.Session, message string, finalStatus *types.SessionStatus, chatCtx *chatModel.ChatContext) error {
+// executeAster orchestrates the aster execution: plan → parallel exec → replan → loop → final response.
+func (c *AsterChat) executeAster(ctx context.Context, ssn *session.Session, message string, chatCtx *chatModel.ChatContext) error {
 	target := chatCtx.Ticket
 	ticketless := chatCtx.IsTicketless()
 	logger := logging.From(ctx)
@@ -293,10 +233,9 @@ func (c *AsterChat) executeAster(ctx context.Context, ssn *session.Session, mess
 	// Planning phase
 	planResult, err := c.plan(ctx, planSession, planCtx, systemPrompt)
 	if err != nil {
-		if abortErr := checkAborted(ctx, cleanupCtx, finalStatus); abortErr != nil {
+		if abortErr := checkAborted(ctx, cleanupCtx); abortErr != nil {
 			return abortErr
 		}
-		*finalStatus = types.SessionStatusAborted
 		msg.Notify(ctx, "💥 Planning failed: %s", err.Error())
 		return goerr.Wrap(err, "planning failed")
 	}
@@ -375,7 +314,7 @@ func (c *AsterChat) executeAster(ctx context.Context, ssn *session.Session, mess
 		})
 
 		// Check for context cancellation (abort detected by monitor)
-		if abortErr := checkAborted(ctx, cleanupCtx, finalStatus); abortErr != nil {
+		if abortErr := checkAborted(ctx, cleanupCtx); abortErr != nil {
 			if !ticketless {
 				c.saveLatestHistory(cleanupCtx, planSession, target.ID, storageSvc)
 			}
@@ -388,7 +327,7 @@ func (c *AsterChat) executeAster(ctx context.Context, ssn *session.Session, mess
 			if !ticketless {
 				c.saveLatestHistory(cleanupCtx, planSession, target.ID, storageSvc)
 			}
-			if abortErr := checkAborted(ctx, cleanupCtx, finalStatus); abortErr != nil {
+			if abortErr := checkAborted(ctx, cleanupCtx); abortErr != nil {
 				return abortErr
 			}
 			logger.Error("replan failed", "error", err, "phase", phase)
@@ -439,10 +378,9 @@ func (c *AsterChat) executeAster(ctx context.Context, ssn *session.Session, mess
 		if !ticketless {
 			c.saveLatestHistory(cleanupCtx, planSession, target.ID, storageSvc)
 		}
-		if abortErr := checkAborted(ctx, cleanupCtx, finalStatus); abortErr != nil {
+		if abortErr := checkAborted(ctx, cleanupCtx); abortErr != nil {
 			return abortErr
 		}
-		*finalStatus = types.SessionStatusAborted
 		msg.Notify(ctx, "💥 Failed to generate final response: %s", err.Error())
 		return goerr.Wrap(err, "failed to generate final response")
 	}
@@ -549,163 +487,6 @@ func (c *AsterChat) handleQuestion(ctx context.Context, q *Question, target *tic
 	}, nil
 }
 
-// createSession creates and persists a new chat session.
-func (c *AsterChat) createSession(ctx context.Context, target *ticket.Ticket, message string) (*session.Session, context.Context) {
-	userID := types.UserID(user.FromContext(ctx))
-	slackURL := slackctx.SlackURL(ctx)
-
-	ssn := session.NewSession(ctx, target.ID, userID, message, slackURL)
-	if err := c.repository.PutSession(ctx, ssn); err != nil {
-		logging.From(ctx).Error("failed to save session", "error", err)
-	}
-
-	logger := logging.From(ctx).With("session_id", ssn.ID, "request_id", request_id.FromContext(ctx))
-	ctx = logging.With(ctx, logger)
-
-	if target.SlackThread != nil {
-		ctx = slackctx.WithThread(ctx, *target.SlackThread)
-	}
-
-	return ssn, ctx
-}
-
-// setupMessageRouting configures Slack/CLI message routing functions in the context.
-func (c *AsterChat) setupMessageRouting(ctx context.Context, ssn *session.Session, target *ticket.Ticket) context.Context {
-	if c.slackService != nil && target.SlackThread != nil {
-		notifyFunc, traceFunc, warnFunc := c.setupSlackMessageFuncs(ctx, ssn, target)
-		ctx = msg.With(ctx, notifyFunc, traceFunc, warnFunc)
-
-		// Post request ID as a context block immediately
-		requestID := request_id.FromContext(ctx)
-		if requestID == "" {
-			requestID = "unknown"
-		}
-		verbs := []string{
-			"Investigating", "Analyzing", "Processing", "Inspecting",
-			"Examining", "Scanning", "Assessing", "Evaluating",
-			"Reviewing", "Probing", "Surveying", "Diagnosing",
-			"Exploring", "Scrutinizing", "Correlating", "Parsing",
-			"Decoding", "Interpreting", "Triaging", "Resolving",
-		}
-		verb := verbs[rand.IntN(len(verbs))] // #nosec G404 -- not security-sensitive, just picking a random UI verb
-		threadSvc := c.slackService.NewThread(*target.SlackThread)
-		if err := threadSvc.PostContextBlock(ctx, fmt.Sprintf("%s ... (ID: `%s`)", verb, requestID)); err != nil {
-			logging.From(ctx).Error("failed to post request ID", "error", err)
-		}
-	}
-
-	return ctx
-}
-
-// setupSlackMessageFuncs creates Slack message routing functions for notify, trace, and warn.
-func (c *AsterChat) setupSlackMessageFuncs(ctx context.Context, sess *session.Session, target *ticket.Ticket) (msg.NotifyFunc, msg.TraceFunc, msg.WarnFunc) {
-	threadSvc := c.slackService.NewThread(*target.SlackThread)
-
-	notifyFunc := func(ctx context.Context, message string) {
-		m := session.NewMessage(ctx, sess.ID, session.MessageTypeResponse, message)
-		if err := c.repository.PutSessionMessage(ctx, m); err != nil {
-			errutil.Handle(ctx, err)
-		}
-		if err := threadSvc.PostComment(ctx, message); err != nil {
-			errutil.Handle(ctx, err)
-		}
-	}
-
-	var traceUpdateFunc func(context.Context, string)
-	traceFunc := func(ctx context.Context, message string) {
-		m := session.NewMessage(ctx, sess.ID, session.MessageTypeTrace, message)
-		if err := c.repository.PutSessionMessage(ctx, m); err != nil {
-			errutil.Handle(ctx, err)
-		}
-
-		if traceUpdateFunc == nil {
-			traceUpdateFunc = threadSvc.NewUpdatableMessage(ctx, message)
-		} else {
-			traceUpdateFunc(ctx, message)
-		}
-	}
-
-	warnFunc := func(ctx context.Context, message string) {
-		m := session.NewMessage(ctx, sess.ID, session.MessageTypeWarning, message)
-		if err := c.repository.PutSessionMessage(ctx, m); err != nil {
-			errutil.Handle(ctx, err)
-		}
-		if err := threadSvc.PostComment(ctx, message); err != nil {
-			errutil.Handle(ctx, err)
-		}
-	}
-
-	return notifyFunc, traceFunc, warnFunc
-}
-
-// setupStatusCheck embeds a session abort check function in the context.
-func (c *AsterChat) setupStatusCheck(ctx context.Context, ssn *session.Session) context.Context {
-	statusCheckFunc := func(ctx context.Context) error {
-		s, err := c.repository.GetSession(ctx, ssn.ID)
-		if err != nil {
-			return goerr.Wrap(err, "failed to get session status")
-		}
-		if s != nil && s.Status == types.SessionStatusAborted {
-			return ErrSessionAborted
-		}
-		return nil
-	}
-	return ssnutil.WithStatusCheck(ctx, statusCheckFunc)
-}
-
-// finishSession updates session status and posts session actions on completion.
-func (c *AsterChat) finishSession(ctx context.Context, ssn *session.Session, target *ticket.Ticket, finalStatus *types.SessionStatus) {
-	logger := logging.From(ctx)
-	if r := recover(); r != nil {
-		*finalStatus = types.SessionStatusAborted
-		ssn.UpdateStatus(ctx, *finalStatus)
-		if err := c.repository.PutSession(ctx, ssn); err != nil {
-			logger.Error("failed to update session status on panic", "error", err, "status", *finalStatus)
-		}
-		panic(r)
-	}
-
-	ssn.UpdateStatus(ctx, *finalStatus)
-	if err := c.repository.PutSession(ctx, ssn); err != nil {
-		logger.Error("failed to update final session status", "error", err, "status", *finalStatus)
-	}
-
-	// Skip session actions for ticketless chat (no ticket to act on)
-	if target.ID != "" && *finalStatus == types.SessionStatusCompleted && c.slackService != nil && target.SlackThread != nil {
-		threadSvc := c.slackService.NewThread(*target.SlackThread)
-
-		var sessionURL string
-		if c.frontendURL != "" {
-			sessionURL = fmt.Sprintf("%s/sessions/%s", c.frontendURL, ssn.ID)
-		}
-
-		currentTicket, err := c.repository.GetTicket(ctx, target.ID)
-		if err != nil {
-			logger.Error("failed to get ticket for session actions", "error", err, "ticket_id", target.ID)
-		} else if currentTicket != nil {
-			if err := threadSvc.PostSessionActions(ctx, target.ID, currentTicket.Status, sessionURL); err != nil {
-				logger.Error("failed to post session actions to Slack", "error", err, "session_id", ssn.ID)
-			}
-		}
-	}
-}
-
-// authorize checks policy-based authorization for agent execution.
-func (c *AsterChat) authorize(ctx context.Context, message string) (bool, error) {
-	if err := chat.AuthorizeAgentRequest(ctx, c.policyClient, c.noAuthorization, message); err != nil {
-		if errors.Is(err, chat.ErrAgentAuthPolicyNotDefined) {
-			msg.Notify(ctx, "🚫 *Authorization Failed*\n\nAgent execution policy is not defined. Please configure the `auth.agent` policy or use `--no-authorization` flag for development.\n\nSee: https://docs.warren.secmon-lab.com/policy.md#agent-execution-authorization")
-		} else if errors.Is(err, chat.ErrAgentAuthDenied) {
-			msg.Notify(ctx, "🚫 *Authorization Failed*\n\nYou are not authorized to execute agent requests. Please contact your administrator if you believe this is an error.")
-		} else {
-			msg.Notify(ctx, "🚫 *Authorization Failed*\n\nFailed to check authorization. Please contact your administrator.")
-			return false, goerr.Wrap(err, "failed to evaluate agent auth")
-		}
-		return false, nil
-	}
-	return true, nil
-}
-
 // saveLatestHistory saves the current planning session history as the latest snapshot.
 // Errors are handled via errutil but do not interrupt execution.
 func (c *AsterChat) saveLatestHistory(ctx context.Context, planSession gollem.Session, ticketID types.TicketID, storageSvc *storage.Service) {
@@ -732,13 +513,12 @@ func (c *AsterChat) saveSessionHistory(ctx context.Context, planSession gollem.S
 }
 
 // checkAborted checks if the context has been cancelled (e.g. by the session
-// monitor detecting an abort) and, if so, sets finalStatus and notifies via
-// cleanupCtx. Returns ErrSessionAborted when aborted, nil otherwise.
-func checkAborted(ctx context.Context, cleanupCtx context.Context, finalStatus *types.SessionStatus) error {
+// monitor detecting an abort) and, if so, notifies via cleanupCtx.
+// Returns chat.ErrSessionAborted when aborted, nil otherwise.
+func checkAborted(ctx context.Context, cleanupCtx context.Context) error {
 	if ctx.Err() != nil {
-		*finalStatus = types.SessionStatusAborted
 		msg.Notify(cleanupCtx, "🛑 Execution aborted by user request.")
-		return ErrSessionAborted
+		return chat.ErrSessionAborted
 	}
 	return nil
 }

--- a/pkg/usecase/chat/aster/aster_test.go
+++ b/pkg/usecase/chat/aster/aster_test.go
@@ -2,7 +2,6 @@ package aster_test
 
 import (
 	"context"
-	"encoding/json"
 	"strings"
 	"sync"
 	"testing"
@@ -11,7 +10,6 @@ import (
 	"github.com/m-mizutani/goerr/v2"
 	"github.com/m-mizutani/gollem"
 	"github.com/m-mizutani/gt"
-	"github.com/m-mizutani/opaq"
 	adapter "github.com/secmon-lab/warren/pkg/adapter/storage"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	"github.com/secmon-lab/warren/pkg/domain/mock"
@@ -22,21 +20,16 @@ import (
 	"github.com/secmon-lab/warren/pkg/domain/types"
 	"github.com/secmon-lab/warren/pkg/repository"
 	storage_svc "github.com/secmon-lab/warren/pkg/service/storage"
+	"github.com/secmon-lab/warren/pkg/usecase/chat"
 	"github.com/secmon-lab/warren/pkg/usecase/chat/aster"
 	"github.com/secmon-lab/warren/pkg/utils/msg"
 )
 
-func newMockPolicyClient(t *testing.T) *mock.PolicyClientMock {
-	return &mock.PolicyClientMock{
-		QueryFunc: func(ctx context.Context, query string, input, result any, opts ...opaq.QueryOption) error {
-			if query == "data.auth.agent" {
-				gt.NoError(t, json.Unmarshal([]byte(`{"allow":true}`), &result))
-			}
-			return nil
-		},
-		SourcesFunc: func() map[string]string {
-			return map[string]string{}
-		},
+func newDummySession(ticketID types.TicketID) *session.Session {
+	return &session.Session{
+		ID:       types.NewSessionID(),
+		TicketID: ticketID,
+		Status:   types.SessionStatusRunning,
 	}
 }
 
@@ -97,11 +90,10 @@ func TestAsterChat_DirectResponse(t *testing.T) {
 		},
 	}
 
-	chatUC := aster.New(repo, mockLLM, newMockPolicyClient(t),
-		aster.WithNoAuthorization(true),
-	)
+	chatUC := aster.New(repo, mockLLM)
+	ssn := newDummySession(testTicket.ID)
 
-	err := chatUC.Execute(ctx, "What is the meaning of life?", chatModel.ChatContext{Ticket: testTicket})
+	err := chatUC.Execute(ctx, &chat.RunContext{Session: ssn, Message: "What is the meaning of life?", ChatCtx: &chatModel.ChatContext{Ticket: testTicket}})
 	gt.NoError(t, err)
 }
 
@@ -156,11 +148,10 @@ func TestAsterChat_SinglePhaseWithTasks(t *testing.T) {
 		},
 	}
 
-	chatUC := aster.New(repo, mockLLM, newMockPolicyClient(t),
-		aster.WithNoAuthorization(true),
-	)
+	chatUC := aster.New(repo, mockLLM)
+	ssn := newDummySession(testTicket.ID)
 
-	err := chatUC.Execute(ctx, "Analyze this alert", chatModel.ChatContext{Ticket: testTicket})
+	err := chatUC.Execute(ctx, &chat.RunContext{Session: ssn, Message: "Analyze this alert", ChatCtx: &chatModel.ChatContext{Ticket: testTicket}})
 	gt.NoError(t, err)
 }
 
@@ -197,12 +188,12 @@ func TestAsterChat_MaxPhasesLimit(t *testing.T) {
 		},
 	}
 
-	chatUC := aster.New(repo, mockLLM, newMockPolicyClient(t),
-		aster.WithNoAuthorization(true),
+	chatUC := aster.New(repo, mockLLM,
 		aster.WithMaxPhases(2),
 	)
+	ssn := newDummySession(testTicket.ID)
 
-	err := chatUC.Execute(ctx, "Do something", chatModel.ChatContext{Ticket: testTicket})
+	err := chatUC.Execute(ctx, &chat.RunContext{Session: ssn, Message: "Do something", ChatCtx: &chatModel.ChatContext{Ticket: testTicket}})
 	gt.NoError(t, err)
 }
 
@@ -253,11 +244,10 @@ func TestAsterChat_ParallelExecution(t *testing.T) {
 		},
 	}
 
-	chatUC := aster.New(repo, mockLLM, newMockPolicyClient(t),
-		aster.WithNoAuthorization(true),
-	)
+	chatUC := aster.New(repo, mockLLM)
+	ssn := newDummySession(testTicket.ID)
 
-	err := chatUC.Execute(ctx, "Analyze all indicators", chatModel.ChatContext{Ticket: testTicket})
+	err := chatUC.Execute(ctx, &chat.RunContext{Session: ssn, Message: "Analyze all indicators", ChatCtx: &chatModel.ChatContext{Ticket: testTicket}})
 	gt.NoError(t, err)
 }
 
@@ -314,12 +304,11 @@ func TestAsterChat_ErrorIsolation(t *testing.T) {
 		},
 	}
 
-	chatUC := aster.New(repo, mockLLM, newMockPolicyClient(t),
-		aster.WithNoAuthorization(true),
-	)
+	chatUC := aster.New(repo, mockLLM)
+	ssn := newDummySession(testTicket.ID)
 
 	// Execute should complete without error even though one task failed
-	err := chatUC.Execute(ctx, "Test error isolation", chatModel.ChatContext{Ticket: testTicket})
+	err := chatUC.Execute(ctx, &chat.RunContext{Session: ssn, Message: "Test error isolation", ChatCtx: &chatModel.ChatContext{Ticket: testTicket}})
 	gt.NoError(t, err)
 }
 
@@ -418,41 +407,10 @@ func TestAsterChat_MultiPhaseReplan(t *testing.T) {
 		},
 	}
 
-	chatUC := aster.New(repo, mockLLM, newMockPolicyClient(t),
-		aster.WithNoAuthorization(true),
-	)
+	chatUC := aster.New(repo, mockLLM)
+	ssn := newDummySession(testTicket.ID)
 
-	err := chatUC.Execute(ctx, "Run multi-phase analysis", chatModel.ChatContext{Ticket: testTicket})
-	gt.NoError(t, err)
-}
-
-func TestAsterChat_AuthorizationDenied(t *testing.T) {
-	ctx := setupTestContext(t)
-	repo := repository.NewMemory()
-	testTicket := setupTicketAndAlert(t, ctx, repo)
-
-	denyPolicy := &mock.PolicyClientMock{
-		QueryFunc: func(ctx context.Context, query string, input, result any, opts ...opaq.QueryOption) error {
-			if query == "data.auth.agent" {
-				gt.NoError(t, json.Unmarshal([]byte(`{"allow":false}`), &result))
-			}
-			return nil
-		},
-		SourcesFunc: func() map[string]string {
-			return map[string]string{}
-		},
-	}
-
-	mockLLM := &mock.LLMClientMock{
-		NewSessionFunc: func(ctx context.Context, opts ...gollem.SessionOption) (gollem.Session, error) {
-			t.Fatal("LLM should not be called when authorization is denied")
-			return nil, nil
-		},
-	}
-
-	chatUC := aster.New(repo, mockLLM, denyPolicy)
-
-	err := chatUC.Execute(ctx, "Analyze this", chatModel.ChatContext{Ticket: testTicket})
+	err := chatUC.Execute(ctx, &chat.RunContext{Session: ssn, Message: "Run multi-phase analysis", ChatCtx: &chatModel.ChatContext{Ticket: testTicket}})
 	gt.NoError(t, err)
 }
 
@@ -503,7 +461,7 @@ func TestStartSessionMonitor_AbortDetection(t *testing.T) {
 	}
 	gt.NoError(t, repo.PutSession(ctx, ssn))
 
-	chatUC := aster.New(repo, nil, nil,
+	chatUC := aster.New(repo, nil,
 		aster.WithMonitorPollInterval(10*time.Millisecond),
 	)
 
@@ -539,7 +497,7 @@ func TestStartSessionMonitor_NormalCompletion(t *testing.T) {
 	}
 	gt.NoError(t, repo.PutSession(ctx, ssn))
 
-	chatUC := aster.New(repo, nil, nil)
+	chatUC := aster.New(repo, nil)
 
 	monitorCtx, stop := chatUC.StartSessionMonitor(ctx, ssn.ID)
 
@@ -558,7 +516,7 @@ func TestStartSessionMonitor_DBErrorContinuesMonitoring(t *testing.T) {
 	// This simulates a DB error scenario where session is not found
 	nonExistentID := types.NewSessionID()
 
-	chatUC := aster.New(repo, nil, nil)
+	chatUC := aster.New(repo, nil)
 
 	monitorCtx, stop := chatUC.StartSessionMonitor(ctx, nonExistentID)
 	defer stop()
@@ -588,12 +546,12 @@ func TestAsterChat_LatestHistorySavedOnDirectResponse(t *testing.T) {
 		},
 	}
 
-	chatUC := aster.New(repo, mockLLM, newMockPolicyClient(t),
-		aster.WithNoAuthorization(true),
+	chatUC := aster.New(repo, mockLLM,
 		aster.WithStorageClient(mockStorage),
 	)
+	ssn := newDummySession(testTicket.ID)
 
-	gt.NoError(t, chatUC.Execute(ctx, "Hello", chatModel.ChatContext{Ticket: testTicket}))
+	gt.NoError(t, chatUC.Execute(ctx, &chat.RunContext{Session: ssn, Message: "Hello", ChatCtx: &chatModel.ChatContext{Ticket: testTicket}}))
 
 	// Verify latest.json was saved
 	storageSvc := storage_svc.New(mockStorage)
@@ -644,12 +602,12 @@ func TestAsterChat_LatestHistorySavedAfterReplan(t *testing.T) {
 		},
 	}
 
-	chatUC := aster.New(repo, mockLLM, newMockPolicyClient(t),
-		aster.WithNoAuthorization(true),
+	chatUC := aster.New(repo, mockLLM,
 		aster.WithStorageClient(mockStorage),
 	)
+	ssn := newDummySession(testTicket.ID)
 
-	gt.NoError(t, chatUC.Execute(ctx, "Analyze", chatModel.ChatContext{Ticket: testTicket}))
+	gt.NoError(t, chatUC.Execute(ctx, &chat.RunContext{Session: ssn, Message: "Analyze", ChatCtx: &chatModel.ChatContext{Ticket: testTicket}}))
 
 	// Verify latest.json was saved (saved after plan, replan, and final response)
 	storageSvc := storage_svc.New(mockStorage)
@@ -697,15 +655,15 @@ func TestAsterChat_LatestHistorySavedOnAbort(t *testing.T) {
 		},
 	}
 
-	chatUC := aster.New(repo, mockLLM, newMockPolicyClient(t),
-		aster.WithNoAuthorization(true),
+	chatUC := aster.New(repo, mockLLM,
 		aster.WithStorageClient(mockStorage),
 		aster.WithMonitorPollInterval(10*time.Millisecond),
 	)
+	ssn := newDummySession(testTicket.ID)
 
 	// Execute — plan succeeds and latest is saved,
 	// but replan may fail or be aborted
-	_ = chatUC.Execute(ctx, "Slow analysis", chatModel.ChatContext{Ticket: testTicket})
+	_ = chatUC.Execute(ctx, &chat.RunContext{Session: ssn, Message: "Slow analysis", ChatCtx: &chatModel.ChatContext{Ticket: testTicket}})
 
 	// Verify latest.json was saved at least after the planning phase
 	storageSvc := storage_svc.New(mockStorage)
@@ -760,13 +718,13 @@ func TestAsterChat_LatestHistorySavedOnReplanError(t *testing.T) {
 		},
 	}
 
-	chatUC := aster.New(repo, mockLLM, newMockPolicyClient(t),
-		aster.WithNoAuthorization(true),
+	chatUC := aster.New(repo, mockLLM,
 		aster.WithStorageClient(mockStorage),
 	)
+	ssn := newDummySession(testTicket.ID)
 
 	// Execute completes (replan error is logged, proceeds to final response)
-	_ = chatUC.Execute(ctx, "Test replan error", chatModel.ChatContext{Ticket: testTicket})
+	_ = chatUC.Execute(ctx, &chat.RunContext{Session: ssn, Message: "Test replan error", ChatCtx: &chatModel.ChatContext{Ticket: testTicket}})
 
 	// Verify latest.json was saved at least after the planning phase
 	storageSvc := storage_svc.New(mockStorage)
@@ -886,14 +844,14 @@ func TestAsterChat_BudgetMiddlewareNotAccumulated(t *testing.T) {
 		},
 	}
 
-	chatUC := aster.New(repo, mockLLM, newMockPolicyClient(t),
-		aster.WithNoAuthorization(true),
+	chatUC := aster.New(repo, mockLLM,
 		aster.WithMaxPhases(3),
 		aster.WithBudgetStrategy(budgetStrategy),
 		aster.WithTools([]interfaces.ToolSet{testToolSet}),
 	)
+	ssn := newDummySession(testTicket.ID)
 
-	err := chatUC.Execute(ctx, "Analyze with budget", chatModel.ChatContext{Ticket: testTicket})
+	err := chatUC.Execute(ctx, &chat.RunContext{Session: ssn, Message: "Analyze with budget", ChatCtx: &chatModel.ChatContext{Ticket: testTicket}})
 	gt.NoError(t, err)
 
 	mu.Lock()

--- a/pkg/usecase/chat/aster/errors.go
+++ b/pkg/usecase/chat/aster/errors.go
@@ -1,10 +1,8 @@
 package aster
 
 import (
-	"github.com/m-mizutani/goerr/v2"
+	"github.com/secmon-lab/warren/pkg/usecase/chat"
 )
 
-var (
-	// ErrSessionAborted is returned when a session is aborted by user request
-	ErrSessionAborted = goerr.New("session aborted by user")
-)
+// ErrSessionAborted is an alias for chat.ErrSessionAborted for backward compatibility.
+var ErrSessionAborted = chat.ErrSessionAborted

--- a/pkg/usecase/chat/aster/plan_test.go
+++ b/pkg/usecase/chat/aster/plan_test.go
@@ -11,6 +11,7 @@ import (
 	chatModel "github.com/secmon-lab/warren/pkg/domain/model/chat"
 	"github.com/secmon-lab/warren/pkg/repository"
 	svcknowledge "github.com/secmon-lab/warren/pkg/service/knowledge"
+	"github.com/secmon-lab/warren/pkg/usecase/chat"
 	"github.com/secmon-lab/warren/pkg/usecase/chat/aster"
 )
 
@@ -63,12 +64,12 @@ func TestAsterChat_PlanWithKnowledgeService(t *testing.T) {
 		},
 	}
 
-	chatUC := aster.New(repo, mockLLM, newMockPolicyClient(t),
+	chatUC := aster.New(repo, mockLLM,
 		aster.WithKnowledgeService(knowledgeSvc),
-		aster.WithNoAuthorization(true),
 	)
+	ssn := newDummySession(testTicket.ID)
 
-	err := chatUC.Execute(ctx, "Analyze this alert", chatModel.ChatContext{Ticket: testTicket})
+	err := chatUC.Execute(ctx, &chat.RunContext{Session: ssn, Message: "Analyze this alert", ChatCtx: &chatModel.ChatContext{Ticket: testTicket}})
 	gt.NoError(t, err)
 
 	// Verify that multiple sessions were created (planSession + agent's internal session)
@@ -104,11 +105,10 @@ func TestAsterChat_PlanWithoutKnowledgeService(t *testing.T) {
 		},
 	}
 
-	chatUC := aster.New(repo, mockLLM, newMockPolicyClient(t),
-		aster.WithNoAuthorization(true),
-	)
+	chatUC := aster.New(repo, mockLLM)
+	ssn := newDummySession(testTicket.ID)
 
-	err := chatUC.Execute(ctx, "Analyze this alert", chatModel.ChatContext{Ticket: testTicket})
+	err := chatUC.Execute(ctx, &chat.RunContext{Session: ssn, Message: "Analyze this alert", ChatCtx: &chatModel.ChatContext{Ticket: testTicket}})
 	gt.NoError(t, err)
 
 	// Without knowledge service, only one session should be created (planSession).

--- a/pkg/usecase/chat/behavior_test.go
+++ b/pkg/usecase/chat/behavior_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/secmon-lab/warren/pkg/domain/types"
 	"github.com/secmon-lab/warren/pkg/repository"
 	svcknowledge "github.com/secmon-lab/warren/pkg/service/knowledge"
+	chatuc "github.com/secmon-lab/warren/pkg/usecase/chat"
 	"github.com/secmon-lab/warren/pkg/usecase/chat/aster"
 	"github.com/secmon-lab/warren/pkg/usecase/chat/bluebell"
 	"github.com/secmon-lab/warren/pkg/utils/msg"
@@ -131,47 +132,42 @@ type chatUCFactory struct {
 	knowledgeSvc *svcknowledge.Service
 }
 
-func (f *chatUCFactory) build(t *testing.T, strategy string) interfaces.ChatUseCase {
+func (f *chatUCFactory) buildStrategy(t *testing.T, strategy string) chatuc.Strategy {
 	t.Helper()
 	switch strategy {
 	case "aster":
-		opts := []aster.Option{aster.WithNoAuthorization(false)}
-		return aster.New(f.repo, f.llm, f.policy, opts...)
+		return aster.New(f.repo, f.llm)
 	case "bluebell":
 		if f.knowledgeSvc == nil {
 			f.knowledgeSvc = svcknowledge.New(f.repo, newMockEmbeddingClient())
 		}
-		uc, err := bluebell.New(f.repo, f.llm, f.policy,
-			bluebell.WithNoAuthorization(false),
+		s, err := bluebell.New(f.repo, f.llm,
 			bluebell.WithKnowledgeService(f.knowledgeSvc),
 		)
 		gt.NoError(t, err)
-		return uc
+		return s
 	default:
 		t.Fatalf("unknown strategy: %s", strategy)
 		return nil
 	}
 }
 
+func (f *chatUCFactory) build(t *testing.T, strategy string) interfaces.ChatUseCase {
+	t.Helper()
+	return chatuc.NewUseCase(f.buildStrategy(t, strategy),
+		chatuc.WithRepository(f.repo),
+		chatuc.WithPolicyClient(f.policy),
+		chatuc.WithNoAuthorization(false),
+	)
+}
+
 func (f *chatUCFactory) buildNoAuthz(t *testing.T, strategy string) interfaces.ChatUseCase {
 	t.Helper()
-	switch strategy {
-	case "aster":
-		return aster.New(f.repo, f.llm, f.policy, aster.WithNoAuthorization(true))
-	case "bluebell":
-		if f.knowledgeSvc == nil {
-			f.knowledgeSvc = svcknowledge.New(f.repo, newMockEmbeddingClient())
-		}
-		uc, err := bluebell.New(f.repo, f.llm, f.policy,
-			bluebell.WithNoAuthorization(true),
-			bluebell.WithKnowledgeService(f.knowledgeSvc),
-		)
-		gt.NoError(t, err)
-		return uc
-	default:
-		t.Fatalf("unknown strategy: %s", strategy)
-		return nil
-	}
+	return chatuc.NewUseCase(f.buildStrategy(t, strategy),
+		chatuc.WithRepository(f.repo),
+		chatuc.WithPolicyClient(f.policy),
+		chatuc.WithNoAuthorization(true),
+	)
 }
 
 // --- characterization tests ---

--- a/pkg/usecase/chat/behavior_test.go
+++ b/pkg/usecase/chat/behavior_test.go
@@ -1,0 +1,439 @@
+package chat_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/m-mizutani/gollem"
+	"github.com/m-mizutani/gt"
+	"github.com/m-mizutani/opaq"
+	"github.com/secmon-lab/warren/pkg/domain/interfaces"
+	"github.com/secmon-lab/warren/pkg/domain/mock"
+	"github.com/secmon-lab/warren/pkg/domain/model/alert"
+	chatModel "github.com/secmon-lab/warren/pkg/domain/model/chat"
+	"github.com/secmon-lab/warren/pkg/domain/model/ticket"
+	"github.com/secmon-lab/warren/pkg/domain/types"
+	"github.com/secmon-lab/warren/pkg/repository"
+	svcknowledge "github.com/secmon-lab/warren/pkg/service/knowledge"
+	"github.com/secmon-lab/warren/pkg/usecase/chat/aster"
+	"github.com/secmon-lab/warren/pkg/usecase/chat/bluebell"
+	"github.com/secmon-lab/warren/pkg/utils/msg"
+)
+
+// --- shared test helpers ---
+
+func newAllowPolicyClient(t *testing.T) *mock.PolicyClientMock {
+	t.Helper()
+	return &mock.PolicyClientMock{
+		QueryFunc: func(ctx context.Context, query string, input, result any, opts ...opaq.QueryOption) error {
+			if query == "data.auth.agent" {
+				gt.NoError(t, json.Unmarshal([]byte(`{"allow":true}`), &result))
+			}
+			return nil
+		},
+		SourcesFunc: func() map[string]string { return map[string]string{} },
+	}
+}
+
+func newDenyPolicyClient(t *testing.T) *mock.PolicyClientMock {
+	t.Helper()
+	return &mock.PolicyClientMock{
+		QueryFunc: func(ctx context.Context, query string, input, result any, opts ...opaq.QueryOption) error {
+			if query == "data.auth.agent" {
+				gt.NoError(t, json.Unmarshal([]byte(`{"allow":false}`), &result))
+			}
+			return nil
+		},
+		SourcesFunc: func() map[string]string { return map[string]string{} },
+	}
+}
+
+func newUndefinedPolicyClient() *mock.PolicyClientMock {
+	return &mock.PolicyClientMock{
+		QueryFunc: func(ctx context.Context, query string, input, result any, opts ...opaq.QueryOption) error {
+			if query == "data.auth.agent" {
+				return opaq.ErrNoEvalResult
+			}
+			return nil
+		},
+		SourcesFunc: func() map[string]string { return map[string]string{} },
+	}
+}
+
+func newMockEmbeddingClient() *mock.EmbeddingClientMock {
+	return &mock.EmbeddingClientMock{
+		EmbeddingsFunc: func(ctx context.Context, texts []string, dim int) ([][]float32, error) {
+			result := make([][]float32, len(texts))
+			for i := range texts {
+				result[i] = make([]float32, dim)
+			}
+			return result, nil
+		},
+	}
+}
+
+func newDirectResponseLLM() *mock.LLMClientMock {
+	return &mock.LLMClientMock{
+		NewSessionFunc: func(ctx context.Context, opts ...gollem.SessionOption) (gollem.Session, error) {
+			ssn := &mock.LLMSessionMock{
+				HistoryFunc: func() (*gollem.History, error) {
+					return &gollem.History{
+						Version:  gollem.HistoryVersion,
+						Messages: []gollem.Message{{Role: gollem.RoleUser}},
+					}, nil
+				},
+				AppendHistoryFunc: func(h *gollem.History) error { return nil },
+				GenerateFunc: func(ctx context.Context, input []gollem.Input, opts ...gollem.GenerateOption) (*gollem.Response, error) {
+					return &gollem.Response{
+						Texts: []string{`{"message": "Direct response.", "tasks": []}`},
+					}, nil
+				},
+			}
+			return ssn, nil
+		},
+	}
+}
+
+func setupTestContext(t *testing.T) context.Context {
+	t.Helper()
+	return msg.With(t.Context(),
+		func(ctx context.Context, message string) {},
+		func(ctx context.Context, message string) {},
+		func(ctx context.Context, message string) {},
+	)
+}
+
+func setupRepo(t *testing.T, ctx context.Context) (*repository.Memory, *ticket.Ticket) {
+	t.Helper()
+	repo := repository.NewMemory()
+	tk := ticket.Ticket{
+		ID:       types.NewTicketID(),
+		Status:   types.TicketStatusOpen,
+		AlertIDs: []types.AlertID{types.NewAlertID()},
+	}
+	gt.NoError(t, repo.PutTicket(ctx, tk))
+	gt.NoError(t, repo.PutAlert(ctx, alert.Alert{
+		ID:     tk.AlertIDs[0],
+		Schema: "test.alert",
+		Data:   map[string]any{"test": "data"},
+	}))
+	return repo, &tk
+}
+
+// chatUCFactory builds a ChatUseCase for a given strategy name.
+type chatUCFactory struct {
+	repo         *repository.Memory
+	llm          *mock.LLMClientMock
+	policy       *mock.PolicyClientMock
+	knowledgeSvc *svcknowledge.Service
+}
+
+func (f *chatUCFactory) build(t *testing.T, strategy string) interfaces.ChatUseCase {
+	t.Helper()
+	switch strategy {
+	case "aster":
+		opts := []aster.Option{aster.WithNoAuthorization(false)}
+		return aster.New(f.repo, f.llm, f.policy, opts...)
+	case "bluebell":
+		if f.knowledgeSvc == nil {
+			f.knowledgeSvc = svcknowledge.New(f.repo, newMockEmbeddingClient())
+		}
+		uc, err := bluebell.New(f.repo, f.llm, f.policy,
+			bluebell.WithNoAuthorization(false),
+			bluebell.WithKnowledgeService(f.knowledgeSvc),
+		)
+		gt.NoError(t, err)
+		return uc
+	default:
+		t.Fatalf("unknown strategy: %s", strategy)
+		return nil
+	}
+}
+
+func (f *chatUCFactory) buildNoAuthz(t *testing.T, strategy string) interfaces.ChatUseCase {
+	t.Helper()
+	switch strategy {
+	case "aster":
+		return aster.New(f.repo, f.llm, f.policy, aster.WithNoAuthorization(true))
+	case "bluebell":
+		if f.knowledgeSvc == nil {
+			f.knowledgeSvc = svcknowledge.New(f.repo, newMockEmbeddingClient())
+		}
+		uc, err := bluebell.New(f.repo, f.llm, f.policy,
+			bluebell.WithNoAuthorization(true),
+			bluebell.WithKnowledgeService(f.knowledgeSvc),
+		)
+		gt.NoError(t, err)
+		return uc
+	default:
+		t.Fatalf("unknown strategy: %s", strategy)
+		return nil
+	}
+}
+
+// --- characterization tests ---
+
+// TestSessionCreated verifies that a Warren session is created and persisted
+// in the repository when Execute is called.
+func TestSessionCreated(t *testing.T) {
+	strategies := []string{"aster", "bluebell"}
+	for _, s := range strategies {
+		t.Run(s, func(t *testing.T) {
+			ctx := setupTestContext(t)
+			repo, tk := setupRepo(t, ctx)
+
+			factory := &chatUCFactory{
+				repo:   repo,
+				llm:    newDirectResponseLLM(),
+				policy: newAllowPolicyClient(t),
+			}
+			uc := factory.buildNoAuthz(t, s)
+
+			err := uc.Execute(ctx, "hello", chatModel.ChatContext{Ticket: tk})
+			gt.NoError(t, err)
+
+			sessions, err := repo.GetSessionsByTicket(ctx, tk.ID)
+			gt.NoError(t, err)
+			gt.N(t, len(sessions)).GreaterOrEqual(1)
+		})
+	}
+}
+
+// TestSessionStatusCompleted verifies that the Warren session status is set to
+// "completed" after successful execution.
+func TestSessionStatusCompleted(t *testing.T) {
+	strategies := []string{"aster", "bluebell"}
+	for _, s := range strategies {
+		t.Run(s, func(t *testing.T) {
+			ctx := setupTestContext(t)
+			repo, tk := setupRepo(t, ctx)
+
+			factory := &chatUCFactory{
+				repo:   repo,
+				llm:    newDirectResponseLLM(),
+				policy: newAllowPolicyClient(t),
+			}
+			uc := factory.buildNoAuthz(t, s)
+
+			err := uc.Execute(ctx, "hello", chatModel.ChatContext{Ticket: tk})
+			gt.NoError(t, err)
+
+			sessions, err := repo.GetSessionsByTicket(ctx, tk.ID)
+			gt.NoError(t, err)
+			gt.N(t, len(sessions)).GreaterOrEqual(1)
+			gt.V(t, sessions[0].Status).Equal(types.SessionStatusCompleted)
+		})
+	}
+}
+
+// TestAuthorizationDenied verifies that when auth policy denies the request,
+// the LLM is never called and a notification is sent.
+func TestAuthorizationDenied(t *testing.T) {
+	strategies := []string{"aster", "bluebell"}
+	for _, s := range strategies {
+		t.Run(s, func(t *testing.T) {
+			ctx := setupTestContext(t)
+			repo, tk := setupRepo(t, ctx)
+
+			var mu sync.Mutex
+			var notifications []string
+			ctx = msg.With(ctx,
+				func(ctx context.Context, message string) {
+					mu.Lock()
+					notifications = append(notifications, message)
+					mu.Unlock()
+				},
+				func(ctx context.Context, message string) {},
+				func(ctx context.Context, message string) {},
+			)
+
+			llmCalled := false
+			mockLLM := &mock.LLMClientMock{
+				NewSessionFunc: func(ctx context.Context, opts ...gollem.SessionOption) (gollem.Session, error) {
+					llmCalled = true
+					return nil, nil
+				},
+			}
+
+			factory := &chatUCFactory{
+				repo:   repo,
+				llm:    mockLLM,
+				policy: newDenyPolicyClient(t),
+			}
+			uc := factory.build(t, s)
+
+			err := uc.Execute(ctx, "analyze this", chatModel.ChatContext{Ticket: tk})
+			gt.NoError(t, err)
+
+			gt.V(t, llmCalled).Equal(false)
+
+			mu.Lock()
+			defer mu.Unlock()
+			found := false
+			for _, n := range notifications {
+				if strings.Contains(n, "Authorization Failed") {
+					found = true
+					break
+				}
+			}
+			gt.V(t, found).Equal(true)
+		})
+	}
+}
+
+// TestAuthorizationPolicyNotDefined verifies that when auth policy is not defined,
+// LLM is not called and a notification about undefined policy is sent.
+func TestAuthorizationPolicyNotDefined(t *testing.T) {
+	strategies := []string{"aster", "bluebell"}
+	for _, s := range strategies {
+		t.Run(s, func(t *testing.T) {
+			ctx := setupTestContext(t)
+			repo, tk := setupRepo(t, ctx)
+
+			var mu sync.Mutex
+			var notifications []string
+			ctx = msg.With(ctx,
+				func(ctx context.Context, message string) {
+					mu.Lock()
+					notifications = append(notifications, message)
+					mu.Unlock()
+				},
+				func(ctx context.Context, message string) {},
+				func(ctx context.Context, message string) {},
+			)
+
+			llmCalled := false
+			mockLLM := &mock.LLMClientMock{
+				NewSessionFunc: func(ctx context.Context, opts ...gollem.SessionOption) (gollem.Session, error) {
+					llmCalled = true
+					return nil, nil
+				},
+			}
+
+			factory := &chatUCFactory{
+				repo:   repo,
+				llm:    mockLLM,
+				policy: newUndefinedPolicyClient(),
+			}
+			uc := factory.build(t, s)
+
+			err := uc.Execute(ctx, "analyze this", chatModel.ChatContext{Ticket: tk})
+			gt.NoError(t, err)
+
+			gt.V(t, llmCalled).Equal(false)
+
+			mu.Lock()
+			defer mu.Unlock()
+			found := false
+			for _, n := range notifications {
+				if strings.Contains(n, "policy is not defined") {
+					found = true
+					break
+				}
+			}
+			gt.V(t, found).Equal(true)
+		})
+	}
+}
+
+// TestNoAuthzBypass verifies that WithNoAuthorization(true) bypasses auth checks
+// and the strategy executes normally.
+func TestNoAuthzBypass(t *testing.T) {
+	strategies := []string{"aster", "bluebell"}
+	for _, s := range strategies {
+		t.Run(s, func(t *testing.T) {
+			ctx := setupTestContext(t)
+			repo, tk := setupRepo(t, ctx)
+
+			factory := &chatUCFactory{
+				repo:   repo,
+				llm:    newDirectResponseLLM(),
+				policy: newDenyPolicyClient(t),
+			}
+			// buildNoAuthz sets WithNoAuthorization(true)
+			uc := factory.buildNoAuthz(t, s)
+
+			err := uc.Execute(ctx, "hello", chatModel.ChatContext{Ticket: tk})
+			gt.NoError(t, err)
+
+			sessions, err := repo.GetSessionsByTicket(ctx, tk.ID)
+			gt.NoError(t, err)
+			gt.N(t, len(sessions)).GreaterOrEqual(1)
+			gt.V(t, sessions[0].Status).Equal(types.SessionStatusCompleted)
+		})
+	}
+}
+
+// TestNotifyMessageDelivered verifies that msg.Notify is called with the LLM
+// response message during execution.
+func TestNotifyMessageDelivered(t *testing.T) {
+	strategies := []string{"aster", "bluebell"}
+	for _, s := range strategies {
+		t.Run(s, func(t *testing.T) {
+			ctx := setupTestContext(t)
+			repo, tk := setupRepo(t, ctx)
+
+			var mu sync.Mutex
+			var notifications []string
+			ctx = msg.With(ctx,
+				func(ctx context.Context, message string) {
+					mu.Lock()
+					notifications = append(notifications, message)
+					mu.Unlock()
+				},
+				func(ctx context.Context, message string) {},
+				func(ctx context.Context, message string) {},
+			)
+
+			factory := &chatUCFactory{
+				repo:   repo,
+				llm:    newDirectResponseLLM(),
+				policy: newAllowPolicyClient(t),
+			}
+			uc := factory.buildNoAuthz(t, s)
+
+			err := uc.Execute(ctx, "hello", chatModel.ChatContext{Ticket: tk})
+			gt.NoError(t, err)
+
+			mu.Lock()
+			defer mu.Unlock()
+			found := false
+			for _, n := range notifications {
+				if strings.Contains(n, "Direct response.") {
+					found = true
+					break
+				}
+			}
+			gt.V(t, found).Equal(true)
+		})
+	}
+}
+
+// TestSessionCreatedEvenWhenAuthDenied verifies that a Warren session is created
+// even when authorization is denied (session creation happens before auth check).
+func TestSessionCreatedEvenWhenAuthDenied(t *testing.T) {
+	strategies := []string{"aster", "bluebell"}
+	for _, s := range strategies {
+		t.Run(s, func(t *testing.T) {
+			ctx := setupTestContext(t)
+			repo, tk := setupRepo(t, ctx)
+
+			factory := &chatUCFactory{
+				repo:   repo,
+				llm:    newDirectResponseLLM(),
+				policy: newDenyPolicyClient(t),
+			}
+			uc := factory.build(t, s)
+
+			err := uc.Execute(ctx, "denied request", chatModel.ChatContext{Ticket: tk})
+			gt.NoError(t, err)
+
+			sessions, err := repo.GetSessionsByTicket(ctx, tk.ID)
+			gt.NoError(t, err)
+			gt.N(t, len(sessions)).GreaterOrEqual(1)
+		})
+	}
+}

--- a/pkg/usecase/chat/bluebell/bluebell.go
+++ b/pkg/usecase/chat/bluebell/bluebell.go
@@ -2,9 +2,7 @@ package bluebell
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"math/rand/v2"
 	"strings"
 	"time"
 
@@ -28,27 +26,22 @@ import (
 	"github.com/secmon-lab/warren/pkg/utils/logging"
 	"github.com/secmon-lab/warren/pkg/utils/msg"
 	"github.com/secmon-lab/warren/pkg/utils/request_id"
-	ssnutil "github.com/secmon-lab/warren/pkg/utils/session"
-	"github.com/secmon-lab/warren/pkg/utils/slackctx"
 	"github.com/secmon-lab/warren/pkg/utils/user"
 )
 
 const defaultMaxPhases = 10
 
-// BluebellChat implements interfaces.ChatUseCase with intent resolution and parallel task execution.
+// BluebellChat implements chat.Strategy with intent resolution and parallel task execution.
 // Unlike aster, bluebell resolves intent from multiple user-defined prompts before planning,
 // and always runs in agent mode (knowledge service is required).
 type BluebellChat struct {
 	repository          interfaces.Repository
 	llmClient           gollem.LLMClient
-	policyClient        interfaces.PolicyClient
 	storageClient       interfaces.StorageClient
 	slackService        *slackService.Service
 	knowledgeService    *svcknowledge.Service
 	tools               []interfaces.ToolSet
 	storagePrefix       string
-	noAuthorization     bool
-	frontendURL         string
 	traceRepository     trace.Repository
 	maxPhases           int
 	monitorPollInterval time.Duration
@@ -82,16 +75,6 @@ func WithStorageClient(client interfaces.StorageClient) Option {
 // WithStoragePrefix sets the storage prefix for history paths.
 func WithStoragePrefix(prefix string) Option {
 	return func(c *BluebellChat) { c.storagePrefix = prefix }
-}
-
-// WithNoAuthorization disables policy-based authorization checks.
-func WithNoAuthorization(noAuthz bool) Option {
-	return func(c *BluebellChat) { c.noAuthorization = noAuthz }
-}
-
-// WithFrontendURL sets the frontend URL for session links.
-func WithFrontendURL(url string) Option {
-	return func(c *BluebellChat) { c.frontendURL = url }
 }
 
 // WithUserSystemPrompt sets the static user system prompt (environment info, etc.).
@@ -136,11 +119,10 @@ func WithPromptEntries(entries []config.PromptEntry) Option {
 
 // New creates a new BluebellChat with the given dependencies and options.
 // Returns error if knowledge service is not configured (required for bluebell).
-func New(repo interfaces.Repository, llmClient gollem.LLMClient, policyClient interfaces.PolicyClient, opts ...Option) (*BluebellChat, error) {
+func New(repo interfaces.Repository, llmClient gollem.LLMClient, opts ...Option) (*BluebellChat, error) {
 	c := &BluebellChat{
 		repository:          repo,
 		llmClient:           llmClient,
-		policyClient:        policyClient,
 		maxPhases:           defaultMaxPhases,
 		monitorPollInterval: 10 * time.Second,
 	}
@@ -155,50 +137,14 @@ func New(repo interfaces.Repository, llmClient gollem.LLMClient, policyClient in
 	return c, nil
 }
 
-// Execute processes a chat message using intent resolution and parallel task execution.
-func (c *BluebellChat) Execute(ctx context.Context, message string, chatCtx chatModel.ChatContext) error {
-	target := chatCtx.Ticket
-	logger := logging.From(ctx)
-	logger.Debug("bluebell execute: start",
-		"ticket_id", target.ID,
-		"request_id", request_id.FromContext(ctx),
-	)
-
-	ssn, ctx := c.createSession(ctx, target, message)
-	logger = logging.From(ctx)
-	logger.Debug("bluebell execute: session created", "session_id", ssn.ID)
-
-	ctx = c.setupMessageRouting(ctx, ssn, target)
-	logger.Debug("bluebell execute: message routing set up")
-
-	ctx = c.setupStatusCheck(ctx, ssn)
-
-	finalStatus := types.SessionStatusCompleted
-	defer c.finishSession(ctx, ssn, target, &finalStatus)
-
-	authorized, err := c.authorize(ctx, message)
-	if err != nil {
-		finalStatus = types.SessionStatusAborted
-		return err
-	}
-	if !authorized {
-		finalStatus = types.SessionStatusAborted
-		logger.Debug("bluebell execute: not authorized, returning")
-		return nil
-	}
-	logger.Debug("bluebell execute: authorized, starting execution")
-
-	if err := c.executeBluebell(ctx, ssn, message, &finalStatus, &chatCtx); err != nil {
-		if errors.Is(err, ErrSessionAborted) || errors.Is(err, context.Canceled) {
-			return nil
-		}
-		return err
-	}
-	return nil
+// Execute implements chat.Strategy. It receives a RunContext with a pre-initialized
+// Warren session and delegates to the bluebell execution loop.
+func (c *BluebellChat) Execute(ctx context.Context, rc *chat.RunContext) error {
+	return c.executeBluebell(ctx, rc.Session, rc.Message, rc.ChatCtx)
 }
 
 // executeBluebell orchestrates: intent resolution → plan → parallel exec → replan → loop → final response.
-func (c *BluebellChat) executeBluebell(ctx context.Context, ssn *session.Session, message string, finalStatus *types.SessionStatus, chatCtx *chatModel.ChatContext) error {
+func (c *BluebellChat) executeBluebell(ctx context.Context, ssn *session.Session, message string, chatCtx *chatModel.ChatContext) error {
 	target := chatCtx.Ticket
 	ticketless := chatCtx.IsTicketless()
 	logger := logging.From(ctx)
@@ -304,10 +250,9 @@ func (c *BluebellChat) executeBluebell(ctx context.Context, ssn *session.Session
 	// Planning phase
 	planResult, err := c.plan(ctx, planSession, planCtx, systemPrompt)
 	if err != nil {
-		if abortErr := checkAborted(ctx, cleanupCtx, finalStatus); abortErr != nil {
+		if abortErr := checkAborted(ctx, cleanupCtx); abortErr != nil {
 			return abortErr
 		}
-		*finalStatus = types.SessionStatusAborted
 		msg.Notify(ctx, "💥 Planning failed: %s", err.Error())
 		return goerr.Wrap(err, "planning failed")
 	}
@@ -380,7 +325,7 @@ func (c *BluebellChat) executeBluebell(ctx context.Context, ssn *session.Session
 			results: results,
 		})
 
-		if abortErr := checkAborted(ctx, cleanupCtx, finalStatus); abortErr != nil {
+		if abortErr := checkAborted(ctx, cleanupCtx); abortErr != nil {
 			if !ticketless {
 				c.saveLatestHistory(cleanupCtx, planSession, target.ID, storageSvc)
 			}
@@ -392,7 +337,7 @@ func (c *BluebellChat) executeBluebell(ctx context.Context, ssn *session.Session
 			if !ticketless {
 				c.saveLatestHistory(cleanupCtx, planSession, target.ID, storageSvc)
 			}
-			if abortErr := checkAborted(ctx, cleanupCtx, finalStatus); abortErr != nil {
+			if abortErr := checkAborted(ctx, cleanupCtx); abortErr != nil {
 				return abortErr
 			}
 			logger.Error("replan failed", "error", err, "phase", phase)
@@ -437,10 +382,9 @@ func (c *BluebellChat) executeBluebell(ctx context.Context, ssn *session.Session
 		if !ticketless {
 			c.saveLatestHistory(cleanupCtx, planSession, target.ID, storageSvc)
 		}
-		if abortErr := checkAborted(ctx, cleanupCtx, finalStatus); abortErr != nil {
+		if abortErr := checkAborted(ctx, cleanupCtx); abortErr != nil {
 			return abortErr
 		}
-		*finalStatus = types.SessionStatusAborted
 		msg.Notify(ctx, "💥 Failed to generate final response: %s", err.Error())
 		return goerr.Wrap(err, "failed to generate final response")
 	}
@@ -546,161 +490,6 @@ func (c *BluebellChat) handleQuestion(ctx context.Context, q *Question, target *
 	}, nil
 }
 
-// createSession creates and persists a new chat session.
-func (c *BluebellChat) createSession(ctx context.Context, target *ticket.Ticket, message string) (*session.Session, context.Context) {
-	userID := types.UserID(user.FromContext(ctx))
-	slackURL := slackctx.SlackURL(ctx)
-
-	ssn := session.NewSession(ctx, target.ID, userID, message, slackURL)
-	if err := c.repository.PutSession(ctx, ssn); err != nil {
-		logging.From(ctx).Error("failed to save session", "error", err)
-	}
-
-	logger := logging.From(ctx).With("session_id", ssn.ID, "request_id", request_id.FromContext(ctx))
-	ctx = logging.With(ctx, logger)
-
-	if target.SlackThread != nil {
-		ctx = slackctx.WithThread(ctx, *target.SlackThread)
-	}
-
-	return ssn, ctx
-}
-
-// setupMessageRouting configures Slack/CLI message routing functions in the context.
-func (c *BluebellChat) setupMessageRouting(ctx context.Context, ssn *session.Session, target *ticket.Ticket) context.Context {
-	if c.slackService != nil && target.SlackThread != nil {
-		notifyFunc, traceFunc, warnFunc := c.setupSlackMessageFuncs(ctx, ssn, target)
-		ctx = msg.With(ctx, notifyFunc, traceFunc, warnFunc)
-
-		requestID := request_id.FromContext(ctx)
-		if requestID == "" {
-			requestID = "unknown"
-		}
-		verbs := []string{
-			"Investigating", "Analyzing", "Processing", "Inspecting",
-			"Examining", "Scanning", "Assessing", "Evaluating",
-			"Reviewing", "Probing", "Surveying", "Diagnosing",
-			"Exploring", "Scrutinizing", "Correlating", "Parsing",
-			"Decoding", "Interpreting", "Triaging", "Resolving",
-		}
-		verb := verbs[rand.IntN(len(verbs))] // #nosec G404 -- not security-sensitive, just picking a random UI verb
-		threadSvc := c.slackService.NewThread(*target.SlackThread)
-		if err := threadSvc.PostContextBlock(ctx, fmt.Sprintf("%s ... (ID: `%s`)", verb, requestID)); err != nil {
-			logging.From(ctx).Error("failed to post request ID", "error", err)
-		}
-	}
-
-	return ctx
-}
-
-// setupSlackMessageFuncs creates Slack message routing functions for notify, trace, and warn.
-func (c *BluebellChat) setupSlackMessageFuncs(ctx context.Context, sess *session.Session, target *ticket.Ticket) (msg.NotifyFunc, msg.TraceFunc, msg.WarnFunc) {
-	threadSvc := c.slackService.NewThread(*target.SlackThread)
-
-	notifyFunc := func(ctx context.Context, message string) {
-		m := session.NewMessage(ctx, sess.ID, session.MessageTypeResponse, message)
-		if err := c.repository.PutSessionMessage(ctx, m); err != nil {
-			errutil.Handle(ctx, err)
-		}
-		if err := threadSvc.PostComment(ctx, message); err != nil {
-			errutil.Handle(ctx, err)
-		}
-	}
-
-	var traceUpdateFunc func(context.Context, string)
-	traceFunc := func(ctx context.Context, message string) {
-		m := session.NewMessage(ctx, sess.ID, session.MessageTypeTrace, message)
-		if err := c.repository.PutSessionMessage(ctx, m); err != nil {
-			errutil.Handle(ctx, err)
-		}
-
-		if traceUpdateFunc == nil {
-			traceUpdateFunc = threadSvc.NewUpdatableMessage(ctx, message)
-		} else {
-			traceUpdateFunc(ctx, message)
-		}
-	}
-
-	warnFunc := func(ctx context.Context, message string) {
-		m := session.NewMessage(ctx, sess.ID, session.MessageTypeWarning, message)
-		if err := c.repository.PutSessionMessage(ctx, m); err != nil {
-			errutil.Handle(ctx, err)
-		}
-		if err := threadSvc.PostComment(ctx, message); err != nil {
-			errutil.Handle(ctx, err)
-		}
-	}
-
-	return notifyFunc, traceFunc, warnFunc
-}
-
-// setupStatusCheck embeds a session abort check function in the context.
-func (c *BluebellChat) setupStatusCheck(ctx context.Context, ssn *session.Session) context.Context {
-	statusCheckFunc := func(ctx context.Context) error {
-		s, err := c.repository.GetSession(ctx, ssn.ID)
-		if err != nil {
-			return goerr.Wrap(err, "failed to get session status")
-		}
-		if s != nil && s.Status == types.SessionStatusAborted {
-			return ErrSessionAborted
-		}
-		return nil
-	}
-	return ssnutil.WithStatusCheck(ctx, statusCheckFunc)
-}
-
-// finishSession updates session status and posts session actions on completion.
-func (c *BluebellChat) finishSession(ctx context.Context, ssn *session.Session, target *ticket.Ticket, finalStatus *types.SessionStatus) {
-	logger := logging.From(ctx)
-	if r := recover(); r != nil {
-		*finalStatus = types.SessionStatusAborted
-		ssn.UpdateStatus(ctx, *finalStatus)
-		if err := c.repository.PutSession(ctx, ssn); err != nil {
-			logger.Error("failed to update session status on panic", "error", err, "status", *finalStatus)
-		}
-		panic(r)
-	}
-
-	ssn.UpdateStatus(ctx, *finalStatus)
-	if err := c.repository.PutSession(ctx, ssn); err != nil {
-		logger.Error("failed to update final session status", "error", err, "status", *finalStatus)
-	}
-
-	if target.ID != "" && *finalStatus == types.SessionStatusCompleted && c.slackService != nil && target.SlackThread != nil {
-		threadSvc := c.slackService.NewThread(*target.SlackThread)
-
-		var sessionURL string
-		if c.frontendURL != "" {
-			sessionURL = fmt.Sprintf("%s/sessions/%s", c.frontendURL, ssn.ID)
-		}
-
-		currentTicket, err := c.repository.GetTicket(ctx, target.ID)
-		if err != nil {
-			logger.Error("failed to get ticket for session actions", "error", err, "ticket_id", target.ID)
-		} else if currentTicket != nil {
-			if err := threadSvc.PostSessionActions(ctx, target.ID, currentTicket.Status, sessionURL); err != nil {
-				logger.Error("failed to post session actions to Slack", "error", err, "session_id", ssn.ID)
-			}
-		}
-	}
-}
-
-// authorize checks policy-based authorization for agent execution.
-func (c *BluebellChat) authorize(ctx context.Context, message string) (bool, error) {
-	if err := chat.AuthorizeAgentRequest(ctx, c.policyClient, c.noAuthorization, message); err != nil {
-		if errors.Is(err, chat.ErrAgentAuthPolicyNotDefined) {
-			msg.Notify(ctx, "🚫 *Authorization Failed*\n\nAgent execution policy is not defined. Please configure the `auth.agent` policy or use `--no-authorization` flag for development.\n\nSee: https://docs.warren.secmon-lab.com/policy.md#agent-execution-authorization")
-		} else if errors.Is(err, chat.ErrAgentAuthDenied) {
-			msg.Notify(ctx, "🚫 *Authorization Failed*\n\nYou are not authorized to execute agent requests. Please contact your administrator if you believe this is an error.")
-		} else {
-			msg.Notify(ctx, "🚫 *Authorization Failed*\n\nFailed to check authorization. Please contact your administrator.")
-			return false, goerr.Wrap(err, "failed to evaluate agent auth")
-		}
-		return false, nil
-	}
-	return true, nil
-}
-
 // saveLatestHistory saves the current planning session history as the latest snapshot.
 func (c *BluebellChat) saveLatestHistory(ctx context.Context, planSession gollem.Session, ticketID types.TicketID, storageSvc *storage.Service) {
 	history, err := planSession.History()
@@ -725,12 +514,12 @@ func (c *BluebellChat) saveSessionHistory(ctx context.Context, planSession golle
 	return chat.SaveHistory(ctx, c.repository, c.storageClient, storageSvc, ticketID, newHistory)
 }
 
-// checkAborted checks if the context has been cancelled and sets finalStatus accordingly.
-func checkAborted(ctx context.Context, cleanupCtx context.Context, finalStatus *types.SessionStatus) error {
+// checkAborted checks if the context has been cancelled.
+// Returns chat.ErrSessionAborted when aborted, nil otherwise.
+func checkAborted(ctx context.Context, cleanupCtx context.Context) error {
 	if ctx.Err() != nil {
-		*finalStatus = types.SessionStatusAborted
 		msg.Notify(cleanupCtx, "🛑 Execution aborted by user request.")
-		return ErrSessionAborted
+		return chat.ErrSessionAborted
 	}
 	return nil
 }

--- a/pkg/usecase/chat/bluebell/bluebell_test.go
+++ b/pkg/usecase/chat/bluebell/bluebell_test.go
@@ -2,7 +2,6 @@ package bluebell_test
 
 import (
 	"context"
-	"encoding/json"
 	"strings"
 	"sync"
 	"testing"
@@ -10,31 +9,25 @@ import (
 	"github.com/m-mizutani/goerr/v2"
 	"github.com/m-mizutani/gollem"
 	"github.com/m-mizutani/gt"
-	"github.com/m-mizutani/opaq"
 	"github.com/secmon-lab/warren/pkg/cli/config"
 	"github.com/secmon-lab/warren/pkg/domain/mock"
 	"github.com/secmon-lab/warren/pkg/domain/model/alert"
 	chatModel "github.com/secmon-lab/warren/pkg/domain/model/chat"
+	"github.com/secmon-lab/warren/pkg/domain/model/session"
 	"github.com/secmon-lab/warren/pkg/domain/model/ticket"
 	"github.com/secmon-lab/warren/pkg/domain/types"
 	"github.com/secmon-lab/warren/pkg/repository"
 	svcknowledge "github.com/secmon-lab/warren/pkg/service/knowledge"
+	"github.com/secmon-lab/warren/pkg/usecase/chat"
 	"github.com/secmon-lab/warren/pkg/usecase/chat/bluebell"
 	"github.com/secmon-lab/warren/pkg/utils/msg"
 )
 
-func newMockPolicyClient(t *testing.T) *mock.PolicyClientMock {
-	t.Helper()
-	return &mock.PolicyClientMock{
-		QueryFunc: func(ctx context.Context, query string, input, result any, opts ...opaq.QueryOption) error {
-			if query == "data.auth.agent" {
-				gt.NoError(t, json.Unmarshal([]byte(`{"allow":true}`), &result))
-			}
-			return nil
-		},
-		SourcesFunc: func() map[string]string {
-			return map[string]string{}
-		},
+func newDummySession(ticketID types.TicketID) *session.Session {
+	return &session.Session{
+		ID:       types.NewSessionID(),
+		TicketID: ticketID,
+		Status:   types.SessionStatusRunning,
 	}
 }
 
@@ -96,9 +89,8 @@ func setupTicketAndAlert(t *testing.T, ctx context.Context, repo *repository.Mem
 func TestBluebellChat_NewRequiresKnowledgeService(t *testing.T) {
 	repo := repository.NewMemory()
 	mockLLM := &mock.LLMClientMock{}
-	mockPolicy := newMockPolicyClient(t)
 
-	_, err := bluebell.New(repo, mockLLM, mockPolicy)
+	_, err := bluebell.New(repo, mockLLM)
 	gt.V(t, err).NotNil()
 	gt.True(t, strings.Contains(err.Error(), "requires knowledge service"))
 }
@@ -121,13 +113,16 @@ func TestBluebellChat_DirectResponse(t *testing.T) {
 		},
 	}
 
-	chatUC, err := bluebell.New(repo, mockLLM, newMockPolicyClient(t),
-		bluebell.WithNoAuthorization(true),
+	chatUC, err := bluebell.New(repo, mockLLM,
 		bluebell.WithKnowledgeService(knowledgeSvc),
 	)
 	gt.NoError(t, err)
 
-	err = chatUC.Execute(ctx, "What is the meaning of life?", chatModel.ChatContext{Ticket: testTicket})
+	err = chatUC.Execute(ctx, &chat.RunContext{
+		Session: newDummySession(testTicket.ID),
+		Message: "What is the meaning of life?",
+		ChatCtx: &chatModel.ChatContext{Ticket: testTicket},
+	})
 	gt.NoError(t, err)
 }
 
@@ -182,13 +177,16 @@ func TestBluebellChat_SinglePhaseWithTasks(t *testing.T) {
 		},
 	}
 
-	chatUC, err := bluebell.New(repo, mockLLM, newMockPolicyClient(t),
-		bluebell.WithNoAuthorization(true),
+	chatUC, err := bluebell.New(repo, mockLLM,
 		bluebell.WithKnowledgeService(knowledgeSvc),
 	)
 	gt.NoError(t, err)
 
-	err = chatUC.Execute(ctx, "Analyze this alert", chatModel.ChatContext{Ticket: testTicket})
+	err = chatUC.Execute(ctx, &chat.RunContext{
+		Session: newDummySession(testTicket.ID),
+		Message: "Analyze this alert",
+		ChatCtx: &chatModel.ChatContext{Ticket: testTicket},
+	})
 	gt.NoError(t, err)
 }
 
@@ -234,14 +232,17 @@ func TestBluebellChat_WithPromptEntries_IntentInjected(t *testing.T) {
 		},
 	}
 
-	chatUC, err := bluebell.New(repo, mockLLM, newMockPolicyClient(t),
-		bluebell.WithNoAuthorization(true),
+	chatUC, err := bluebell.New(repo, mockLLM,
 		bluebell.WithKnowledgeService(knowledgeSvc),
 		bluebell.WithPromptEntries(entries),
 	)
 	gt.NoError(t, err)
 
-	err = chatUC.Execute(ctx, "Check this alert", chatModel.ChatContext{Ticket: testTicket})
+	err = chatUC.Execute(ctx, &chat.RunContext{
+		Session: newDummySession(testTicket.ID),
+		Message: "Check this alert",
+		ChatCtx: &chatModel.ChatContext{Ticket: testTicket},
+	})
 	gt.NoError(t, err)
 }
 
@@ -278,14 +279,17 @@ func TestBluebellChat_MaxPhasesLimit(t *testing.T) {
 		},
 	}
 
-	chatUC, err := bluebell.New(repo, mockLLM, newMockPolicyClient(t),
-		bluebell.WithNoAuthorization(true),
+	chatUC, err := bluebell.New(repo, mockLLM,
 		bluebell.WithKnowledgeService(knowledgeSvc),
 		bluebell.WithMaxPhases(2),
 	)
 	gt.NoError(t, err)
 
-	err = chatUC.Execute(ctx, "Do something", chatModel.ChatContext{Ticket: testTicket})
+	err = chatUC.Execute(ctx, &chat.RunContext{
+		Session: newDummySession(testTicket.ID),
+		Message: "Do something",
+		ChatCtx: &chatModel.ChatContext{Ticket: testTicket},
+	})
 	gt.NoError(t, err)
 }
 
@@ -340,13 +344,16 @@ func TestBluebellChat_ErrorIsolation(t *testing.T) {
 		},
 	}
 
-	chatUC, err := bluebell.New(repo, mockLLM, newMockPolicyClient(t),
-		bluebell.WithNoAuthorization(true),
+	chatUC, err := bluebell.New(repo, mockLLM,
 		bluebell.WithKnowledgeService(knowledgeSvc),
 	)
 	gt.NoError(t, err)
 
-	err = chatUC.Execute(ctx, "Test error isolation", chatModel.ChatContext{Ticket: testTicket})
+	err = chatUC.Execute(ctx, &chat.RunContext{
+		Session: newDummySession(testTicket.ID),
+		Message: "Test error isolation",
+		ChatCtx: &chatModel.ChatContext{Ticket: testTicket},
+	})
 	gt.NoError(t, err)
 }
 
@@ -367,15 +374,18 @@ func TestBluebellChat_Ticketless(t *testing.T) {
 		},
 	}
 
-	chatUC, err := bluebell.New(repo, mockLLM, newMockPolicyClient(t),
-		bluebell.WithNoAuthorization(true),
+	chatUC, err := bluebell.New(repo, mockLLM,
 		bluebell.WithKnowledgeService(knowledgeSvc),
 	)
 	gt.NoError(t, err)
 
 	// Ticketless: empty ticket
-	err = chatUC.Execute(ctx, "General question", chatModel.ChatContext{
-		Ticket: &ticket.Ticket{},
+	err = chatUC.Execute(ctx, &chat.RunContext{
+		Session: newDummySession(""),
+		Message: "General question",
+		ChatCtx: &chatModel.ChatContext{
+			Ticket: &ticket.Ticket{},
+		},
 	})
 	gt.NoError(t, err)
 }

--- a/pkg/usecase/chat/bluebell/budget.go
+++ b/pkg/usecase/chat/bluebell/budget.go
@@ -197,7 +197,6 @@ func withBudgetTracker(ctx context.Context, tracker *BudgetTracker) context.Cont
 	return context.WithValue(ctx, budgetTrackerCtxKeyType{}, tracker)
 }
 
-
 // subAgentToolNames contains tool names for sub-agent invocations.
 // These have zero cost because their internal tool calls are tracked individually.
 var subAgentToolNames = map[string]bool{

--- a/pkg/usecase/chat/bluebell/errors.go
+++ b/pkg/usecase/chat/bluebell/errors.go
@@ -1,10 +1,8 @@
 package bluebell
 
 import (
-	"github.com/m-mizutani/goerr/v2"
+	"github.com/secmon-lab/warren/pkg/usecase/chat"
 )
 
-var (
-	// ErrSessionAborted is returned when a session is aborted by user request
-	ErrSessionAborted = goerr.New("session aborted by user")
-)
+// ErrSessionAborted is an alias for chat.ErrSessionAborted for backward compatibility.
+var ErrSessionAborted = chat.ErrSessionAborted

--- a/pkg/usecase/chat/bluebell/selector_test.go
+++ b/pkg/usecase/chat/bluebell/selector_test.go
@@ -62,8 +62,7 @@ func TestResolveIntent_ZeroCandidates(t *testing.T) {
 
 	mockLLM := newSelectorMockLLM(`{"prompt_id":"default","intent":"test"}`)
 
-	chat, err := bluebell.New(repo, mockLLM, newMockPolicyClient(t),
-		bluebell.WithNoAuthorization(true),
+	chat, err := bluebell.New(repo, mockLLM,
 		bluebell.WithKnowledgeService(knowledgeSvc),
 		// No WithPromptEntries — zero candidates
 	)
@@ -98,8 +97,7 @@ func TestResolveIntent_SingleCandidate(t *testing.T) {
 		{ID: "infra", Description: "Infrastructure incident investigation"},
 	}
 
-	chat, err := bluebell.New(repo, mockLLM, newMockPolicyClient(t),
-		bluebell.WithNoAuthorization(true),
+	chat, err := bluebell.New(repo, mockLLM,
 		bluebell.WithKnowledgeService(knowledgeSvc),
 		bluebell.WithPromptEntries(entries),
 	)
@@ -137,8 +135,7 @@ func TestResolveIntent_MultipleCandidates(t *testing.T) {
 		{ID: "infra", Description: "Infrastructure incident investigation"},
 	}
 
-	chat, err := bluebell.New(repo, mockLLM, newMockPolicyClient(t),
-		bluebell.WithNoAuthorization(true),
+	chat, err := bluebell.New(repo, mockLLM,
 		bluebell.WithKnowledgeService(knowledgeSvc),
 		bluebell.WithPromptEntries(entries),
 	)
@@ -177,8 +174,7 @@ func TestResolveIntent_UnknownPromptID_Fallback(t *testing.T) {
 		{ID: "infra", Description: "Infrastructure incident investigation"},
 	}
 
-	chat, err := bluebell.New(repo, mockLLM, newMockPolicyClient(t),
-		bluebell.WithNoAuthorization(true),
+	chat, err := bluebell.New(repo, mockLLM,
 		bluebell.WithKnowledgeService(knowledgeSvc),
 		bluebell.WithPromptEntries(entries),
 	)
@@ -214,8 +210,7 @@ func TestResolveIntent_InvalidJSON_Fallback(t *testing.T) {
 		{ID: "infra", Description: "Infrastructure incident investigation"},
 	}
 
-	chat, err := bluebell.New(repo, mockLLM, newMockPolicyClient(t),
-		bluebell.WithNoAuthorization(true),
+	chat, err := bluebell.New(repo, mockLLM,
 		bluebell.WithKnowledgeService(knowledgeSvc),
 		bluebell.WithPromptEntries(entries),
 	)
@@ -250,8 +245,7 @@ func TestResolveIntent_DefaultPromptID_Accepted(t *testing.T) {
 		{ID: "security", Description: "Security threat investigation"},
 	}
 
-	chat, err := bluebell.New(repo, mockLLM, newMockPolicyClient(t),
-		bluebell.WithNoAuthorization(true),
+	chat, err := bluebell.New(repo, mockLLM,
 		bluebell.WithKnowledgeService(knowledgeSvc),
 		bluebell.WithPromptEntries(entries),
 	)

--- a/pkg/usecase/chat/errors.go
+++ b/pkg/usecase/chat/errors.go
@@ -1,0 +1,10 @@
+package chat
+
+import (
+	"github.com/m-mizutani/goerr/v2"
+)
+
+var (
+	// ErrSessionAborted is returned when a session is aborted by user request
+	ErrSessionAborted = goerr.New("session aborted by user")
+)

--- a/pkg/usecase/chat/usecase.go
+++ b/pkg/usecase/chat/usecase.go
@@ -1,0 +1,304 @@
+package chat
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand/v2"
+
+	"github.com/m-mizutani/goerr/v2"
+	"github.com/secmon-lab/warren/pkg/domain/interfaces"
+	chatModel "github.com/secmon-lab/warren/pkg/domain/model/chat"
+	"github.com/secmon-lab/warren/pkg/domain/model/session"
+	"github.com/secmon-lab/warren/pkg/domain/model/ticket"
+	"github.com/secmon-lab/warren/pkg/domain/types"
+	slackService "github.com/secmon-lab/warren/pkg/service/slack"
+	"github.com/secmon-lab/warren/pkg/utils/errutil"
+	"github.com/secmon-lab/warren/pkg/utils/logging"
+	"github.com/secmon-lab/warren/pkg/utils/msg"
+	"github.com/secmon-lab/warren/pkg/utils/request_id"
+	ssnutil "github.com/secmon-lab/warren/pkg/utils/session"
+	"github.com/secmon-lab/warren/pkg/utils/slackctx"
+	"github.com/secmon-lab/warren/pkg/utils/user"
+)
+
+// Strategy defines the interface for chat execution strategies.
+// Implementations receive a RunContext with a pre-initialized Warren session
+// (session created, message routing configured, authorization verified).
+// The strategy is responsible for its own gollem LLM session management
+// and execution workflow (planning, task execution, replanning, etc.).
+type Strategy interface {
+	Execute(ctx context.Context, rc *RunContext) error
+}
+
+// RunContext holds all the pre-initialized resources that UseCase
+// passes to a Strategy after completing common setup.
+type RunContext struct {
+	Session *session.Session
+	Message string
+	ChatCtx *chatModel.ChatContext
+}
+
+// UseCase implements interfaces.ChatUseCase by performing common setup
+// (Warren session management, message routing, authorization) and delegating
+// strategy-specific execution to a Strategy implementation.
+type UseCase struct {
+	strategy        Strategy
+	repository      interfaces.Repository
+	policyClient    interfaces.PolicyClient
+	slackService    *slackService.Service
+	noAuthorization bool
+	frontendURL     string
+}
+
+// Option configures a UseCase.
+type Option func(*UseCase)
+
+// WithRepository sets the repository.
+func WithRepository(repo interfaces.Repository) Option {
+	return func(u *UseCase) { u.repository = repo }
+}
+
+// WithPolicyClient sets the policy client for authorization.
+func WithPolicyClient(pc interfaces.PolicyClient) Option {
+	return func(u *UseCase) { u.policyClient = pc }
+}
+
+// WithSlackService sets the Slack service for message routing.
+func WithSlackService(svc *slackService.Service) Option {
+	return func(u *UseCase) { u.slackService = svc }
+}
+
+// WithNoAuthorization disables policy-based authorization checks.
+func WithNoAuthorization(noAuthz bool) Option {
+	return func(u *UseCase) { u.noAuthorization = noAuthz }
+}
+
+// WithFrontendURL sets the frontend URL for session links.
+func WithFrontendURL(url string) Option {
+	return func(u *UseCase) { u.frontendURL = url }
+}
+
+// NewUseCase creates a new UseCase with the given strategy and options.
+func NewUseCase(strategy Strategy, opts ...Option) *UseCase {
+	u := &UseCase{
+		strategy: strategy,
+	}
+	for _, opt := range opts {
+		opt(u)
+	}
+	return u
+}
+
+// Execute processes a chat message: creates a Warren session, sets up message
+// routing, checks authorization, and delegates to the Strategy.
+func (u *UseCase) Execute(ctx context.Context, message string, chatCtx chatModel.ChatContext) error {
+	target := chatCtx.Ticket
+	logger := logging.From(ctx)
+	logger.Debug("chat usecase execute: start",
+		"ticket_id", target.ID,
+		"request_id", request_id.FromContext(ctx),
+	)
+
+	// Phase 1: Warren session setup
+	ssn, ctx := u.createSession(ctx, target, message)
+	logger = logging.From(ctx)
+	logger.Debug("chat usecase execute: session created", "session_id", ssn.ID)
+
+	// Phase 2: Message routing setup
+	ctx = u.setupMessageRouting(ctx, ssn, target)
+	logger.Debug("chat usecase execute: message routing set up")
+
+	// Phase 3: Session status tracking
+	ctx = u.setupStatusCheck(ctx, ssn)
+
+	finalStatus := types.SessionStatusCompleted
+	defer u.finishSession(ctx, ssn, target, &finalStatus)
+
+	// Phase 4: Authorization
+	authorized, err := u.authorize(ctx, message)
+	if err != nil {
+		finalStatus = types.SessionStatusAborted
+		return err
+	}
+	if !authorized {
+		finalStatus = types.SessionStatusAborted
+		logger.Debug("chat usecase execute: not authorized, returning")
+		return nil
+	}
+	logger.Debug("chat usecase execute: authorized, delegating to strategy")
+
+	// Phase 5: Delegate to strategy
+	rc := &RunContext{
+		Session: ssn,
+		Message: message,
+		ChatCtx: &chatCtx,
+	}
+	if err := u.strategy.Execute(ctx, rc); err != nil {
+		if errors.Is(err, ErrSessionAborted) || errors.Is(err, context.Canceled) {
+			finalStatus = types.SessionStatusAborted
+			return nil
+		}
+		finalStatus = types.SessionStatusAborted
+		return err
+	}
+
+	return nil
+}
+
+// createSession creates and persists a new Warren chat session.
+func (u *UseCase) createSession(ctx context.Context, target *ticket.Ticket, message string) (*session.Session, context.Context) {
+	userID := types.UserID(user.FromContext(ctx))
+	slackURL := slackctx.SlackURL(ctx)
+
+	ssn := session.NewSession(ctx, target.ID, userID, message, slackURL)
+	if err := u.repository.PutSession(ctx, ssn); err != nil {
+		logging.From(ctx).Error("failed to save session", "error", err)
+	}
+
+	logger := logging.From(ctx).With("session_id", ssn.ID, "request_id", request_id.FromContext(ctx))
+	ctx = logging.With(ctx, logger)
+
+	if target.SlackThread != nil {
+		ctx = slackctx.WithThread(ctx, *target.SlackThread)
+	}
+
+	return ssn, ctx
+}
+
+// setupMessageRouting configures Slack/CLI message routing functions in the context.
+func (u *UseCase) setupMessageRouting(ctx context.Context, ssn *session.Session, target *ticket.Ticket) context.Context {
+	if u.slackService != nil && target.SlackThread != nil {
+		notifyFunc, traceFunc, warnFunc := u.setupSlackMessageFuncs(ctx, ssn, target)
+		ctx = msg.With(ctx, notifyFunc, traceFunc, warnFunc)
+
+		// Post request ID as a context block immediately
+		requestID := request_id.FromContext(ctx)
+		if requestID == "" {
+			requestID = "unknown"
+		}
+		verbs := []string{
+			"Investigating", "Analyzing", "Processing", "Inspecting",
+			"Examining", "Scanning", "Assessing", "Evaluating",
+			"Reviewing", "Probing", "Surveying", "Diagnosing",
+			"Exploring", "Scrutinizing", "Correlating", "Parsing",
+			"Decoding", "Interpreting", "Triaging", "Resolving",
+		}
+		verb := verbs[rand.IntN(len(verbs))] // #nosec G404 -- not security-sensitive, just picking a random UI verb
+		threadSvc := u.slackService.NewThread(*target.SlackThread)
+		if err := threadSvc.PostContextBlock(ctx, fmt.Sprintf("%s ... (ID: `%s`)", verb, requestID)); err != nil {
+			logging.From(ctx).Error("failed to post request ID", "error", err)
+		}
+	}
+
+	return ctx
+}
+
+// setupSlackMessageFuncs creates Slack message routing functions for notify, trace, and warn.
+func (u *UseCase) setupSlackMessageFuncs(_ context.Context, sess *session.Session, target *ticket.Ticket) (msg.NotifyFunc, msg.TraceFunc, msg.WarnFunc) {
+	threadSvc := u.slackService.NewThread(*target.SlackThread)
+
+	notifyFunc := func(ctx context.Context, message string) {
+		m := session.NewMessage(ctx, sess.ID, session.MessageTypeResponse, message)
+		if err := u.repository.PutSessionMessage(ctx, m); err != nil {
+			errutil.Handle(ctx, err)
+		}
+		if err := threadSvc.PostComment(ctx, message); err != nil {
+			errutil.Handle(ctx, err)
+		}
+	}
+
+	var traceUpdateFunc func(context.Context, string)
+	traceFunc := func(ctx context.Context, message string) {
+		m := session.NewMessage(ctx, sess.ID, session.MessageTypeTrace, message)
+		if err := u.repository.PutSessionMessage(ctx, m); err != nil {
+			errutil.Handle(ctx, err)
+		}
+
+		if traceUpdateFunc == nil {
+			traceUpdateFunc = threadSvc.NewUpdatableMessage(ctx, message)
+		} else {
+			traceUpdateFunc(ctx, message)
+		}
+	}
+
+	warnFunc := func(ctx context.Context, message string) {
+		m := session.NewMessage(ctx, sess.ID, session.MessageTypeWarning, message)
+		if err := u.repository.PutSessionMessage(ctx, m); err != nil {
+			errutil.Handle(ctx, err)
+		}
+		if err := threadSvc.PostComment(ctx, message); err != nil {
+			errutil.Handle(ctx, err)
+		}
+	}
+
+	return notifyFunc, traceFunc, warnFunc
+}
+
+// setupStatusCheck embeds a session abort check function in the context.
+func (u *UseCase) setupStatusCheck(ctx context.Context, ssn *session.Session) context.Context {
+	statusCheckFunc := func(ctx context.Context) error {
+		s, err := u.repository.GetSession(ctx, ssn.ID)
+		if err != nil {
+			return goerr.Wrap(err, "failed to get session status")
+		}
+		if s != nil && s.Status == types.SessionStatusAborted {
+			return ErrSessionAborted
+		}
+		return nil
+	}
+	return ssnutil.WithStatusCheck(ctx, statusCheckFunc)
+}
+
+// authorize checks policy-based authorization for agent execution.
+func (u *UseCase) authorize(ctx context.Context, message string) (bool, error) {
+	if err := AuthorizeAgentRequest(ctx, u.policyClient, u.noAuthorization, message); err != nil {
+		if errors.Is(err, ErrAgentAuthPolicyNotDefined) {
+			msg.Notify(ctx, "🚫 *Authorization Failed*\n\nAgent execution policy is not defined. Please configure the `auth.agent` policy or use `--no-authorization` flag for development.\n\nSee: https://docs.warren.secmon-lab.com/policy.md#agent-execution-authorization")
+		} else if errors.Is(err, ErrAgentAuthDenied) {
+			msg.Notify(ctx, "🚫 *Authorization Failed*\n\nYou are not authorized to execute agent requests. Please contact your administrator if you believe this is an error.")
+		} else {
+			msg.Notify(ctx, "🚫 *Authorization Failed*\n\nFailed to check authorization. Please contact your administrator.")
+			return false, goerr.Wrap(err, "failed to evaluate agent auth")
+		}
+		return false, nil
+	}
+	return true, nil
+}
+
+// finishSession updates session status and posts session actions on completion.
+func (u *UseCase) finishSession(ctx context.Context, ssn *session.Session, target *ticket.Ticket, finalStatus *types.SessionStatus) {
+	logger := logging.From(ctx)
+	if r := recover(); r != nil {
+		*finalStatus = types.SessionStatusAborted
+		ssn.UpdateStatus(ctx, *finalStatus)
+		if err := u.repository.PutSession(ctx, ssn); err != nil {
+			logger.Error("failed to update session status on panic", "error", err, "status", *finalStatus)
+		}
+		panic(r)
+	}
+
+	ssn.UpdateStatus(ctx, *finalStatus)
+	if err := u.repository.PutSession(ctx, ssn); err != nil {
+		logger.Error("failed to update final session status", "error", err, "status", *finalStatus)
+	}
+
+	// Skip session actions for ticketless chat (no ticket to act on)
+	if target.ID != "" && *finalStatus == types.SessionStatusCompleted && u.slackService != nil && target.SlackThread != nil {
+		threadSvc := u.slackService.NewThread(*target.SlackThread)
+
+		var sessionURL string
+		if u.frontendURL != "" {
+			sessionURL = fmt.Sprintf("%s/sessions/%s", u.frontendURL, ssn.ID)
+		}
+
+		currentTicket, err := u.repository.GetTicket(ctx, target.ID)
+		if err != nil {
+			logger.Error("failed to get ticket for session actions", "error", err, "ticket_id", target.ID)
+		} else if currentTicket != nil {
+			if err := threadSvc.PostSessionActions(ctx, target.ID, currentTicket.Status, sessionURL); err != nil {
+				logger.Error("failed to post session actions to Slack", "error", err, "session_id", ssn.ID)
+			}
+		}
+	}
+}

--- a/pkg/usecase/usecase.go
+++ b/pkg/usecase/usecase.go
@@ -19,7 +19,8 @@ import (
 	"github.com/secmon-lab/warren/pkg/service/notifier"
 	slackService "github.com/secmon-lab/warren/pkg/service/slack"
 	"github.com/secmon-lab/warren/pkg/service/tag"
-	chatUC "github.com/secmon-lab/warren/pkg/usecase/chat/aster"
+	chatuc "github.com/secmon-lab/warren/pkg/usecase/chat"
+	"github.com/secmon-lab/warren/pkg/usecase/chat/aster"
 )
 
 var (
@@ -233,17 +234,33 @@ func New(opts ...Option) *UseCases {
 
 	// Initialize chat use case (only if not already set via WithChatUseCase)
 	if u.ChatUC == nil {
-		chatOpts := []chatUC.Option{
-			chatUC.WithSlackService(u.slackService),
-			chatUC.WithTools(u.tools),
-			chatUC.WithStorageClient(u.storageClient),
-			chatUC.WithStoragePrefix(u.storagePrefix),
-			chatUC.WithNoAuthorization(u.noAuthorization),
-			chatUC.WithFrontendURL(u.frontendURL),
-			chatUC.WithUserSystemPrompt(u.userSystemPrompt),
-			chatUC.WithTraceRepository(u.traceRepository),
+		asterStrategy := aster.New(u.repository, u.llmClient,
+			aster.WithTools(u.tools),
+			aster.WithStorageClient(u.storageClient),
+			aster.WithStoragePrefix(u.storagePrefix),
+			aster.WithUserSystemPrompt(u.userSystemPrompt),
+			aster.WithTraceRepository(u.traceRepository),
+		)
+		if u.slackService != nil {
+			asterStrategy = aster.New(u.repository, u.llmClient,
+				aster.WithSlackService(u.slackService),
+				aster.WithTools(u.tools),
+				aster.WithStorageClient(u.storageClient),
+				aster.WithStoragePrefix(u.storagePrefix),
+				aster.WithUserSystemPrompt(u.userSystemPrompt),
+				aster.WithTraceRepository(u.traceRepository),
+			)
 		}
-		u.ChatUC = chatUC.New(u.repository, u.llmClient, u.policyClient, chatOpts...)
+		commonOpts := []chatuc.Option{
+			chatuc.WithRepository(u.repository),
+			chatuc.WithPolicyClient(u.policyClient),
+			chatuc.WithNoAuthorization(u.noAuthorization),
+			chatuc.WithFrontendURL(u.frontendURL),
+		}
+		if u.slackService != nil {
+			commonOpts = append(commonOpts, chatuc.WithSlackService(u.slackService))
+		}
+		u.ChatUC = chatuc.NewUseCase(asterStrategy, commonOpts...)
 	}
 
 	// Initialize tag use case if tag service is available

--- a/pkg/usecase/usecase.go
+++ b/pkg/usecase/usecase.go
@@ -234,23 +234,17 @@ func New(opts ...Option) *UseCases {
 
 	// Initialize chat use case (only if not already set via WithChatUseCase)
 	if u.ChatUC == nil {
-		asterStrategy := aster.New(u.repository, u.llmClient,
+		asterOpts := []aster.Option{
 			aster.WithTools(u.tools),
 			aster.WithStorageClient(u.storageClient),
 			aster.WithStoragePrefix(u.storagePrefix),
 			aster.WithUserSystemPrompt(u.userSystemPrompt),
 			aster.WithTraceRepository(u.traceRepository),
-		)
-		if u.slackService != nil {
-			asterStrategy = aster.New(u.repository, u.llmClient,
-				aster.WithSlackService(u.slackService),
-				aster.WithTools(u.tools),
-				aster.WithStorageClient(u.storageClient),
-				aster.WithStoragePrefix(u.storagePrefix),
-				aster.WithUserSystemPrompt(u.userSystemPrompt),
-				aster.WithTraceRepository(u.traceRepository),
-			)
 		}
+		if u.slackService != nil {
+			asterOpts = append(asterOpts, aster.WithSlackService(u.slackService))
+		}
+		asterStrategy := aster.New(u.repository, u.llmClient, asterOpts...)
 		commonOpts := []chatuc.Option{
 			chatuc.WithRepository(u.repository),
 			chatuc.WithPolicyClient(u.policyClient),


### PR DESCRIPTION
## Summary
- Extract shared Warren session management and authorization from aster/bluebell into `chat.UseCase`, which implements `interfaces.ChatUseCase`
- Introduce `chat.Strategy` interface that aster/bluebell now implement, focusing only on their gollem LLM session and execution workflow
- Unify `ErrSessionAborted` into `pkg/usecase/chat/errors.go`, referenced by both strategies

## Details
The following duplicated methods were moved from aster and bluebell into `chat.UseCase`:
- `createSession` — Warren session creation and persistence
- `setupMessageRouting` / `setupSlackMessageFuncs` — Slack/CLI message routing
- `setupStatusCheck` — session abort detection
- `authorize` — Rego policy-based authorization with Slack notification on failure
- `finishSession` — session status update and Slack action posting

Each strategy now implements `chat.Strategy` with `Execute(ctx, *RunContext) error`, receiving a pre-initialized Warren session after authorization.

Net diff: **+546 / -680 lines** (134 line reduction).

## Test plan
- [x] Added characterization tests (`behavior_test.go`) verifying common behavior across both strategies before refactoring
- [x] Updated all existing aster/bluebell tests for new API
- [x] `go test ./...` — all pass
- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)