### PR TITLE
fix(bluebell): run intent resolver with 0 prompt entries and post context block

### DIFF
--- a/pkg/usecase/chat/bluebell/bluebell.go
+++ b/pkg/usecase/chat/bluebell/bluebell.go
@@ -203,9 +203,9 @@ func (c *BluebellChat) executeBluebell(ctx context.Context, ssn *session.Session
 			threadSvc := c.slackService.NewThread(*target.SlackThread)
 			promptLabel := resolved.PromptName
 			if promptLabel == "" {
-				promptLabel = resolved.PromptID
+				promptLabel = "(default)"
 			}
-			if postErr := threadSvc.PostContextBlock(ctx, fmt.Sprintf("📋 Prompt: %s", promptLabel)); postErr != nil {
+			if postErr := threadSvc.PostContextBlock(ctx, fmt.Sprintf("📋 Prompt: `%s`", promptLabel)); postErr != nil {
 				logging.From(ctx).Error("failed to post prompt selection", "error", postErr)
 			}
 		}

--- a/pkg/usecase/chat/bluebell/bluebell_test.go
+++ b/pkg/usecase/chat/bluebell/bluebell_test.go
@@ -14,13 +14,17 @@ import (
 	"github.com/secmon-lab/warren/pkg/domain/model/alert"
 	chatModel "github.com/secmon-lab/warren/pkg/domain/model/chat"
 	"github.com/secmon-lab/warren/pkg/domain/model/session"
+	slackModel "github.com/secmon-lab/warren/pkg/domain/model/slack"
 	"github.com/secmon-lab/warren/pkg/domain/model/ticket"
 	"github.com/secmon-lab/warren/pkg/domain/types"
 	"github.com/secmon-lab/warren/pkg/repository"
 	svcknowledge "github.com/secmon-lab/warren/pkg/service/knowledge"
+	slackService "github.com/secmon-lab/warren/pkg/service/slack"
 	"github.com/secmon-lab/warren/pkg/usecase/chat"
 	"github.com/secmon-lab/warren/pkg/usecase/chat/bluebell"
 	"github.com/secmon-lab/warren/pkg/utils/msg"
+
+	slack "github.com/slack-go/slack"
 )
 
 func newDummySession(ticketID types.TicketID) *session.Session {
@@ -355,6 +359,241 @@ func TestBluebellChat_ErrorIsolation(t *testing.T) {
 		ChatCtx: &chatModel.ChatContext{Ticket: testTicket},
 	})
 	gt.NoError(t, err)
+}
+
+// newTestSlackService creates a slack.Service with a mock client for testing.
+// The returned postedMessages slice captures all PostMessageContext calls.
+func newTestSlackService(t *testing.T) (*slackService.Service, *[]slack.MsgOption) {
+	t.Helper()
+	var mu sync.Mutex
+	var postedOptions []slack.MsgOption
+
+	slackMock := &mock.SlackClientMock{
+		PostMessageContextFunc: func(ctx context.Context, channelID string, options ...slack.MsgOption) (string, string, error) {
+			mu.Lock()
+			postedOptions = append(postedOptions, options...)
+			mu.Unlock()
+			return channelID, "1234567890.123456", nil
+		},
+		UpdateMessageContextFunc: func(ctx context.Context, channelID, timestamp string, options ...slack.MsgOption) (string, string, string, error) {
+			return channelID, timestamp, "", nil
+		},
+		AuthTestFunc: func() (*slack.AuthTestResponse, error) {
+			return &slack.AuthTestResponse{
+				UserID:       "U123",
+				TeamID:       "T123",
+				Team:         "test-team",
+				EnterpriseID: "",
+				BotID:        "B123",
+			}, nil
+		},
+		GetTeamInfoFunc: func() (*slack.TeamInfo, error) {
+			return &slack.TeamInfo{
+				Domain: "test-workspace",
+			}, nil
+		},
+	}
+
+	svc, err := slackService.New(slackMock, "C1234567890")
+	gt.NoError(t, err)
+	return svc, &postedOptions
+}
+
+func setupTicketWithSlackThread(t *testing.T, ctx context.Context, repo *repository.Memory) *ticket.Ticket {
+	t.Helper()
+	testTicket := ticket.Ticket{
+		ID:       types.NewTicketID(),
+		Status:   types.TicketStatusOpen,
+		AlertIDs: []types.AlertID{types.NewAlertID()},
+		SlackThread: &slackModel.Thread{
+			ChannelID: "C1234567890",
+			ThreadID:  "1234567890.000000",
+		},
+	}
+	gt.NoError(t, repo.PutTicket(ctx, testTicket))
+
+	testAlert := alert.Alert{
+		ID:     testTicket.AlertIDs[0],
+		Schema: "test.alert",
+		Data:   map[string]any{"test": "data"},
+	}
+	gt.NoError(t, repo.PutAlert(ctx, testAlert))
+
+	return &testTicket
+}
+
+func TestBluebellChat_ContextBlock_ZeroEntries(t *testing.T) {
+	ctx := setupTestContext(t)
+	repo := repository.NewMemory()
+	testTicket := setupTicketWithSlackThread(t, ctx, repo)
+	knowledgeSvc := svcknowledge.New(repo, newMockEmbeddingClient())
+	slackSvc, postedOptions := newTestSlackService(t)
+
+	var mu sync.Mutex
+	sessionCount := 0
+	mockLLM := &mock.LLMClientMock{
+		NewSessionFunc: func(ctx context.Context, opts ...gollem.SessionOption) (gollem.Session, error) {
+			mu.Lock()
+			sessionCount++
+			sc := sessionCount
+			mu.Unlock()
+
+			ssn := newMockSession()
+			if sc == 1 {
+				// Resolver session (0 entries: resolver only)
+				ssn.GenerateFunc = func(ctx context.Context, input []gollem.Input, opts ...gollem.GenerateOption) (*gollem.Response, error) {
+					return &gollem.Response{
+						Texts: []string{`{"prompt_id":"default","intent":"Investigate root cause of the alert."}`},
+					}, nil
+				}
+			} else {
+				// Planning session
+				ssn.GenerateFunc = func(ctx context.Context, input []gollem.Input, opts ...gollem.GenerateOption) (*gollem.Response, error) {
+					return &gollem.Response{
+						Texts: []string{`{"message": "Direct response.", "tasks": []}`},
+					}, nil
+				}
+			}
+			return ssn, nil
+		},
+	}
+
+	chatUC, err := bluebell.New(repo, mockLLM,
+		bluebell.WithKnowledgeService(knowledgeSvc),
+		bluebell.WithSlackService(slackSvc),
+		// No WithPromptEntries — 0 entries, resolver still runs
+	)
+	gt.NoError(t, err)
+
+	err = chatUC.Execute(ctx, &chat.RunContext{
+		Session: newDummySession(testTicket.ID),
+		Message: "Investigate this alert",
+		ChatCtx: &chatModel.ChatContext{Ticket: testTicket},
+	})
+	gt.NoError(t, err)
+
+	// Verify context block with "(default)" was posted
+	found := false
+	for _, opt := range *postedOptions {
+		rendered := renderMsgOption(opt)
+		if strings.Contains(rendered, "Prompt:") && strings.Contains(rendered, "(default)") {
+			found = true
+			break
+		}
+	}
+	gt.True(t, found)
+}
+
+func TestBluebellChat_ContextBlock_WithPromptEntry(t *testing.T) {
+	ctx := setupTestContext(t)
+	repo := repository.NewMemory()
+	testTicket := setupTicketWithSlackThread(t, ctx, repo)
+	knowledgeSvc := svcknowledge.New(repo, newMockEmbeddingClient())
+	slackSvc, postedOptions := newTestSlackService(t)
+
+	entries := []config.PromptEntry{
+		{ID: "security", Name: "Security Investigation", Description: "Security threat investigation"},
+	}
+
+	var mu sync.Mutex
+	sessionCount := 0
+	mockLLM := &mock.LLMClientMock{
+		NewSessionFunc: func(ctx context.Context, opts ...gollem.SessionOption) (gollem.Session, error) {
+			mu.Lock()
+			sessionCount++
+			sc := sessionCount
+			mu.Unlock()
+
+			ssn := newMockSession()
+			if sc == 1 {
+				// Selector session
+				ssn.GenerateFunc = func(ctx context.Context, input []gollem.Input, opts ...gollem.GenerateOption) (*gollem.Response, error) {
+					return &gollem.Response{
+						Texts: []string{`{"prompt_id":"security","intent":"Investigate credential compromise."}`},
+					}, nil
+				}
+			} else {
+				// Planning session
+				ssn.GenerateFunc = func(ctx context.Context, input []gollem.Input, opts ...gollem.GenerateOption) (*gollem.Response, error) {
+					return &gollem.Response{
+						Texts: []string{`{"message": "Direct response.", "tasks": []}`},
+					}, nil
+				}
+			}
+			return ssn, nil
+		},
+	}
+
+	chatUC, err := bluebell.New(repo, mockLLM,
+		bluebell.WithKnowledgeService(knowledgeSvc),
+		bluebell.WithSlackService(slackSvc),
+		bluebell.WithPromptEntries(entries),
+	)
+	gt.NoError(t, err)
+
+	err = chatUC.Execute(ctx, &chat.RunContext{
+		Session: newDummySession(testTicket.ID),
+		Message: "Check suspicious login",
+		ChatCtx: &chatModel.ChatContext{Ticket: testTicket},
+	})
+	gt.NoError(t, err)
+
+	// Verify context block with prompt name was posted
+	found := false
+	for _, opt := range *postedOptions {
+		rendered := renderMsgOption(opt)
+		if strings.Contains(rendered, "Prompt:") && strings.Contains(rendered, "Security Investigation") {
+			found = true
+			break
+		}
+	}
+	gt.True(t, found)
+}
+
+func TestBluebellChat_ContextBlock_NoSlackThread(t *testing.T) {
+	ctx := setupTestContext(t)
+	repo := repository.NewMemory()
+	// Ticket WITHOUT SlackThread
+	testTicket := setupTicketAndAlert(t, ctx, repo)
+	knowledgeSvc := svcknowledge.New(repo, newMockEmbeddingClient())
+	slackSvc, postedOptions := newTestSlackService(t)
+
+	mockLLM := &mock.LLMClientMock{
+		NewSessionFunc: func(ctx context.Context, opts ...gollem.SessionOption) (gollem.Session, error) {
+			ssn := newMockSession()
+			ssn.GenerateFunc = func(ctx context.Context, input []gollem.Input, opts ...gollem.GenerateOption) (*gollem.Response, error) {
+				return &gollem.Response{
+					Texts: []string{`{"message": "Direct response.", "tasks": []}`},
+				}, nil
+			}
+			return ssn, nil
+		},
+	}
+
+	chatUC, err := bluebell.New(repo, mockLLM,
+		bluebell.WithKnowledgeService(knowledgeSvc),
+		bluebell.WithSlackService(slackSvc),
+	)
+	gt.NoError(t, err)
+
+	err = chatUC.Execute(ctx, &chat.RunContext{
+		Session: newDummySession(testTicket.ID),
+		Message: "Test without slack thread",
+		ChatCtx: &chatModel.ChatContext{Ticket: testTicket},
+	})
+	gt.NoError(t, err)
+
+	// No context block should be posted (no SlackThread)
+	for _, opt := range *postedOptions {
+		rendered := renderMsgOption(opt)
+		gt.V(t, strings.Contains(rendered, "Prompt:")).Equal(false)
+	}
+}
+
+// renderMsgOption extracts the blocks JSON from a slack.MsgOption for test assertions.
+func renderMsgOption(opt slack.MsgOption) string {
+	_, values, _ := slack.UnsafeApplyMsgOptions("", "", "", opt)
+	return values.Get("blocks")
 }
 
 func TestBluebellChat_Ticketless(t *testing.T) {

--- a/pkg/usecase/chat/bluebell/prompt/selector.md
+++ b/pkg/usecase/chat/bluebell/prompt/selector.md
@@ -1,11 +1,6 @@
 You are an intent resolver for a security operations system. Your task is to:
-{{ if .Prompts -}}
 1. Select the most appropriate investigation prompt
 2. Generate a situation-specific investigation directive based on the selected prompt
-{{ else -}}
-1. Detect XY problem mismatches between the user's question and the actual problem
-2. Generate a situation-specific investigation directive
-{{ end }}
 
 ## User Message
 {{ .Message }}
@@ -34,18 +29,16 @@ You are an intent resolver for a security operations system. Your task is to:
 {{ end }}
 {{ end }}
 
-{{ if .Prompts }}
 ## Available Prompts
 {{ range .Prompts }}
 - **{{ .ID }}**: {{ .Description }}
-{{ end }}
 {{ end }}
 
 ## Instructions
 
 ### Step 1: XY Problem Detection
 
-Before {{ if .Prompts }}selecting a prompt{{ else }}generating the directive{{ end }}, assess whether the user's stated question matches the actual problem indicated by the alert data and context.
+Before selecting a prompt, assess whether the user's stated question matches the actual problem indicated by the alert data and context.
 
 - **X (stated problem)**: What the user is literally asking
 - **Y (actual problem)**: What the alert data, context, and conversation history suggest the real issue is
@@ -56,7 +49,6 @@ Common patterns:
 - User focuses on a symptom while the root cause is visible in the context
 
 If X != Y, the resolved intent MUST address Y, not X. Briefly note the reframing so the planner understands the shift.
-{{ if .Prompts }}
 
 ### Step 2: Prompt Selection
 
@@ -75,17 +67,3 @@ Based on the selected prompt's description AND the specific situation, generate 
 Respond with JSON:
 - `prompt_id`: The selected prompt's id (or "default")
 - `intent`: The resolved investigation directive (2-5 sentences)
-{{ else }}
-
-### Step 2: Intent Resolution
-
-Based on the specific situation, generate a concise, actionable investigation directive. This directive should:
-- Address the actual problem (Y), not just the stated question (X)
-- If XY reframing occurred, briefly explain why (e.g., "User asked about IP reputation, but alert context indicates a deployment misconfiguration")
-- Be specific to THIS situation (not generic)
-- Tell the planner what to focus on and why
-
-Respond with JSON:
-- `prompt_id`: "default"
-- `intent`: The resolved investigation directive (2-5 sentences)
-{{ end }}

--- a/pkg/usecase/chat/bluebell/prompt/selector.md
+++ b/pkg/usecase/chat/bluebell/prompt/selector.md
@@ -1,6 +1,11 @@
 You are an intent resolver for a security operations system. Your task is to:
+{{ if .Prompts -}}
 1. Select the most appropriate investigation prompt
 2. Generate a situation-specific investigation directive based on the selected prompt
+{{ else -}}
+1. Detect XY problem mismatches between the user's question and the actual problem
+2. Generate a situation-specific investigation directive
+{{ end }}
 
 ## User Message
 {{ .Message }}
@@ -29,16 +34,18 @@ You are an intent resolver for a security operations system. Your task is to:
 {{ end }}
 {{ end }}
 
+{{ if .Prompts }}
 ## Available Prompts
 {{ range .Prompts }}
 - **{{ .ID }}**: {{ .Description }}
+{{ end }}
 {{ end }}
 
 ## Instructions
 
 ### Step 1: XY Problem Detection
 
-Before selecting a prompt, assess whether the user's stated question matches the actual problem indicated by the alert data and context.
+Before {{ if .Prompts }}selecting a prompt{{ else }}generating the directive{{ end }}, assess whether the user's stated question matches the actual problem indicated by the alert data and context.
 
 - **X (stated problem)**: What the user is literally asking
 - **Y (actual problem)**: What the alert data, context, and conversation history suggest the real issue is
@@ -49,6 +56,7 @@ Common patterns:
 - User focuses on a symptom while the root cause is visible in the context
 
 If X != Y, the resolved intent MUST address Y, not X. Briefly note the reframing so the planner understands the shift.
+{{ if .Prompts }}
 
 ### Step 2: Prompt Selection
 
@@ -67,3 +75,17 @@ Based on the selected prompt's description AND the specific situation, generate 
 Respond with JSON:
 - `prompt_id`: The selected prompt's id (or "default")
 - `intent`: The resolved investigation directive (2-5 sentences)
+{{ else }}
+
+### Step 2: Intent Resolution
+
+Based on the specific situation, generate a concise, actionable investigation directive. This directive should:
+- Address the actual problem (Y), not just the stated question (X)
+- If XY reframing occurred, briefly explain why (e.g., "User asked about IP reputation, but alert context indicates a deployment misconfiguration")
+- Be specific to THIS situation (not generic)
+- Tell the planner what to focus on and why
+
+Respond with JSON:
+- `prompt_id`: "default"
+- `intent`: The resolved investigation directive (2-5 sentences)
+{{ end }}

--- a/pkg/usecase/chat/bluebell/selector.go
+++ b/pkg/usecase/chat/bluebell/selector.go
@@ -83,53 +83,18 @@ func (c *BluebellChat) resolveIntent(ctx context.Context, message string, chatCt
 		return nil, goerr.Wrap(err, "failed to generate selector prompt")
 	}
 
-	switch len(c.promptEntries) {
-	case 0:
-		// No prompt entries: run resolver only (XY Detection + Intent Resolution)
-		logger.Debug("intent resolution: no prompt entries, running resolver only")
-		return c.resolveIntentDefault(ctx, selectorPrompt)
-	case 1:
-		// Single candidate: skip selection but still resolve intent
-		logger.Debug("intent resolution: single prompt entry", "prompt_id", c.promptEntries[0].ID)
+	logger.Debug("intent resolution: starting", "prompt_entries", len(c.promptEntries))
+
+	// For single candidate, skip selection but still resolve intent
+	if len(c.promptEntries) == 1 {
 		return c.resolveIntentForSinglePrompt(ctx, selectorPrompt, c.promptEntries[0])
-	default:
-		// Multiple candidates: selection + intent resolution in one LLM call
-		logger.Debug("intent resolution: multiple prompt entries", "count", len(c.promptEntries))
-		return c.resolveIntentWithSelection(ctx, selectorPrompt, c.promptEntries)
-	}
-}
-
-// resolveIntentDefault resolves intent without prompt selection (0 entries).
-// Runs XY Problem Detection and Intent Resolution only.
-func (c *BluebellChat) resolveIntentDefault(ctx context.Context, selectorPrompt string) (*ResolvedIntent, error) {
-	logger := logging.From(ctx)
-
-	session, err := c.llmClient.NewSession(ctx,
-		gollem.WithSessionContentType(gollem.ContentTypeJSON),
-		gollem.WithSessionResponseSchema(selectorSchema),
-		gollem.WithSessionSystemPrompt(selectorPrompt),
-	)
-	if err != nil {
-		return nil, goerr.Wrap(err, "failed to create resolver session")
 	}
 
-	resp, err := session.Generate(ctx, []gollem.Input{
-		gollem.Text("Detect XY problem and resolve the investigation intent."),
-	})
-	if err != nil {
-		return nil, goerr.Wrap(err, "failed to generate intent resolution")
-	}
-
-	resolved, err := parseSelectorResult(resp.Texts)
-	if err != nil {
-		logger.Warn("failed to parse resolver result for default, using empty intent", "error", err)
-		return &ResolvedIntent{PromptID: "default", Intent: ""}, nil
-	}
-
-	// Force prompt_id to "default" (no entries to select from)
-	resolved.PromptID = "default"
-	logger.Debug("intent resolved", "prompt_id", "default")
-	return resolved, nil
+	// 0 or 2+ candidates: run selector + intent resolution in one LLM call.
+	// When 0 entries, the template omits the prompt selection step and the LLM
+	// returns "default"; resolveIntentWithSelection handles this via the
+	// prompt_id == "default" pass-through.
+	return c.resolveIntentWithSelection(ctx, selectorPrompt, c.promptEntries)
 }
 
 // resolveIntentForSinglePrompt resolves intent for a single prompt candidate (no selection needed).
@@ -188,7 +153,7 @@ func (c *BluebellChat) resolveIntentWithSelection(ctx context.Context, selectorP
 	resolved, err := parseSelectorResult(resp.Texts)
 	if err != nil {
 		logger.Warn("failed to parse selector result, falling back to default", "error", err)
-		return nil, nil
+		return &ResolvedIntent{PromptID: "default", Intent: ""}, nil
 	}
 
 	// Validate the selected prompt_id exists and set name
@@ -204,7 +169,8 @@ func (c *BluebellChat) resolveIntentWithSelection(ctx context.Context, selectorP
 		if !found {
 			logger.Warn("selector returned unknown prompt_id, falling back to default",
 				"prompt_id", resolved.PromptID)
-			return nil, nil
+			resolved.PromptID = "default"
+			resolved.PromptName = ""
 		}
 	}
 

--- a/pkg/usecase/chat/bluebell/selector.go
+++ b/pkg/usecase/chat/bluebell/selector.go
@@ -55,11 +55,10 @@ type promptSummary struct {
 }
 
 // resolveIntent performs prompt selection and intent resolution.
-// Returns nil if no prompt entries are configured (default behavior).
+// When no prompt entries are configured, it still runs the resolver
+// (XY Problem Detection + Intent Resolution) without prompt selection.
 func (c *BluebellChat) resolveIntent(ctx context.Context, message string, chatCtx *chatModel.ChatContext) (*ResolvedIntent, error) {
-	if len(c.promptEntries) == 0 {
-		return nil, nil
-	}
+	logger := logging.From(ctx)
 
 	// Build selector template data — only id + description, NOT Content
 	summaries := make([]promptSummary, len(c.promptEntries))
@@ -76,7 +75,7 @@ func (c *BluebellChat) resolveIntent(ctx context.Context, message string, chatCt
 	tmplData := selectorTemplateData{
 		Message: message,
 		Context: ctxData,
-		Prompts: summaries,
+		Prompts: summaries, // empty when 0 entries — template adapts via {{ if .Prompts }}
 	}
 
 	selectorPrompt, err := prompt.GenerateWithStruct(ctx, selectorPromptTemplate, tmplData)
@@ -84,13 +83,53 @@ func (c *BluebellChat) resolveIntent(ctx context.Context, message string, chatCt
 		return nil, goerr.Wrap(err, "failed to generate selector prompt")
 	}
 
-	// For single candidate, skip selection but still resolve intent
-	if len(c.promptEntries) == 1 {
+	switch len(c.promptEntries) {
+	case 0:
+		// No prompt entries: run resolver only (XY Detection + Intent Resolution)
+		logger.Debug("intent resolution: no prompt entries, running resolver only")
+		return c.resolveIntentDefault(ctx, selectorPrompt)
+	case 1:
+		// Single candidate: skip selection but still resolve intent
+		logger.Debug("intent resolution: single prompt entry", "prompt_id", c.promptEntries[0].ID)
 		return c.resolveIntentForSinglePrompt(ctx, selectorPrompt, c.promptEntries[0])
+	default:
+		// Multiple candidates: selection + intent resolution in one LLM call
+		logger.Debug("intent resolution: multiple prompt entries", "count", len(c.promptEntries))
+		return c.resolveIntentWithSelection(ctx, selectorPrompt, c.promptEntries)
+	}
+}
+
+// resolveIntentDefault resolves intent without prompt selection (0 entries).
+// Runs XY Problem Detection and Intent Resolution only.
+func (c *BluebellChat) resolveIntentDefault(ctx context.Context, selectorPrompt string) (*ResolvedIntent, error) {
+	logger := logging.From(ctx)
+
+	session, err := c.llmClient.NewSession(ctx,
+		gollem.WithSessionContentType(gollem.ContentTypeJSON),
+		gollem.WithSessionResponseSchema(selectorSchema),
+		gollem.WithSessionSystemPrompt(selectorPrompt),
+	)
+	if err != nil {
+		return nil, goerr.Wrap(err, "failed to create resolver session")
 	}
 
-	// Multiple candidates: selection + intent resolution in one LLM call
-	return c.resolveIntentWithSelection(ctx, selectorPrompt, c.promptEntries)
+	resp, err := session.Generate(ctx, []gollem.Input{
+		gollem.Text("Detect XY problem and resolve the investigation intent."),
+	})
+	if err != nil {
+		return nil, goerr.Wrap(err, "failed to generate intent resolution")
+	}
+
+	resolved, err := parseSelectorResult(resp.Texts)
+	if err != nil {
+		logger.Warn("failed to parse resolver result for default, using empty intent", "error", err)
+		return &ResolvedIntent{PromptID: "default", Intent: ""}, nil
+	}
+
+	// Force prompt_id to "default" (no entries to select from)
+	resolved.PromptID = "default"
+	logger.Debug("intent resolved", "prompt_id", "default")
+	return resolved, nil
 }
 
 // resolveIntentForSinglePrompt resolves intent for a single prompt candidate (no selection needed).

--- a/pkg/usecase/chat/bluebell/selector_test.go
+++ b/pkg/usecase/chat/bluebell/selector_test.go
@@ -188,7 +188,10 @@ func TestResolveIntent_UnknownPromptID_Fallback(t *testing.T) {
 	}
 
 	resolved := bluebell.ExportResolveIntent(ctx, chat, "test", chatCtx)
-	gt.V(t, resolved == nil).Equal(true) // fallback to nil
+	gt.V(t, resolved).NotNil()
+	gt.V(t, resolved.PromptID).Equal("default")   // falls back to default
+	gt.V(t, resolved.Intent).Equal("something")    // intent is preserved from LLM response
+	gt.V(t, resolved.PromptName).Equal("")          // name cleared on fallback
 }
 
 func TestResolveIntent_InvalidJSON_Fallback(t *testing.T) {
@@ -224,7 +227,9 @@ func TestResolveIntent_InvalidJSON_Fallback(t *testing.T) {
 	}
 
 	resolved := bluebell.ExportResolveIntent(ctx, chat, "test", chatCtx)
-	gt.V(t, resolved == nil).Equal(true) // fallback to nil
+	gt.V(t, resolved).NotNil()
+	gt.V(t, resolved.PromptID).Equal("default") // falls back to default
+	gt.V(t, resolved.Intent).Equal("")           // empty intent on parse failure
 }
 
 func TestResolveIntent_DefaultPromptID_Accepted(t *testing.T) {

--- a/pkg/usecase/chat/bluebell/selector_test.go
+++ b/pkg/usecase/chat/bluebell/selector_test.go
@@ -60,7 +60,7 @@ func TestResolveIntent_ZeroCandidates(t *testing.T) {
 	}
 	knowledgeSvc := svcknowledge.New(repo, embMock)
 
-	mockLLM := newSelectorMockLLM(`{"prompt_id":"default","intent":"test"}`)
+	mockLLM := newSelectorMockLLM(`{"prompt_id":"default","intent":"Investigate the root cause of the alert."}`)
 
 	chat, err := bluebell.New(repo, mockLLM,
 		bluebell.WithKnowledgeService(knowledgeSvc),
@@ -72,8 +72,11 @@ func TestResolveIntent_ZeroCandidates(t *testing.T) {
 		Ticket: &ticket.Ticket{ID: types.NewTicketID()},
 	}
 
+	// With 0 entries, resolver still runs (XY Detection + Intent Resolution)
 	resolved := bluebell.ExportResolveIntent(ctx, chat, "test message", chatCtx)
-	gt.V(t, resolved == nil).Equal(true) // no LLM call, nil returned
+	gt.V(t, resolved).NotNil()
+	gt.V(t, resolved.PromptID).Equal("default")
+	gt.V(t, resolved.Intent).Equal("Investigate the root cause of the alert.")
 }
 
 func TestResolveIntent_SingleCandidate(t *testing.T) {


### PR DESCRIPTION
## Summary
- `resolveIntent()` が `promptEntries == 0` で即座にスキップしていたため、Resolver（XY Problem Detection + Intent Resolution）も実行されず、context block も投稿されなかった
- 0 entries 時も Resolver を実行する `resolveIntentDefault()` を追加し、結果を context block で投稿するよう修正
- context block のラベルをバッククォートで囲む形式に変更: `📋 Prompt: \`label\``

## Changes
- `selector.go`: `resolveIntentDefault` 新設、`resolveIntent` を switch で 0/1/2+ entries を分岐、debug ログ追加
- `prompt/selector.md`: `{{ if .Prompts }}` で 0 entries 対応（Step 2: Prompt Selection をスキップ）
- `bluebell.go`: フォールバックラベルを `(default)` に変更、バッククォート付き
- `bluebell_test.go`: context block 投稿の 3 テスト追加（0 entries / 1 entry / no SlackThread）
- `selector_test.go`: 0 entries テストが resolver 実行を検証するよう修正

## Test plan
- [x] `TestResolveIntent_ZeroCandidates` — 0 entries で resolver が動作し intent が返る
- [x] `TestBluebellChat_ContextBlock_ZeroEntries` — 0 entries で `📋 Prompt: \`(default)\`` が投稿される
- [x] `TestBluebellChat_ContextBlock_WithPromptEntry` — 1 entry で `📋 Prompt: \`Security Investigation\`` が投稿される
- [x] `TestBluebellChat_ContextBlock_NoSlackThread` — SlackThread なしで context block が投稿されない
- [x] 既存テスト全 pass、lint/vet/gosec clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)