### PR TITLE
feat: add eval framework for scenario-based agent evaluation

### DIFF
--- a/.claude/skills/create-eval-scenario/SKILL.md
+++ b/.claude/skills/create-eval-scenario/SKILL.md
@@ -129,7 +129,19 @@ At minimum, create:
 1. **Ingest policy** (`policy/ingest.rego`) — transforms raw alert data into Warren Alert objects
    - Package: `data.ingest.<schema_name>` (must match `alert.schema` in scenario.yaml)
    - Input: the alert data from `alert.data`
-   - Output: array of alert objects with title, description, attributes
+   - Output: array of alert objects with title, description
+   - **CRITICAL: Always pass through the full raw data via `"data": input`** so the agent has access to all IoCs (IPs, hashes, domains, etc.). Without this, the agent will lack concrete indicators and ask questions instead of investigating.
+   
+   Example:
+   ```rego
+   alerts contains {
+       "title": title,
+       "description": description,
+       "data": input,
+   } if {
+       # ... conditions and formatting ...
+   }
+   ```
 
 2. **Triage policy** (`policy/triage.rego`) — determines publish type and metadata
    - Package: `data.triage`

--- a/.claude/skills/create-eval-scenario/SKILL.md
+++ b/.claude/skills/create-eval-scenario/SKILL.md
@@ -1,0 +1,262 @@
+---
+name: create-eval-scenario
+description: Create an evaluation scenario folder for warren eval. Use when the user wants to create a new test scenario for agent evaluation, or asks to generate scenario data for eval testing.
+allowed-tools: Read, Write, Bash(ls:*), Bash(cat:*), Glob, Grep, Agent
+---
+
+# Create Evaluation Scenario
+
+Generate a scenario folder for `warren eval` command. A scenario defines an alert, the world context for mock tool responses, and expected evaluation criteria.
+
+## Step 1: Understand the scenario
+
+Ask the user or infer from context:
+- What kind of security alert? (e.g., SSH login from Tor, suspicious file download, IAM privilege escalation)
+- What schema? (e.g., gcp_scc, aws_guardduty, falco)
+- What should the agent find? (expected outcome)
+- Which tools should be called? (trajectory expectations)
+
+## Step 2: Explore available tool specs
+
+Read the tool definitions to understand what tools are available and their arguments:
+
+```bash
+ls pkg/tool/
+```
+
+For each relevant tool, check its `Specs()` to understand the tool's interface:
+
+```
+Read pkg/tool/<tool_name>/tool.go
+```
+
+## Step 3: Create scenario folder structure
+
+Create the following structure:
+
+```
+<scenario_dir>/
+  scenario.yaml
+  policy/                          (Rego policies for ingest/enrich/triage)
+    ingest.rego
+    triage.rego
+    enrich.rego                    (optional)
+  responses/
+    <tool_name>__<args_hash>.json  (for deterministic tools)
+  traces/                          (auto-created by eval run)
+```
+
+### scenario.yaml template
+
+```yaml
+name: <descriptive_slug>
+description: "<One-line description>"
+
+alert:
+  schema: "<schema_name>"
+  data:
+    # Alert payload matching the schema
+
+world:
+  description: |
+    <Detailed description of the scenario world.
+    Include specific IPs, hostnames, users, timestamps, and behaviors.
+    This is fed to the mock LLM to generate consistent tool responses.>
+
+  tool_hints:
+    # Only for tools that need specific guidance
+    bigquery: |
+      Available tables and their schemas.
+      Expected data patterns.
+    virustotal: |
+      Reputation data for relevant IPs/domains/hashes.
+
+initial_message: "Investigate this alert"
+
+config:
+  policy_dir: "policy"                    # Rego policies (required)
+  # bigquery_configs:                     # BigQuery dataset/table YAML configs
+  #   - "bigquery/config.yaml"
+  # bigquery_runbooks:                    # BigQuery SQL runbook files/directories
+  #   - "bigquery/runbooks"
+  # github_configs:                       # GitHub repository config YAMLs
+  #   - "github/config.yaml"
+  # user_system_prompt: "prompt/system.md" # User system prompt (markdown)
+
+expectations:
+  outcome:
+    finding_must_contain:
+      - "<keyword1>"
+    severity: "<expected_severity>"
+    criteria:
+      - "<LLM judge criterion 1>"
+      - "<LLM judge criterion 2>"
+
+  trajectory:
+    must_call:
+      - <tool1>
+      - <tool2>
+    must_not_call:
+      - <irrelevant_tool>
+    ordered_calls:
+      - <tool_to_call_first>
+      - <tool_to_call_second>
+
+  efficiency:
+    max_total_calls: 20
+    max_duplicate_calls: 3
+```
+
+## Step 3.5: Create Rego policy files
+
+Create Rego policies in `<scenario_dir>/policy/`. These are evaluated by the pipeline during `HandleAlert`.
+
+Look at existing policy examples in the codebase for the correct format:
+
+```bash
+ls pkg/usecase/testdata/*.rego
+```
+
+Read a few examples to understand the policy structure:
+
+```
+Read pkg/usecase/testdata/ingest_test.rego
+Read pkg/usecase/testdata/triage_basic.rego
+```
+
+At minimum, create:
+
+1. **Ingest policy** (`policy/ingest.rego`) — transforms raw alert data into Warren Alert objects
+   - Package: `data.ingest.<schema_name>` (must match `alert.schema` in scenario.yaml)
+   - Input: the alert data from `alert.data`
+   - Output: array of alert objects with title, description, attributes
+
+2. **Triage policy** (`policy/triage.rego`) — determines publish type and metadata
+   - Package: `data.triage`
+   - Input: alert + enrich results
+   - Output: publish type (alert/notice/discard), title, description, severity
+
+3. **Enrich policy** (`policy/enrich.rego`, optional) — defines enrichment tasks
+   - Package: `data.enrich`
+   - Only needed if you want the pipeline to run enrichment before triage
+
+## Step 4: Create pre-defined response files
+
+For deterministic tools (VT, OTX, Shodan, etc.), create response files in `responses/`:
+
+Each file is a JSON object:
+```json
+{
+  "tool_name": "<tool_name>",
+  "args": { <the exact args the tool would be called with> },
+  "response": { <realistic response data> }
+}
+```
+
+File naming: `<tool_name>__<first_8_chars_of_sha256_of_normalized_args>.json`
+
+To compute the hash, normalize args by:
+1. Sort map keys recursively
+2. Exclude nil values
+3. JSON marshal → SHA256 → first 8 hex chars
+
+For non-deterministic tools (BigQuery, Slack search), do NOT create response files. The MockAgent will generate them at runtime using the world description.
+
+## Step 5: Validate the scenario (MANDATORY)
+
+After creating all files, **ALWAYS** run the warren validate command to check the scenario:
+
+```bash
+go run . eval validate -s <scenario_dir>
+```
+
+This validates:
+- Required fields (name, alert.schema, alert.data, initial_message, world.description)
+- Trajectory consistency (must_call vs must_not_call overlap, ordered_calls subset)
+- Efficiency thresholds are non-negative
+- Response files: valid JSON, tool_name present, response present, filename matches tool_name prefix
+
+**Do NOT report the scenario as complete until validation passes.** If validation fails, fix all reported errors and re-run.
+
+## Step 6: Look up the latest Gemini model (MANDATORY)
+
+Before generating the run command, **search the web** for the latest available Gemini model on Vertex AI:
+
+```
+WebSearch "Vertex AI Gemini latest model ID site:cloud.google.com"
+```
+
+Check the official docs to find the current stable/preview model name (e.g., `gemini-2.5-flash`, `gemini-3-flash-preview`). Also determine the correct `--gemini-location` — newer preview models may only be available in `global`, not regional endpoints like `us-central1`.
+
+## Step 7: Show the run command (MANDATORY)
+
+After validation passes, **ALWAYS** present the exact command to run the scenario. Read the scenario's `config` section and generate CLI flags pointing to the scenario's config files.
+
+Build the command by mapping `config` fields to CLI flags:
+
+| config field | CLI flag |
+|---|---|
+| `policy_dir` | `--policy <scenario_dir>/<value>` |
+| `bigquery_configs` | `--bigquery-config <scenario_dir>/<value>` (repeat per entry) |
+| `bigquery_runbooks` | `--bigquery-runbook-path <scenario_dir>/<value>` (repeat per entry) |
+| `github_configs` | `--github-app-config <scenario_dir>/<value>` (repeat per entry) |
+| `user_system_prompt` | `--user-system-prompt <scenario_dir>/<value>` |
+
+Use the model name and location found in Step 6 for `--gemini-model` and `--gemini-location`.
+
+Example output:
+
+```bash
+go run . eval run -s <scenario_dir> \
+  --policy <scenario_dir>/policy \
+  --bigquery-config <scenario_dir>/bigquery/config.yaml \
+  --gemini-project-id <PROJECT_ID> \
+  --gemini-model <LATEST_MODEL> \
+  --gemini-location <LOCATION> \
+  -o report.md -f markdown
+```
+
+Only include flags for config fields that are actually set in the scenario. Replace `<PROJECT_ID>` with the user's GCP project ID.
+
+## Tips
+
+- The `world.description` is the most important field. It defines the "ground truth" that all mock responses must be consistent with. Be specific about IPs, timestamps, usernames, and behaviors.
+- `tool_hints` are optional but help the mock LLM generate better responses for complex tools like BigQuery (include table schemas).
+- Start with 2-3 pre-defined response files for the most predictable tools, and let the MockAgent handle the rest.
+- `expectations.criteria` are evaluated by LLM-as-Judge. Write them as specific, verifiable statements about what the agent should conclude.
+
+## Critical: Avoid agent questions
+
+In eval CLI mode, the agent cannot ask questions to the user (no presenter available). If the agent asks a question, the eval run will fail with `"question requires a presenter but none is available"`.
+
+**To prevent this, the `alert.data` MUST contain specific, concrete IoCs** (Indicators of Compromise). The agent asks questions when it lacks enough information to investigate. Include:
+
+- Specific IP addresses, domain names, file hashes in the alert payload
+- Process names, container IDs, user accounts involved
+- Timestamps and event categories (e.g., MITRE ATT&CK technique IDs)
+- Any detection-specific fields the schema would normally contain
+
+**Bad** (too vague — agent will ask for details):
+```yaml
+alert:
+  data:
+    finding:
+      category: "SUSPICIOUS_PROCESS"
+      description: "Suspicious process detected in GKE pod"
+```
+
+**Good** (specific — agent can investigate immediately):
+```yaml
+alert:
+  data:
+    finding:
+      category: "Malware: Cryptomining Bad IP"
+      sourceProperties:
+        sourceIp: "185.122.204.197"
+        destIp: "10.128.0.45"
+        processName: "xmrig"
+        sha256: "440784338980838b939e663675c2e17e3f81df68853b8214b62f84090940428d"
+        podName: "web-frontend-7d8f9b6c4-x2j9k"
+        containerName: "nginx"
+        projectId: "my-project"
+```

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,7 +38,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
-    "dompurify": "^3.3.3",
+    "dompurify": "^3.4.0",
     "graphql": "^16.13.2",
     "lucide-react": "^0.511.0",
     "react": "^19.2.4",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -72,8 +72,8 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       dompurify:
-        specifier: ^3.3.3
-        version: 3.3.3
+        specifier: ^3.4.0
+        version: 3.4.0
       graphql:
         specifier: ^16.13.2
         version: 16.13.2
@@ -2076,8 +2076,8 @@ packages:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
 
-  dompurify@3.3.3:
-    resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
+  dompurify@3.4.0:
+    resolution: {integrity: sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==}
 
   dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
@@ -6067,7 +6067,7 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
-  dompurify@3.3.3:
+  dompurify@3.4.0:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/m-mizutani/clog v0.2.1
 	github.com/m-mizutani/fireconf v0.2.1
 	github.com/m-mizutani/goerr/v2 v2.0.1
-	github.com/m-mizutani/gollem v0.24.3-0.20260414085700-70cb3cf18589
+	github.com/m-mizutani/gollem v0.24.2
 	github.com/m-mizutani/gt v0.2.1
 	github.com/m-mizutani/harlog v0.0.3
 	github.com/m-mizutani/masq v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -268,8 +268,6 @@ github.com/m-mizutani/goerr/v2 v2.0.1 h1:Z0XZiliOcCw/qoPR8dEle0xMQw781UmvlySbDHE
 github.com/m-mizutani/goerr/v2 v2.0.1/go.mod h1:Ax59zs+j3NmzB/mPLc1w3g4yIutdrwcY7cB6IRO18EU=
 github.com/m-mizutani/gollem v0.24.2 h1:2mDHBoiFHQosj4KqDUEmQsmAR/MJKVP8UOgtneS8QOU=
 github.com/m-mizutani/gollem v0.24.2/go.mod h1:P1XLm5TS81vErrpu6hGhOL8UCkdXiFvQmSt+eayi8Hk=
-github.com/m-mizutani/gollem v0.24.3-0.20260414085700-70cb3cf18589 h1:wDHhO4naE+8Zqg7awFif5hEqXlXU0O4w5rzvphC6Ot8=
-github.com/m-mizutani/gollem v0.24.3-0.20260414085700-70cb3cf18589/go.mod h1:P1XLm5TS81vErrpu6hGhOL8UCkdXiFvQmSt+eayi8Hk=
 github.com/m-mizutani/gt v0.2.1 h1:mOl1PPIgEHoW2rQgqkfE31OGID06dO2uly8X8kvOEVY=
 github.com/m-mizutani/gt v0.2.1/go.mod h1:0MPYSfGBLmYjTduzADVmIqD58ELQ5IfBFiK/f0FmB3k=
 github.com/m-mizutani/harlog v0.0.3 h1:bL3i/xM3wWPsvoOOsuu/a4eaz+1yj1UyO7OPUzkWPyU=

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -54,6 +54,7 @@ func Run(ctx context.Context, args []string) error {
 			cmdAlert(),
 			cmdMigrate(),
 			cmdRefine(),
+			cmdEval(),
 		},
 	}
 

--- a/pkg/cli/eval.go
+++ b/pkg/cli/eval.go
@@ -242,7 +242,7 @@ func cmdEvalRun() *cli.Command {
 			// Write output
 			var w io.Writer = os.Stdout
 			if outputPath != "" {
-				f, err := os.Create(outputPath)
+				f, err := os.Create(outputPath) // #nosec G304 -- path from CLI flag
 				if err != nil {
 					return goerr.Wrap(err, "failed to create output file",
 						goerr.V("path", outputPath))

--- a/pkg/cli/eval.go
+++ b/pkg/cli/eval.go
@@ -1,0 +1,266 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/m-mizutani/goerr/v2"
+
+	gollemTrace "github.com/m-mizutani/gollem/trace"
+	traceAdapter "github.com/secmon-lab/warren/pkg/adapter/trace"
+	"github.com/secmon-lab/warren/pkg/cli/config"
+	"github.com/secmon-lab/warren/pkg/domain/model/eval"
+	"github.com/secmon-lab/warren/pkg/repository"
+	"github.com/secmon-lab/warren/pkg/usecase"
+	evalUC "github.com/secmon-lab/warren/pkg/usecase/eval"
+	"github.com/secmon-lab/warren/pkg/utils/logging"
+	"github.com/secmon-lab/warren/pkg/utils/safe"
+	"github.com/urfave/cli/v3"
+)
+
+func cmdEval() *cli.Command {
+	return &cli.Command{
+		Name:    "eval",
+		Aliases: []string{"e"},
+		Usage:   "Evaluate agent behavior with scenarios",
+		Commands: []*cli.Command{
+			cmdEvalRun(),
+			cmdEvalValidate(),
+		},
+	}
+}
+
+func cmdEvalValidate() *cli.Command {
+	var scenarioDir string
+
+	return &cli.Command{
+		Name:    "validate",
+		Aliases: []string{"v"},
+		Usage:   "Validate a scenario directory without running it",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:        "scenario",
+				Aliases:     []string{"s"},
+				Usage:       "Path to scenario directory",
+				Required:    true,
+				Destination: &scenarioDir,
+			},
+		},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			errors := evalUC.ValidateScenarioDir(scenarioDir)
+			if len(errors) == 0 {
+				fmt.Println("✅ Scenario is valid")
+				return nil
+			}
+
+			fmt.Printf("❌ Scenario validation failed (%d errors):\n", len(errors))
+			for _, e := range errors {
+				fmt.Printf("  - %s\n", e)
+			}
+			return goerr.New("scenario validation failed",
+				goerr.V("scenario_dir", scenarioDir),
+				goerr.V("error_count", len(errors)),
+			)
+		},
+	}
+}
+
+func cmdEvalRun() *cli.Command {
+	var (
+		scenarioDir  string
+		mode         string
+		outputPath   string
+		outputFormat string
+
+		policyCfg           config.Policy
+		llmCfg              config.LLMCfg
+		storageCfg          config.Storage
+		userSystemPromptCfg config.UserSystemPrompt
+	)
+
+	flags := joinFlags(
+		[]cli.Flag{
+			&cli.StringFlag{
+				Name:        "scenario",
+				Aliases:     []string{"s"},
+				Usage:       "Path to scenario directory",
+				Required:    true,
+				Destination: &scenarioDir,
+			},
+			&cli.StringFlag{
+				Name:        "mode",
+				Aliases:     []string{"m"},
+				Usage:       "Execution mode: cli (default) or slack",
+				Value:       "cli",
+				Destination: &mode,
+			},
+			&cli.StringFlag{
+				Name:        "output",
+				Aliases:     []string{"o"},
+				Usage:       "Output file path (default: stdout)",
+				Destination: &outputPath,
+			},
+			&cli.StringFlag{
+				Name:        "output-format",
+				Aliases:     []string{"f"},
+				Usage:       "Output format: markdown (default) or json",
+				Value:       "markdown",
+				Destination: &outputFormat,
+			},
+		},
+		policyCfg.Flags(),
+		llmCfg.Flags(),
+		tools.Flags(),
+		storageCfg.Flags(),
+		userSystemPromptCfg.Flags(),
+	)
+
+	return &cli.Command{
+		Name:    "run",
+		Aliases: []string{"r"},
+		Usage:   "Run an evaluation scenario",
+		Flags:   flags,
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			logger := logging.From(ctx)
+
+			// Validate scenario first
+			validationErrors := evalUC.ValidateScenarioDir(scenarioDir)
+			if len(validationErrors) > 0 {
+				fmt.Printf("❌ Scenario validation failed (%d errors):\n", len(validationErrors))
+				for _, e := range validationErrors {
+					fmt.Printf("  - %s\n", e)
+				}
+				return goerr.New("scenario validation failed, cannot run eval")
+			}
+
+			logger.Info("eval: starting",
+				"scenario", scenarioDir,
+				"output", outputPath,
+				"format", outputFormat,
+			)
+
+			// Load scenario
+			scenario, err := evalUC.LoadScenario(scenarioDir)
+			if err != nil {
+				return err
+			}
+			logger.Info("eval: scenario loaded", "name", scenario.Name)
+
+			// Configure policy
+			policyClient, err := policyCfg.Configure()
+			if err != nil {
+				return goerr.Wrap(err, "failed to configure policy")
+			}
+
+			// Configure LLM (used for both Warren agent and mock/eval)
+			llmClient, err := llmCfg.Configure(ctx)
+			if err != nil {
+				return goerr.Wrap(err, "failed to configure LLM")
+			}
+
+			// Configure embedding
+			embeddingClient, err := llmCfg.ConfigureEmbeddingClient(ctx)
+			if err != nil {
+				return goerr.Wrap(err, "failed to configure embedding client")
+			}
+
+			// Use memory repository (no Firestore for eval)
+			repo := repository.NewMemory()
+
+			// Configure tools
+			tools.InjectDependencies(repo, embeddingClient)
+			toolSets, err := tools.ToolSets(ctx)
+			if err != nil {
+				return goerr.Wrap(err, "failed to configure tools")
+			}
+
+			// Configure user system prompt
+			userSystemPrompt, err := userSystemPromptCfg.Configure()
+			if err != nil {
+				return goerr.Wrap(err, "failed to configure user system prompt")
+			}
+
+			// Configure gollem trace repository — save to scenario's traces/ dir
+			tracesDir := filepath.Join(scenarioDir, "traces")
+			fileTraceRepo := gollemTrace.NewFileRepository(tracesDir)
+			safeTraceRepo := traceAdapter.NewSafe(fileTraceRepo, logging.From(ctx))
+			logger.Info("eval: trace recording enabled", "traces_dir", tracesDir)
+
+			// Build usecase options (tools will be wrapped by Runner)
+			ucOpts := []usecase.Option{
+				usecase.WithLLMClient(llmClient),
+				usecase.WithPolicyClient(policyClient),
+				usecase.WithRepository(repo),
+				usecase.WithNoAuthorization(true),
+				usecase.WithUserSystemPrompt(userSystemPrompt),
+				usecase.WithTraceRepository(safeTraceRepo),
+			}
+
+			// Create and run eval
+			runner, err := evalUC.NewRunner(
+				ctx,
+				scenario,
+				scenarioDir,
+				llmClient,
+				ucOpts,
+				toolSets,
+				evalUC.WithLLMClientForEval(llmClient),
+			)
+			if err != nil {
+				return goerr.Wrap(err, "failed to create eval runner")
+			}
+
+			var evalResult *eval.EvalResult
+			switch mode {
+			case "cli":
+				evalResult, err = runner.RunCLI(ctx)
+				if err != nil {
+					return goerr.Wrap(err, "eval CLI run failed")
+				}
+			case "slack":
+				_, slackErr := runner.RunSlack(ctx)
+				return slackErr
+			default:
+				return goerr.New("unknown eval mode", goerr.V("mode", mode))
+			}
+
+			// Determine report format
+			format := eval.ReportFormatMarkdown
+			if outputFormat == "json" {
+				format = eval.ReportFormatJSON
+			}
+
+			// Generate report
+			report, err := evalUC.GenerateReport(ctx, evalResult, format, llmClient)
+			if err != nil {
+				return goerr.Wrap(err, "failed to generate report")
+			}
+
+			// Write output
+			var w io.Writer = os.Stdout
+			if outputPath != "" {
+				f, err := os.Create(outputPath)
+				if err != nil {
+					return goerr.Wrap(err, "failed to create output file",
+						goerr.V("path", outputPath))
+				}
+				defer safe.Close(ctx, f)
+				w = f
+			}
+
+			if _, err := fmt.Fprint(w, report.Content); err != nil {
+				return goerr.Wrap(err, "failed to write report")
+			}
+
+			logger.Info("eval: completed",
+				"scenario", scenario.Name,
+				"tool_calls", len(evalResult.Trace.ToolCalls),
+			)
+
+			return nil
+		},
+	}
+}

--- a/pkg/cli/eval.go
+++ b/pkg/cli/eval.go
@@ -242,7 +242,7 @@ func cmdEvalRun() *cli.Command {
 			// Write output
 			var w io.Writer = os.Stdout
 			if outputPath != "" {
-				f, err := os.Create(outputPath) // #nosec G304 -- path from CLI flag
+				f, err := os.Create(filepath.Clean(outputPath))
 				if err != nil {
 					return goerr.Wrap(err, "failed to create output file",
 						goerr.V("path", outputPath))

--- a/pkg/domain/model/eval/scenario.go
+++ b/pkg/domain/model/eval/scenario.go
@@ -1,0 +1,263 @@
+package eval
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/secmon-lab/warren/pkg/domain/types"
+)
+
+// Scenario represents a loaded evaluation scenario (single scenario.yaml).
+type Scenario struct {
+	Name           string        `yaml:"name"`
+	Description    string        `yaml:"description"`
+	Alert          AlertConfig   `yaml:"alert"`
+	World          WorldConfig   `yaml:"world"`
+	InitialMessage string        `yaml:"initial_message"`
+	Config         ScenarioConfig `yaml:"config"`
+	Slack          *SlackConfig  `yaml:"slack"`
+	Expectations   *Expectations `yaml:"expectations"`
+}
+
+// ScenarioConfig holds paths to config files relative to the scenario directory.
+// All paths are resolved relative to the scenario folder at load time.
+type ScenarioConfig struct {
+	PolicyDir            string   `yaml:"policy_dir"`              // Rego policy directory (required for pipeline)
+	BigQueryConfigs      []string `yaml:"bigquery_configs"`        // BigQuery dataset/table YAML configs
+	BigQueryRunbooks     []string `yaml:"bigquery_runbooks"`       // BigQuery SQL runbook files/directories
+	GitHubConfigs        []string `yaml:"github_configs"`          // GitHub repository config YAMLs
+	UserSystemPrompt     string   `yaml:"user_system_prompt"`      // User system prompt file (markdown)
+}
+
+// AlertConfig defines the alert to inject into the pipeline.
+type AlertConfig struct {
+	Schema types.AlertSchema `yaml:"schema"`
+	Data   any               `yaml:"data"`
+}
+
+// WorldConfig defines the mock world for dynamic response generation.
+type WorldConfig struct {
+	Description string            `yaml:"description"`
+	ToolHints   map[string]string `yaml:"tool_hints"`
+}
+
+// SlackConfig holds Slack simulation settings.
+type SlackConfig struct {
+	Channel string `yaml:"channel"`
+}
+
+// Expectations defines the 3-layer evaluation criteria.
+type Expectations struct {
+	Outcome    *OutcomeExpectation    `yaml:"outcome"`
+	Trajectory *TrajectoryExpectation `yaml:"trajectory"`
+	Efficiency *EfficiencyExpectation `yaml:"efficiency"`
+}
+
+// OutcomeExpectation — Layer A: result evaluation.
+type OutcomeExpectation struct {
+	FindingMustContain []string `yaml:"finding_must_contain"`
+	Severity           string   `yaml:"severity"`
+	Criteria           []string `yaml:"criteria"`
+}
+
+// TrajectoryExpectation — Layer B: tool call sequence evaluation.
+type TrajectoryExpectation struct {
+	MustCall     []string `yaml:"must_call"`
+	MustNotCall  []string `yaml:"must_not_call"`
+	OrderedCalls []string `yaml:"ordered_calls"`
+}
+
+// EfficiencyExpectation — Layer C: resource usage evaluation.
+type EfficiencyExpectation struct {
+	MaxTotalCalls     int `yaml:"max_total_calls"`
+	MaxDuplicateCalls int `yaml:"max_duplicate_calls"`
+}
+
+// Validate checks the Scenario for structural and logical consistency.
+// Returns a list of validation errors (empty = valid).
+func (s *Scenario) Validate() []string {
+	var errors []string
+
+	if s.Name == "" {
+		errors = append(errors, "name is required")
+	}
+	if s.Alert.Schema == "" {
+		errors = append(errors, "alert.schema is required")
+	}
+	if s.Alert.Data == nil {
+		errors = append(errors, "alert.data is required")
+	}
+	if s.InitialMessage == "" {
+		errors = append(errors, "initial_message is required")
+	}
+	if s.World.Description == "" {
+		errors = append(errors, "world.description is required (mock agent needs scenario context)")
+	}
+	if s.Config.PolicyDir == "" {
+		errors = append(errors, "config.policy_dir is required (pipeline needs Rego policies)")
+	}
+
+	if s.Expectations != nil {
+		errors = append(errors, s.Expectations.Validate()...)
+	}
+
+	return errors
+}
+
+// Validate checks Expectations for logical consistency.
+func (e *Expectations) Validate() []string {
+	var errors []string
+
+	if e.Trajectory != nil {
+		mustCallSet := make(map[string]bool)
+		for _, t := range e.Trajectory.MustCall {
+			mustCallSet[t] = true
+		}
+		for _, t := range e.Trajectory.MustNotCall {
+			if mustCallSet[t] {
+				errors = append(errors, fmt.Sprintf("tool %q appears in both must_call and must_not_call", t))
+			}
+		}
+		if len(e.Trajectory.MustCall) > 0 && len(e.Trajectory.OrderedCalls) > 0 {
+			for _, t := range e.Trajectory.OrderedCalls {
+				if !mustCallSet[t] {
+					errors = append(errors, fmt.Sprintf("ordered_calls tool %q is not in must_call", t))
+				}
+			}
+		}
+	}
+
+	if e.Efficiency != nil {
+		if e.Efficiency.MaxTotalCalls < 0 {
+			errors = append(errors, "efficiency.max_total_calls must be non-negative")
+		}
+		if e.Efficiency.MaxDuplicateCalls < 0 {
+			errors = append(errors, "efficiency.max_duplicate_calls must be non-negative")
+		}
+	}
+
+	return errors
+}
+
+// Validate checks a ResponseFile for structural correctness.
+// filename is the on-disk filename (e.g., "virustotal__a3f2b1c9.json") for prefix checking.
+func (rf *ResponseFile) Validate(filename string) []string {
+	var errors []string
+
+	if rf.ToolName == "" {
+		errors = append(errors, fmt.Sprintf("responses/%s: tool_name is required", filename))
+	}
+	if rf.Response == nil {
+		errors = append(errors, fmt.Sprintf("responses/%s: response is required", filename))
+	}
+	if rf.ToolName != "" {
+		expectedPrefix := rf.ToolName + "__"
+		if !strings.HasPrefix(filename, expectedPrefix) {
+			errors = append(errors, fmt.Sprintf("responses/%s: filename should start with %q (got tool_name=%q)", filename, expectedPrefix, rf.ToolName))
+		}
+	}
+
+	return errors
+}
+
+// ResponseSource indicates where a tool response came from.
+type ResponseSource string
+
+const (
+	ResponseSourcePreDefined ResponseSource = "pre_defined"
+	ResponseSourceGenerated  ResponseSource = "generated"
+)
+
+// ToolCallRecord records a single tool invocation during evaluation.
+type ToolCallRecord struct {
+	Sequence   int            `json:"sequence"`
+	ToolName   string         `json:"tool_name"`
+	Args       map[string]any `json:"args"`
+	Response   map[string]any `json:"response"`
+	Source     ResponseSource `json:"source"`
+	Duration   time.Duration  `json:"duration"`
+	TokensUsed int64          `json:"tokens_used,omitempty"`
+}
+
+// PipelineTrace records pipeline stage results.
+type PipelineTrace struct {
+	IngestResult string `json:"ingest_result"`
+	EnrichTasks  int    `json:"enrich_tasks"`
+	TriageResult string `json:"triage_result"`
+}
+
+// Trace records the full execution trace of a scenario run.
+type Trace struct {
+	ScenarioName   string           `json:"scenario_name"`
+	RunID          string           `json:"run_id"`
+	StartTime      time.Time        `json:"start_time"`
+	EndTime        time.Time        `json:"end_time"`
+	ToolCalls      []ToolCallRecord `json:"tool_calls"`
+	AgentOutput    string           `json:"agent_output"`
+	PipelineResult *PipelineTrace   `json:"pipeline_result,omitempty"`
+	TotalTokens    int64            `json:"total_tokens"`
+}
+
+// EvalResult represents the structured evaluation across 3 layers.
+type EvalResult struct {
+	Trace      *Trace            `json:"trace"`
+	Outcome    *OutcomeResult    `json:"outcome"`
+	Trajectory *TrajectoryResult `json:"trajectory"`
+	Efficiency *EfficiencyResult `json:"efficiency"`
+}
+
+// OutcomeResult — deterministic checks + LLM judge.
+type OutcomeResult struct {
+	FindingKeywordsFound  []string          `json:"finding_keywords_found"`
+	FindingKeywordsMissed []string          `json:"finding_keywords_missed"`
+	SeverityMatch         bool              `json:"severity_match"`
+	CriteriaResults       []CriterionResult `json:"criteria_results"`
+}
+
+// CriterionResult holds a single LLM judge evaluation.
+type CriterionResult struct {
+	Criterion string `json:"criterion"`
+	Pass      bool   `json:"pass"`
+	Reasoning string `json:"reasoning"`
+}
+
+// TrajectoryResult — tool call sequence evaluation.
+type TrajectoryResult struct {
+	MustCallResults    map[string]bool `json:"must_call_results"`
+	MustNotCallResults map[string]bool `json:"must_not_call_results"`
+	OrderedCallsPass   bool            `json:"ordered_calls_pass"`
+	OrderedCallsDetail string          `json:"ordered_calls_detail"`
+}
+
+// EfficiencyResult — quantitative metrics.
+type EfficiencyResult struct {
+	TotalCalls       int           `json:"total_calls"`
+	DuplicateCalls   int           `json:"duplicate_calls"`
+	TotalTokens      int64         `json:"total_tokens"`
+	Duration         time.Duration `json:"duration"`
+	MaxCallsPass     bool          `json:"max_calls_pass"`
+	MaxDuplicatePass bool          `json:"max_duplicate_pass"`
+}
+
+// ReportFormat defines the output format for evaluation reports.
+type ReportFormat string
+
+const (
+	ReportFormatMarkdown ReportFormat = "markdown"
+	ReportFormatJSON     ReportFormat = "json"
+)
+
+// Report represents the final evaluation report.
+type Report struct {
+	Format     ReportFormat `json:"format"`
+	Content    string       `json:"content"`
+	EvalResult *EvalResult  `json:"eval_result"`
+}
+
+// ResponseFile represents the on-disk format of a tool response file.
+type ResponseFile struct {
+	ToolName string         `json:"tool_name"`
+	Args     map[string]any `json:"args"`
+	Response map[string]any `json:"response"`
+}

--- a/pkg/domain/model/eval/scenario_test.go
+++ b/pkg/domain/model/eval/scenario_test.go
@@ -1,0 +1,82 @@
+package eval_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/m-mizutani/gt"
+	"github.com/secmon-lab/warren/pkg/domain/model/eval"
+	"github.com/secmon-lab/warren/pkg/domain/types"
+)
+
+func TestScenario_Validate_Valid(t *testing.T) {
+	s := &eval.Scenario{
+		Name:           "test",
+		Alert:          eval.AlertConfig{Schema: types.AlertSchema("gcp_scc"), Data: map[string]any{"key": "val"}},
+		World:          eval.WorldConfig{Description: "test world"},
+		InitialMessage: "investigate",
+		Config:         eval.ScenarioConfig{PolicyDir: "policy"},
+	}
+	errors := s.Validate()
+	gt.V(t, len(errors)).Equal(0)
+}
+
+func TestScenario_Validate_MissingFields(t *testing.T) {
+	s := &eval.Scenario{}
+	errors := s.Validate()
+	gt.V(t, slices.Contains(errors, "name is required")).Equal(true)
+	gt.V(t, slices.Contains(errors, "alert.schema is required")).Equal(true)
+	gt.V(t, slices.Contains(errors, "alert.data is required")).Equal(true)
+	gt.V(t, slices.Contains(errors, "initial_message is required")).Equal(true)
+	gt.V(t, slices.Contains(errors, "world.description is required (mock agent needs scenario context)")).Equal(true)
+	gt.V(t, slices.Contains(errors, "config.policy_dir is required (pipeline needs Rego policies)")).Equal(true)
+}
+
+func TestExpectations_Validate_TrajectoryConflict(t *testing.T) {
+	exp := &eval.Expectations{
+		Trajectory: &eval.TrajectoryExpectation{
+			MustCall:    []string{"virustotal", "bigquery"},
+			MustNotCall: []string{"virustotal"},
+		},
+	}
+	errors := exp.Validate()
+	gt.V(t, slices.Contains(errors, `tool "virustotal" appears in both must_call and must_not_call`)).Equal(true)
+}
+
+func TestExpectations_Validate_OrderedCallsSubset(t *testing.T) {
+	exp := &eval.Expectations{
+		Trajectory: &eval.TrajectoryExpectation{
+			MustCall:     []string{"virustotal"},
+			OrderedCalls: []string{"virustotal", "bigquery"},
+		},
+	}
+	errors := exp.Validate()
+	gt.V(t, slices.Contains(errors, `ordered_calls tool "bigquery" is not in must_call`)).Equal(true)
+}
+
+func TestResponseFile_Validate_Valid(t *testing.T) {
+	rf := &eval.ResponseFile{
+		ToolName: "virustotal",
+		Args:     map[string]any{"ip": "1.2.3.4"},
+		Response: map[string]any{"malicious": true},
+	}
+	errors := rf.Validate("virustotal__a3f2b1c9.json")
+	gt.V(t, len(errors)).Equal(0)
+}
+
+func TestResponseFile_Validate_MissingToolName(t *testing.T) {
+	rf := &eval.ResponseFile{
+		Response: map[string]any{"ok": true},
+	}
+	errors := rf.Validate("bad__12345678.json")
+	gt.V(t, slices.Contains(errors, "responses/bad__12345678.json: tool_name is required")).Equal(true)
+}
+
+func TestResponseFile_Validate_FilenameMismatch(t *testing.T) {
+	rf := &eval.ResponseFile{
+		ToolName: "virustotal",
+		Response: map[string]any{"ok": true},
+	}
+	errors := rf.Validate("wrong__12345678.json")
+	gt.V(t, slices.Contains(errors, `responses/wrong__12345678.json: filename should start with "virustotal__" (got tool_name="virustotal")`)).Equal(true)
+}

--- a/pkg/usecase/eval/evaluator.go
+++ b/pkg/usecase/eval/evaluator.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/m-mizutani/goerr/v2"
 	"github.com/m-mizutani/gollem"
+	gollemTrace "github.com/m-mizutani/gollem/trace"
 	"github.com/secmon-lab/warren/pkg/domain/model/eval"
 )
 
@@ -41,6 +42,85 @@ func Evaluate(ctx context.Context, trace *eval.Trace, expectations *eval.Expecta
 	return result, nil
 }
 
+// EvaluateWithAgent runs a full evaluation using an LLM agent that reads the
+// gollem trace and agent output to produce a comprehensive assessment.
+// The agent is given tools to navigate the trace structure without loading
+// the entire trace into context at once.
+func EvaluateWithAgent(ctx context.Context, trace *eval.Trace, gollemTraceData *gollemTrace.Trace, expectations *eval.Expectations, agentOutput string, llmClient gollem.LLMClient) (*eval.EvalResult, error) {
+	// First run deterministic evaluations
+	result, err := Evaluate(ctx, trace, expectations, nil) // nil LLM = skip LLM judge in deterministic pass
+	if err != nil {
+		return nil, err
+	}
+
+	if llmClient == nil || expectations == nil {
+		return result, nil
+	}
+
+	// Build trace reader tool for the agent
+	traceToolSet := newTraceReaderToolSet(gollemTraceData, agentOutput)
+
+	// Build evaluation prompt
+	criteriaJSON, _ := json.MarshalIndent(expectations, "", "  ")
+	systemPrompt := fmt.Sprintf(`You are a security agent evaluator. Your job is to assess whether a security investigation agent performed well.
+
+You have access to tools that let you navigate the agent's execution trace. Use them to understand what the agent did, then evaluate against the criteria.
+
+## Evaluation Criteria
+%s
+
+## Agent's Final Output
+%s
+
+## Instructions
+1. Use get_trace_overview to understand the overall execution structure
+2. Use get_span_detail to examine specific spans (planning, tasks, final response)
+3. Evaluate each criterion and provide pass/fail with reasoning
+4. Respond with a JSON object:
+{
+  "criteria_results": [
+    {"criterion": "...", "pass": true/false, "reasoning": "..."}
+  ]
+}`, string(criteriaJSON), agentOutput)
+
+	agent := gollem.New(llmClient,
+		gollem.WithToolSets(traceToolSet),
+		gollem.WithSystemPrompt(systemPrompt),
+		gollem.WithContentType(gollem.ContentTypeJSON),
+	)
+
+	resp, err := agent.Execute(ctx, gollem.Text("Evaluate the agent's performance against all criteria."))
+	if err != nil {
+		return nil, goerr.Wrap(err, "evaluation agent failed")
+	}
+
+	// Parse agent response
+	responseText := strings.Join(resp.Texts, "")
+	var agentResult struct {
+		CriteriaResults []eval.CriterionResult `json:"criteria_results"`
+	}
+	if err := json.Unmarshal([]byte(responseText), &agentResult); err != nil {
+		// Try to strip code fences
+		cleaned := strings.TrimSpace(responseText)
+		if strings.HasPrefix(cleaned, "```") {
+			lines := strings.Split(cleaned, "\n")
+			if len(lines) >= 3 {
+				cleaned = strings.Join(lines[1:len(lines)-1], "\n")
+			}
+		}
+		if err2 := json.Unmarshal([]byte(cleaned), &agentResult); err2 != nil {
+			return result, nil // Return deterministic results only
+		}
+	}
+
+	if result.Outcome == nil {
+		result.Outcome = &eval.OutcomeResult{}
+	}
+	result.Outcome.CriteriaResults = agentResult.CriteriaResults
+
+	return result, nil
+}
+
 // evaluateOutcome — Layer A: deterministic checks + LLM judge.
 func evaluateOutcome(ctx context.Context, trace *eval.Trace, exp *eval.OutcomeExpectation, llmClient gollem.LLMClient) (*eval.OutcomeResult, error) {
 	result := &eval.OutcomeResult{}
@@ -60,7 +140,7 @@ func evaluateOutcome(ctx context.Context, trace *eval.Trace, exp *eval.OutcomeEx
 		result.SeverityMatch = strings.Contains(agentOutput, strings.ToLower(exp.Severity))
 	}
 
-	// LLM judge: criteria evaluation
+	// LLM judge: criteria evaluation (only if llmClient provided)
 	if len(exp.Criteria) > 0 && llmClient != nil {
 		criteriaResults, err := evaluateCriteriaWithLLM(ctx, trace.AgentOutput, exp.Criteria, llmClient)
 		if err != nil {
@@ -134,7 +214,6 @@ func evaluateTrajectory(trace *eval.Trace, exp *eval.TrajectoryExpectation) *eva
 		MustNotCallResults: make(map[string]bool),
 	}
 
-	// Collect called tool names
 	calledTools := make(map[string]bool)
 	var callSequence []string
 	for _, tc := range trace.ToolCalls {
@@ -142,17 +221,14 @@ func evaluateTrajectory(trace *eval.Trace, exp *eval.TrajectoryExpectation) *eva
 		callSequence = append(callSequence, tc.ToolName)
 	}
 
-	// Check must_call
 	for _, tool := range exp.MustCall {
 		result.MustCallResults[tool] = calledTools[tool]
 	}
 
-	// Check must_not_call (true = violation)
 	for _, tool := range exp.MustNotCall {
 		result.MustNotCallResults[tool] = calledTools[tool]
 	}
 
-	// Check ordered_calls (subsequence match)
 	if len(exp.OrderedCalls) > 0 {
 		result.OrderedCallsPass = isSubsequence(exp.OrderedCalls, callSequence)
 		if result.OrderedCallsPass {
@@ -168,8 +244,6 @@ func evaluateTrajectory(trace *eval.Trace, exp *eval.TrajectoryExpectation) *eva
 	return result
 }
 
-// isSubsequence checks if 'sub' is a subsequence of 'seq'.
-// Elements don't need to be contiguous, but must appear in order.
 func isSubsequence(sub, seq []string) bool {
 	si := 0
 	for _, s := range seq {
@@ -188,7 +262,6 @@ func evaluateEfficiency(trace *eval.Trace, exp *eval.EfficiencyExpectation) *eva
 		Duration:    trace.EndTime.Sub(trace.StartTime),
 	}
 
-	// Count duplicate calls (same tool + same args)
 	type callKey struct {
 		tool string
 		args string
@@ -205,7 +278,6 @@ func evaluateEfficiency(trace *eval.Trace, exp *eval.EfficiencyExpectation) *eva
 		}
 	}
 
-	// Check thresholds
 	if exp.MaxTotalCalls > 0 {
 		result.MaxCallsPass = result.TotalCalls <= exp.MaxTotalCalls
 	} else {
@@ -219,4 +291,171 @@ func evaluateEfficiency(trace *eval.Trace, exp *eval.EfficiencyExpectation) *eva
 	}
 
 	return result
+}
+
+// traceReaderToolSet provides tools for the evaluation agent to navigate a gollem trace.
+type traceReaderToolSet struct {
+	trace       *gollemTrace.Trace
+	agentOutput string
+	spanIndex   map[string]*gollemTrace.Span // spanID -> span
+}
+
+func newTraceReaderToolSet(t *gollemTrace.Trace, agentOutput string) *traceReaderToolSet {
+	ts := &traceReaderToolSet{
+		trace:       t,
+		agentOutput: agentOutput,
+		spanIndex:   make(map[string]*gollemTrace.Span),
+	}
+	if t != nil && t.RootSpan != nil {
+		ts.indexSpans(t.RootSpan)
+	}
+	return ts
+}
+
+func (ts *traceReaderToolSet) indexSpans(span *gollemTrace.Span) {
+	ts.spanIndex[span.SpanID] = span
+	for _, child := range span.Children {
+		ts.indexSpans(child)
+	}
+}
+
+func (ts *traceReaderToolSet) Specs(_ context.Context) ([]gollem.ToolSpec, error) {
+	return []gollem.ToolSpec{
+		{
+			Name:        "get_trace_overview",
+			Description: "Get an overview of the trace execution: root span, direct children (phases/tasks), their kinds, names, statuses, and durations. Does NOT include full content.",
+		},
+		{
+			Name:        "get_span_detail",
+			Description: "Get the full detail of a specific span by span_id. Includes LLM call data (prompts, responses), tool execution data (args, results), and child span summaries.",
+			Parameters: map[string]*gollem.Parameter{
+				"span_id": {Type: gollem.TypeString, Description: "The span_id to inspect", Required: true},
+			},
+		},
+		{
+			Name:        "get_agent_output",
+			Description: "Get the agent's final output text (the messages sent to the user via msg.Notify).",
+		},
+	}, nil
+}
+
+func (ts *traceReaderToolSet) Run(_ context.Context, name string, args map[string]any) (map[string]any, error) {
+	switch name {
+	case "get_trace_overview":
+		return ts.getTraceOverview()
+	case "get_span_detail":
+		spanID, _ := args["span_id"].(string)
+		return ts.getSpanDetail(spanID)
+	case "get_agent_output":
+		return map[string]any{"output": ts.agentOutput}, nil
+	default:
+		return nil, fmt.Errorf("unknown tool: %s", name)
+	}
+}
+
+func (ts *traceReaderToolSet) getTraceOverview() (map[string]any, error) {
+	if ts.trace == nil || ts.trace.RootSpan == nil {
+		return map[string]any{"error": "no trace data"}, nil
+	}
+
+	root := ts.trace.RootSpan
+	children := make([]map[string]any, 0, len(root.Children))
+	for _, child := range root.Children {
+		childInfo := map[string]any{
+			"span_id":  child.SpanID,
+			"kind":     string(child.Kind),
+			"name":     child.Name,
+			"status":   string(child.Status),
+			"duration": child.Duration.String(),
+		}
+		if child.Error != "" {
+			childInfo["error"] = child.Error
+		}
+		grandchildren := make([]string, 0, len(child.Children))
+		for _, gc := range child.Children {
+			grandchildren = append(grandchildren, fmt.Sprintf("%s(%s:%s)", gc.Name, gc.Kind, gc.SpanID))
+		}
+		if len(grandchildren) > 0 {
+			childInfo["children"] = grandchildren
+		}
+		children = append(children, childInfo)
+	}
+
+	return map[string]any{
+		"trace_id":  ts.trace.TraceID,
+		"root_kind": string(root.Kind),
+		"root_name": root.Name,
+		"status":    string(root.Status),
+		"duration":  root.Duration.String(),
+		"children":  children,
+	}, nil
+}
+
+func (ts *traceReaderToolSet) getSpanDetail(spanID string) (map[string]any, error) {
+	span, ok := ts.spanIndex[spanID]
+	if !ok {
+		return map[string]any{"error": fmt.Sprintf("span %q not found", spanID)}, nil
+	}
+
+	result := map[string]any{
+		"span_id":  span.SpanID,
+		"kind":     string(span.Kind),
+		"name":     span.Name,
+		"status":   string(span.Status),
+		"duration": span.Duration.String(),
+	}
+
+	if span.Error != "" {
+		result["error"] = span.Error
+	}
+
+	if span.LLMCall != nil {
+		llmData := map[string]any{
+			"model":         span.LLMCall.Model,
+			"input_tokens":  span.LLMCall.InputTokens,
+			"output_tokens": span.LLMCall.OutputTokens,
+		}
+		if span.LLMCall.Request != nil {
+			llmData["system_prompt_length"] = len(span.LLMCall.Request.SystemPrompt)
+			llmData["message_count"] = len(span.LLMCall.Request.Messages)
+			llmData["tool_count"] = len(span.LLMCall.Request.Tools)
+		}
+		if span.LLMCall.Response != nil {
+			llmData["response_texts"] = span.LLMCall.Response.Texts
+			if len(span.LLMCall.Response.FunctionCalls) > 0 {
+				calls := make([]string, 0, len(span.LLMCall.Response.FunctionCalls))
+				for _, fc := range span.LLMCall.Response.FunctionCalls {
+					calls = append(calls, fc.Name)
+				}
+				llmData["function_calls"] = calls
+			}
+		}
+		result["llm_call"] = llmData
+	}
+
+	if span.ToolExec != nil {
+		result["tool_exec"] = map[string]any{
+			"tool_name": span.ToolExec.ToolName,
+			"args":      span.ToolExec.Args,
+			"result":    span.ToolExec.Result,
+			"error":     span.ToolExec.Error,
+		}
+	}
+
+	// Child summaries (not full detail)
+	if len(span.Children) > 0 {
+		children := make([]map[string]any, 0, len(span.Children))
+		for _, child := range span.Children {
+			childInfo := map[string]any{
+				"span_id": child.SpanID,
+				"kind":    string(child.Kind),
+				"name":    child.Name,
+				"status":  string(child.Status),
+			}
+			children = append(children, childInfo)
+		}
+		result["children"] = children
+	}
+
+	return result, nil
 }

--- a/pkg/usecase/eval/evaluator.go
+++ b/pkg/usecase/eval/evaluator.go
@@ -268,8 +268,7 @@ func evaluateEfficiency(trace *eval.Trace, exp *eval.EfficiencyExpectation) *eva
 	}
 	seen := make(map[callKey]int)
 	for _, tc := range trace.ToolCalls {
-		argsJSON, _ := json.Marshal(tc.Args)
-		key := callKey{tool: tc.ToolName, args: string(argsJSON)}
+		key := callKey{tool: tc.ToolName, args: argsHash(tc.Args)}
 		seen[key]++
 	}
 	for _, count := range seen {

--- a/pkg/usecase/eval/evaluator.go
+++ b/pkg/usecase/eval/evaluator.go
@@ -1,0 +1,222 @@
+package eval
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/m-mizutani/goerr/v2"
+	"github.com/m-mizutani/gollem"
+	"github.com/secmon-lab/warren/pkg/domain/model/eval"
+)
+
+// Evaluate runs the 3-layer evaluation against a trace and expectations.
+// Deterministic verifiers run first; LLM judge is used only for Layer A criteria.
+func Evaluate(ctx context.Context, trace *eval.Trace, expectations *eval.Expectations, llmClient gollem.LLMClient) (*eval.EvalResult, error) {
+	result := &eval.EvalResult{
+		Trace: trace,
+	}
+
+	if expectations == nil {
+		return result, nil
+	}
+
+	if expectations.Outcome != nil {
+		outcome, err := evaluateOutcome(ctx, trace, expectations.Outcome, llmClient)
+		if err != nil {
+			return nil, goerr.Wrap(err, "failed to evaluate outcome")
+		}
+		result.Outcome = outcome
+	}
+
+	if expectations.Trajectory != nil {
+		result.Trajectory = evaluateTrajectory(trace, expectations.Trajectory)
+	}
+
+	if expectations.Efficiency != nil {
+		result.Efficiency = evaluateEfficiency(trace, expectations.Efficiency)
+	}
+
+	return result, nil
+}
+
+// evaluateOutcome — Layer A: deterministic checks + LLM judge.
+func evaluateOutcome(ctx context.Context, trace *eval.Trace, exp *eval.OutcomeExpectation, llmClient gollem.LLMClient) (*eval.OutcomeResult, error) {
+	result := &eval.OutcomeResult{}
+
+	// Deterministic: finding keyword checks
+	agentOutput := strings.ToLower(trace.AgentOutput)
+	for _, keyword := range exp.FindingMustContain {
+		if strings.Contains(agentOutput, strings.ToLower(keyword)) {
+			result.FindingKeywordsFound = append(result.FindingKeywordsFound, keyword)
+		} else {
+			result.FindingKeywordsMissed = append(result.FindingKeywordsMissed, keyword)
+		}
+	}
+
+	// Deterministic: severity match
+	if exp.Severity != "" {
+		result.SeverityMatch = strings.Contains(agentOutput, strings.ToLower(exp.Severity))
+	}
+
+	// LLM judge: criteria evaluation
+	if len(exp.Criteria) > 0 && llmClient != nil {
+		criteriaResults, err := evaluateCriteriaWithLLM(ctx, trace.AgentOutput, exp.Criteria, llmClient)
+		if err != nil {
+			return nil, goerr.Wrap(err, "failed to evaluate criteria with LLM judge")
+		}
+		result.CriteriaResults = criteriaResults
+	}
+
+	return result, nil
+}
+
+// evaluateCriteriaWithLLM uses an LLM to judge each criterion against the agent output.
+func evaluateCriteriaWithLLM(ctx context.Context, agentOutput string, criteria []string, llmClient gollem.LLMClient) ([]eval.CriterionResult, error) {
+	session, err := llmClient.NewSession(ctx,
+		gollem.WithSessionSystemPrompt("You are an evaluation judge for a security analysis agent. Evaluate whether the agent's output meets the given criterion. Respond in JSON."),
+		gollem.WithSessionContentType(gollem.ContentTypeJSON),
+	)
+	if err != nil {
+		return nil, goerr.Wrap(err, "failed to create LLM judge session")
+	}
+
+	results := make([]eval.CriterionResult, 0, len(criteria))
+	for _, criterion := range criteria {
+		prompt := fmt.Sprintf(`Evaluate the following agent output against this criterion.
+
+Criterion: %s
+
+Agent Output:
+%s
+
+Respond with a JSON object: {"pass": true/false, "reasoning": "brief explanation"}`, criterion, agentOutput)
+
+		resp, err := session.Generate(ctx, []gollem.Input{gollem.Text(prompt)})
+		if err != nil {
+			results = append(results, eval.CriterionResult{
+				Criterion: criterion,
+				Pass:      false,
+				Reasoning: fmt.Sprintf("LLM judge error: %v", err),
+			})
+			continue
+		}
+
+		text := strings.TrimSpace(strings.Join(resp.Texts, ""))
+		var judgeResult struct {
+			Pass      bool   `json:"pass"`
+			Reasoning string `json:"reasoning"`
+		}
+		if err := json.Unmarshal([]byte(text), &judgeResult); err != nil {
+			results = append(results, eval.CriterionResult{
+				Criterion: criterion,
+				Pass:      false,
+				Reasoning: fmt.Sprintf("Failed to parse LLM judge response: %s", text),
+			})
+			continue
+		}
+
+		results = append(results, eval.CriterionResult{
+			Criterion: criterion,
+			Pass:      judgeResult.Pass,
+			Reasoning: judgeResult.Reasoning,
+		})
+	}
+
+	return results, nil
+}
+
+// evaluateTrajectory — Layer B: tool call sequence evaluation.
+func evaluateTrajectory(trace *eval.Trace, exp *eval.TrajectoryExpectation) *eval.TrajectoryResult {
+	result := &eval.TrajectoryResult{
+		MustCallResults:    make(map[string]bool),
+		MustNotCallResults: make(map[string]bool),
+	}
+
+	// Collect called tool names
+	calledTools := make(map[string]bool)
+	var callSequence []string
+	for _, tc := range trace.ToolCalls {
+		calledTools[tc.ToolName] = true
+		callSequence = append(callSequence, tc.ToolName)
+	}
+
+	// Check must_call
+	for _, tool := range exp.MustCall {
+		result.MustCallResults[tool] = calledTools[tool]
+	}
+
+	// Check must_not_call (true = violation)
+	for _, tool := range exp.MustNotCall {
+		result.MustNotCallResults[tool] = calledTools[tool]
+	}
+
+	// Check ordered_calls (subsequence match)
+	if len(exp.OrderedCalls) > 0 {
+		result.OrderedCallsPass = isSubsequence(exp.OrderedCalls, callSequence)
+		if result.OrderedCallsPass {
+			result.OrderedCallsDetail = "ordered calls found in expected order"
+		} else {
+			result.OrderedCallsDetail = fmt.Sprintf("expected order %v not found in call sequence %v", exp.OrderedCalls, callSequence)
+		}
+	} else {
+		result.OrderedCallsPass = true
+		result.OrderedCallsDetail = "no ordered calls specified"
+	}
+
+	return result
+}
+
+// isSubsequence checks if 'sub' is a subsequence of 'seq'.
+// Elements don't need to be contiguous, but must appear in order.
+func isSubsequence(sub, seq []string) bool {
+	si := 0
+	for _, s := range seq {
+		if si < len(sub) && s == sub[si] {
+			si++
+		}
+	}
+	return si == len(sub)
+}
+
+// evaluateEfficiency — Layer C: quantitative metrics.
+func evaluateEfficiency(trace *eval.Trace, exp *eval.EfficiencyExpectation) *eval.EfficiencyResult {
+	result := &eval.EfficiencyResult{
+		TotalCalls:  len(trace.ToolCalls),
+		TotalTokens: trace.TotalTokens,
+		Duration:    trace.EndTime.Sub(trace.StartTime),
+	}
+
+	// Count duplicate calls (same tool + same args)
+	type callKey struct {
+		tool string
+		args string
+	}
+	seen := make(map[callKey]int)
+	for _, tc := range trace.ToolCalls {
+		argsJSON, _ := json.Marshal(tc.Args)
+		key := callKey{tool: tc.ToolName, args: string(argsJSON)}
+		seen[key]++
+	}
+	for _, count := range seen {
+		if count > 1 {
+			result.DuplicateCalls += count - 1
+		}
+	}
+
+	// Check thresholds
+	if exp.MaxTotalCalls > 0 {
+		result.MaxCallsPass = result.TotalCalls <= exp.MaxTotalCalls
+	} else {
+		result.MaxCallsPass = true
+	}
+
+	if exp.MaxDuplicateCalls > 0 {
+		result.MaxDuplicatePass = result.DuplicateCalls <= exp.MaxDuplicateCalls
+	} else {
+		result.MaxDuplicatePass = true
+	}
+
+	return result
+}

--- a/pkg/usecase/eval/evaluator_test.go
+++ b/pkg/usecase/eval/evaluator_test.go
@@ -1,0 +1,171 @@
+package eval_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/m-mizutani/gt"
+	evalModel "github.com/secmon-lab/warren/pkg/domain/model/eval"
+	"github.com/secmon-lab/warren/pkg/usecase/eval"
+)
+
+func newTestTrace(toolCalls []evalModel.ToolCallRecord, agentOutput string) *evalModel.Trace {
+	return &evalModel.Trace{
+		ScenarioName: "test",
+		RunID:        "test-run",
+		StartTime:    time.Now(),
+		EndTime:      time.Now().Add(10 * time.Second),
+		ToolCalls:    toolCalls,
+		AgentOutput:  agentOutput,
+		TotalTokens:  1000,
+	}
+}
+
+func TestEvaluate_Outcome_Keywords(t *testing.T) {
+	trace := newTestTrace(nil, "This is a Tor exit node with HIGH severity")
+	expectations := &evalModel.Expectations{
+		Outcome: &evalModel.OutcomeExpectation{
+			FindingMustContain: []string{"Tor", "missing_word"},
+			Severity:           "high",
+		},
+	}
+
+	result, err := eval.Evaluate(context.Background(), trace, expectations, nil)
+	gt.NoError(t, err)
+
+	gt.V(t, result.Outcome.FindingKeywordsFound).Equal([]string{"Tor"})
+	gt.V(t, result.Outcome.FindingKeywordsMissed).Equal([]string{"missing_word"})
+	gt.V(t, result.Outcome.SeverityMatch).Equal(true)
+}
+
+func TestEvaluate_Trajectory_MustCall(t *testing.T) {
+	toolCalls := []evalModel.ToolCallRecord{
+		{Sequence: 1, ToolName: "virustotal"},
+		{Sequence: 2, ToolName: "bigquery_query"},
+		{Sequence: 3, ToolName: "otx"},
+	}
+	trace := newTestTrace(toolCalls, "output")
+
+	expectations := &evalModel.Expectations{
+		Trajectory: &evalModel.TrajectoryExpectation{
+			MustCall:    []string{"virustotal", "bigquery_query"},
+			MustNotCall: []string{"intune"},
+		},
+	}
+
+	result, err := eval.Evaluate(context.Background(), trace, expectations, nil)
+	gt.NoError(t, err)
+
+	gt.V(t, result.Trajectory.MustCallResults["virustotal"]).Equal(true)
+	gt.V(t, result.Trajectory.MustCallResults["bigquery_query"]).Equal(true)
+	gt.V(t, result.Trajectory.MustNotCallResults["intune"]).Equal(false) // not violated
+}
+
+func TestEvaluate_Trajectory_MustNotCall_Violated(t *testing.T) {
+	toolCalls := []evalModel.ToolCallRecord{
+		{Sequence: 1, ToolName: "intune"},
+	}
+	trace := newTestTrace(toolCalls, "output")
+
+	expectations := &evalModel.Expectations{
+		Trajectory: &evalModel.TrajectoryExpectation{
+			MustNotCall: []string{"intune"},
+		},
+	}
+
+	result, err := eval.Evaluate(context.Background(), trace, expectations, nil)
+	gt.NoError(t, err)
+
+	gt.V(t, result.Trajectory.MustNotCallResults["intune"]).Equal(true) // violated
+}
+
+func TestEvaluate_Trajectory_OrderedCalls(t *testing.T) {
+	toolCalls := []evalModel.ToolCallRecord{
+		{Sequence: 1, ToolName: "virustotal"},
+		{Sequence: 2, ToolName: "otx"},
+		{Sequence: 3, ToolName: "bigquery_query"},
+	}
+	trace := newTestTrace(toolCalls, "output")
+
+	expectations := &evalModel.Expectations{
+		Trajectory: &evalModel.TrajectoryExpectation{
+			OrderedCalls: []string{"virustotal", "bigquery_query"},
+		},
+	}
+
+	result, err := eval.Evaluate(context.Background(), trace, expectations, nil)
+	gt.NoError(t, err)
+	gt.V(t, result.Trajectory.OrderedCallsPass).Equal(true)
+}
+
+func TestEvaluate_Trajectory_OrderedCalls_Fail(t *testing.T) {
+	toolCalls := []evalModel.ToolCallRecord{
+		{Sequence: 1, ToolName: "bigquery_query"},
+		{Sequence: 2, ToolName: "virustotal"},
+	}
+	trace := newTestTrace(toolCalls, "output")
+
+	expectations := &evalModel.Expectations{
+		Trajectory: &evalModel.TrajectoryExpectation{
+			OrderedCalls: []string{"virustotal", "bigquery_query"},
+		},
+	}
+
+	result, err := eval.Evaluate(context.Background(), trace, expectations, nil)
+	gt.NoError(t, err)
+	gt.V(t, result.Trajectory.OrderedCallsPass).Equal(false)
+}
+
+func TestEvaluate_Efficiency(t *testing.T) {
+	toolCalls := []evalModel.ToolCallRecord{
+		{Sequence: 1, ToolName: "vt", Args: map[string]any{"ip": "1.2.3.4"}},
+		{Sequence: 2, ToolName: "vt", Args: map[string]any{"ip": "1.2.3.4"}}, // duplicate
+		{Sequence: 3, ToolName: "vt", Args: map[string]any{"ip": "5.6.7.8"}}, // different args
+		{Sequence: 4, ToolName: "bigquery_query", Args: map[string]any{"q": "SELECT 1"}},
+	}
+	trace := newTestTrace(toolCalls, "output")
+
+	expectations := &evalModel.Expectations{
+		Efficiency: &evalModel.EfficiencyExpectation{
+			MaxTotalCalls:     5,
+			MaxDuplicateCalls: 2,
+		},
+	}
+
+	result, err := eval.Evaluate(context.Background(), trace, expectations, nil)
+	gt.NoError(t, err)
+
+	gt.V(t, result.Efficiency.TotalCalls).Equal(4)
+	gt.V(t, result.Efficiency.DuplicateCalls).Equal(1) // vt with same IP called twice
+	gt.V(t, result.Efficiency.MaxCallsPass).Equal(true)
+	gt.V(t, result.Efficiency.MaxDuplicatePass).Equal(true)
+}
+
+func TestEvaluate_Efficiency_Exceeded(t *testing.T) {
+	toolCalls := make([]evalModel.ToolCallRecord, 25)
+	for i := range toolCalls {
+		toolCalls[i] = evalModel.ToolCallRecord{Sequence: i, ToolName: "vt", Args: map[string]any{"i": float64(i)}}
+	}
+	trace := newTestTrace(toolCalls, "output")
+
+	expectations := &evalModel.Expectations{
+		Efficiency: &evalModel.EfficiencyExpectation{
+			MaxTotalCalls: 20,
+		},
+	}
+
+	result, err := eval.Evaluate(context.Background(), trace, expectations, nil)
+	gt.NoError(t, err)
+	gt.V(t, result.Efficiency.MaxCallsPass).Equal(false)
+}
+
+func TestEvaluate_NilExpectations(t *testing.T) {
+	trace := newTestTrace(nil, "output")
+	result, err := eval.Evaluate(context.Background(), trace, nil, nil)
+	gt.NoError(t, err)
+	gt.V(t, result.Trace).NotNil()
+	gt.V(t, result.Outcome).Nil()
+	gt.V(t, result.Trajectory).Nil()
+	gt.V(t, result.Efficiency).Nil()
+}

--- a/pkg/usecase/eval/loader.go
+++ b/pkg/usecase/eval/loader.go
@@ -1,0 +1,110 @@
+package eval
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/m-mizutani/goerr/v2"
+	"github.com/secmon-lab/warren/pkg/domain/model/eval"
+	"github.com/secmon-lab/warren/pkg/utils/errutil"
+	"gopkg.in/yaml.v3"
+)
+
+// LoadScenario loads a scenario from the given directory.
+func LoadScenario(scenarioDir string) (*eval.Scenario, error) {
+	scenarioPath := filepath.Join(scenarioDir, "scenario.yaml")
+
+	data, err := os.ReadFile(scenarioPath)
+	if err != nil {
+		return nil, goerr.Wrap(err, "failed to read scenario file",
+			goerr.V("path", scenarioPath),
+			goerr.T(errutil.TagValidation),
+		)
+	}
+
+	var scenario eval.Scenario
+	if err := yaml.Unmarshal(data, &scenario); err != nil {
+		return nil, goerr.Wrap(err, "failed to parse scenario YAML",
+			goerr.V("path", scenarioPath),
+			goerr.T(errutil.TagValidation),
+		)
+	}
+
+	return &scenario, nil
+}
+
+// ValidateScenarioDir performs comprehensive validation of a scenario directory.
+// It loads the scenario, validates the model, and validates response files.
+// Returns a list of validation errors (empty = valid).
+func ValidateScenarioDir(scenarioDir string) []string {
+	// Load and parse
+	scenarioPath := filepath.Join(scenarioDir, "scenario.yaml")
+	data, err := os.ReadFile(scenarioPath)
+	if err != nil {
+		return []string{fmt.Sprintf("cannot read scenario.yaml: %v", err)}
+	}
+
+	var scenario eval.Scenario
+	if err := yaml.Unmarshal(data, &scenario); err != nil {
+		return []string{fmt.Sprintf("invalid YAML in scenario.yaml: %v", err)}
+	}
+
+	// Model validation
+	errors := scenario.Validate()
+
+	// Policy dir existence check
+	if scenario.Config.PolicyDir != "" {
+		policyPath := filepath.Join(scenarioDir, scenario.Config.PolicyDir)
+		if info, statErr := os.Stat(policyPath); statErr != nil || !info.IsDir() {
+			errors = append(errors, fmt.Sprintf("config.policy_dir %q does not exist or is not a directory", scenario.Config.PolicyDir))
+		}
+	}
+
+	// Response files validation (I/O layer)
+	responsesDir := ResponsesDir(scenarioDir)
+	if info, statErr := os.Stat(responsesDir); statErr == nil && info.IsDir() {
+		errors = append(errors, validateResponseFiles(responsesDir)...)
+	}
+
+	return errors
+}
+
+func validateResponseFiles(responsesDir string) []string {
+	var errors []string
+
+	entries, err := os.ReadDir(responsesDir)
+	if err != nil {
+		return []string{fmt.Sprintf("cannot read responses/: %v", err)}
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+
+		filePath := filepath.Join(responsesDir, entry.Name())
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			errors = append(errors, fmt.Sprintf("responses/%s: cannot read file: %v", entry.Name(), err))
+			continue
+		}
+
+		var rf eval.ResponseFile
+		if err := json.Unmarshal(data, &rf); err != nil {
+			errors = append(errors, fmt.Sprintf("responses/%s: invalid JSON: %v", entry.Name(), err))
+			continue
+		}
+
+		errors = append(errors, rf.Validate(entry.Name())...)
+	}
+
+	return errors
+}
+
+// ResponsesDir returns the path to the responses directory for a scenario.
+func ResponsesDir(scenarioDir string) string {
+	return filepath.Join(scenarioDir, "responses")
+}
+

--- a/pkg/usecase/eval/loader.go
+++ b/pkg/usecase/eval/loader.go
@@ -16,7 +16,7 @@ import (
 func LoadScenario(scenarioDir string) (*eval.Scenario, error) {
 	scenarioPath := filepath.Join(scenarioDir, "scenario.yaml")
 
-	data, err := os.ReadFile(scenarioPath)
+	data, err := os.ReadFile(scenarioPath) // #nosec G304 -- path from CLI flag
 	if err != nil {
 		return nil, goerr.Wrap(err, "failed to read scenario file",
 			goerr.V("path", scenarioPath),
@@ -41,7 +41,7 @@ func LoadScenario(scenarioDir string) (*eval.Scenario, error) {
 func ValidateScenarioDir(scenarioDir string) []string {
 	// Load and parse
 	scenarioPath := filepath.Join(scenarioDir, "scenario.yaml")
-	data, err := os.ReadFile(scenarioPath)
+	data, err := os.ReadFile(scenarioPath) // #nosec G304 -- path from CLI flag
 	if err != nil {
 		return []string{fmt.Sprintf("cannot read scenario.yaml: %v", err)}
 	}
@@ -85,7 +85,7 @@ func validateResponseFiles(responsesDir string) []string {
 		}
 
 		filePath := filepath.Join(responsesDir, entry.Name())
-		data, err := os.ReadFile(filePath)
+		data, err := os.ReadFile(filePath) // #nosec G304 -- path from scenario dir
 		if err != nil {
 			errors = append(errors, fmt.Sprintf("responses/%s: cannot read file: %v", entry.Name(), err))
 			continue

--- a/pkg/usecase/eval/loader.go
+++ b/pkg/usecase/eval/loader.go
@@ -16,7 +16,7 @@ import (
 func LoadScenario(scenarioDir string) (*eval.Scenario, error) {
 	scenarioPath := filepath.Join(scenarioDir, "scenario.yaml")
 
-	data, err := os.ReadFile(scenarioPath) // #nosec G304 -- path from CLI flag
+	data, err := os.ReadFile(filepath.Clean(scenarioPath))
 	if err != nil {
 		return nil, goerr.Wrap(err, "failed to read scenario file",
 			goerr.V("path", scenarioPath),
@@ -41,7 +41,7 @@ func LoadScenario(scenarioDir string) (*eval.Scenario, error) {
 func ValidateScenarioDir(scenarioDir string) []string {
 	// Load and parse
 	scenarioPath := filepath.Join(scenarioDir, "scenario.yaml")
-	data, err := os.ReadFile(scenarioPath) // #nosec G304 -- path from CLI flag
+	data, err := os.ReadFile(filepath.Clean(scenarioPath))
 	if err != nil {
 		return []string{fmt.Sprintf("cannot read scenario.yaml: %v", err)}
 	}
@@ -85,7 +85,7 @@ func validateResponseFiles(responsesDir string) []string {
 		}
 
 		filePath := filepath.Join(responsesDir, entry.Name())
-		data, err := os.ReadFile(filePath) // #nosec G304 -- path from scenario dir
+		data, err := os.ReadFile(filepath.Clean(filePath))
 		if err != nil {
 			errors = append(errors, fmt.Sprintf("responses/%s: cannot read file: %v", entry.Name(), err))
 			continue

--- a/pkg/usecase/eval/loader_test.go
+++ b/pkg/usecase/eval/loader_test.go
@@ -1,0 +1,191 @@
+package eval_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/m-mizutani/gt"
+	evalModel "github.com/secmon-lab/warren/pkg/domain/model/eval"
+	"github.com/secmon-lab/warren/pkg/usecase/eval"
+)
+
+const validScenarioYAML = `
+name: test_scenario
+description: "Test scenario"
+alert:
+  schema: "gcp_scc"
+  data:
+    finding:
+      category: "test"
+world:
+  description: "Test world"
+  tool_hints:
+    bigquery: "test hint"
+initial_message: "Investigate"
+config:
+  policy_dir: "policy"
+expectations:
+  outcome:
+    finding_must_contain:
+      - "test"
+    severity: "high"
+  trajectory:
+    must_call:
+      - virustotal
+      - bigquery
+    must_not_call:
+      - intune
+    ordered_calls:
+      - virustotal
+      - bigquery
+  efficiency:
+    max_total_calls: 20
+    max_duplicate_calls: 3
+`
+
+func TestLoadScenario_Valid(t *testing.T) {
+	dir := t.TempDir()
+	gt.NoError(t, os.WriteFile(filepath.Join(dir, "scenario.yaml"), []byte(validScenarioYAML), 0o640))
+
+	scenario, err := eval.LoadScenario(dir)
+	gt.NoError(t, err)
+
+	gt.V(t, scenario.Name).Equal("test_scenario")
+	gt.V(t, scenario.Description).Equal("Test scenario")
+	gt.V(t, string(scenario.Alert.Schema)).Equal("gcp_scc")
+	gt.V(t, scenario.World.Description).Equal("Test world")
+	gt.V(t, scenario.World.ToolHints["bigquery"]).Equal("test hint")
+	gt.V(t, scenario.InitialMessage).Equal("Investigate")
+	gt.V(t, scenario.Expectations).NotNil()
+	gt.V(t, scenario.Expectations.Outcome.Severity).Equal("high")
+	gt.V(t, scenario.Expectations.Trajectory.MustCall).Equal([]string{"virustotal", "bigquery"})
+	gt.V(t, scenario.Expectations.Efficiency.MaxTotalCalls).Equal(20)
+}
+
+func TestLoadScenario_MissingFile(t *testing.T) {
+	_, err := eval.LoadScenario("/nonexistent/path")
+	gt.V(t, err).NotNil()
+}
+
+func writeValidScenario(t *testing.T, dir string) {
+	t.Helper()
+	gt.NoError(t, os.WriteFile(filepath.Join(dir, "scenario.yaml"), []byte(validScenarioYAML), 0o640))
+	gt.NoError(t, os.MkdirAll(filepath.Join(dir, "policy"), 0o750))
+}
+
+func TestValidateScenario_Valid(t *testing.T) {
+	dir := t.TempDir()
+	writeValidScenario(t, dir)
+
+	errors := eval.ValidateScenarioDir(dir)
+	gt.V(t, len(errors)).Equal(0)
+}
+
+func TestValidateScenario_MissingRequiredFields(t *testing.T) {
+	dir := t.TempDir()
+	yaml := `
+description: "No name or schema"
+`
+	gt.NoError(t, os.WriteFile(filepath.Join(dir, "scenario.yaml"), []byte(yaml), 0o640))
+
+	errors := eval.ValidateScenarioDir(dir)
+	gt.V(t, len(errors) >= 3).Equal(true) // name, alert.schema, alert.data, initial_message, world.description
+}
+
+func TestValidateScenario_TrajectoryConflict(t *testing.T) {
+	dir := t.TempDir()
+	yaml := `
+name: test
+alert:
+  schema: "test"
+  data: {key: val}
+world:
+  description: "test"
+initial_message: "test"
+expectations:
+  trajectory:
+    must_call:
+      - virustotal
+    must_not_call:
+      - virustotal
+`
+	gt.NoError(t, os.WriteFile(filepath.Join(dir, "scenario.yaml"), []byte(yaml), 0o640))
+
+	errors := eval.ValidateScenarioDir(dir)
+	gt.V(t, slices.Contains(errors, `tool "virustotal" appears in both must_call and must_not_call`)).Equal(true)
+}
+
+func TestValidateScenario_OrderedCallsNotInMustCall(t *testing.T) {
+	dir := t.TempDir()
+	yaml := `
+name: test
+alert:
+  schema: "test"
+  data: {key: val}
+world:
+  description: "test"
+initial_message: "test"
+expectations:
+  trajectory:
+    must_call:
+      - virustotal
+    ordered_calls:
+      - bigquery
+`
+	gt.NoError(t, os.WriteFile(filepath.Join(dir, "scenario.yaml"), []byte(yaml), 0o640))
+
+	errors := eval.ValidateScenarioDir(dir)
+	gt.V(t, slices.Contains(errors, `ordered_calls tool "bigquery" is not in must_call`)).Equal(true)
+}
+
+func TestValidateScenario_InvalidResponseFile(t *testing.T) {
+	dir := t.TempDir()
+	gt.NoError(t, os.WriteFile(filepath.Join(dir, "scenario.yaml"), []byte(validScenarioYAML), 0o640))
+	responsesDir := filepath.Join(dir, "responses")
+	gt.NoError(t, os.MkdirAll(responsesDir, 0o750))
+
+	// Write invalid JSON
+	gt.NoError(t, os.WriteFile(filepath.Join(responsesDir, "bad__12345678.json"), []byte("{invalid"), 0o640))
+
+	errors := eval.ValidateScenarioDir(dir)
+	gt.V(t, len(errors) > 0).Equal(true)
+}
+
+func TestValidateScenario_ResponseFileMissingToolName(t *testing.T) {
+	dir := t.TempDir()
+	gt.NoError(t, os.WriteFile(filepath.Join(dir, "scenario.yaml"), []byte(validScenarioYAML), 0o640))
+	responsesDir := filepath.Join(dir, "responses")
+	gt.NoError(t, os.MkdirAll(responsesDir, 0o750))
+
+	rf := evalModel.ResponseFile{
+		ToolName: "",
+		Args:     map[string]any{"ip": "1.2.3.4"},
+		Response: map[string]any{"ok": true},
+	}
+	data, _ := json.Marshal(rf)
+	gt.NoError(t, os.WriteFile(filepath.Join(responsesDir, "bad__12345678.json"), data, 0o640))
+
+	errors := eval.ValidateScenarioDir(dir)
+	gt.V(t, slices.Contains(errors, "responses/bad__12345678.json: tool_name is required")).Equal(true)
+}
+
+func TestValidateScenario_ResponseFileNameMismatch(t *testing.T) {
+	dir := t.TempDir()
+	gt.NoError(t, os.WriteFile(filepath.Join(dir, "scenario.yaml"), []byte(validScenarioYAML), 0o640))
+	responsesDir := filepath.Join(dir, "responses")
+	gt.NoError(t, os.MkdirAll(responsesDir, 0o750))
+
+	rf := evalModel.ResponseFile{
+		ToolName: "virustotal",
+		Args:     map[string]any{"ip": "1.2.3.4"},
+		Response: map[string]any{"malicious": true},
+	}
+	data, _ := json.Marshal(rf)
+	gt.NoError(t, os.WriteFile(filepath.Join(responsesDir, "wrong__12345678.json"), data, 0o640))
+
+	errors := eval.ValidateScenarioDir(dir)
+	gt.V(t, slices.Contains(errors, `responses/wrong__12345678.json: filename should start with "virustotal__" (got tool_name="virustotal")`)).Equal(true)
+}

--- a/pkg/usecase/eval/mock/agent.go
+++ b/pkg/usecase/eval/mock/agent.go
@@ -1,0 +1,149 @@
+package mock
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/m-mizutani/goerr/v2"
+	"github.com/m-mizutani/gollem"
+	"github.com/m-mizutani/gollem/trace"
+	"github.com/secmon-lab/warren/pkg/domain/model/eval"
+)
+
+// Agent generates dynamic tool responses with accumulated context.
+// It maintains a single LLM session to ensure consistency across
+// multiple tool calls within a scenario run.
+type Agent struct {
+	llmClient gollem.LLMClient
+	world     eval.WorldConfig
+	session   gollem.Session
+	mu        sync.Mutex
+}
+
+// New creates a new mock Agent.
+func New(llmClient gollem.LLMClient, world eval.WorldConfig) *Agent {
+	return &Agent{
+		llmClient: llmClient,
+		world:     world,
+	}
+}
+
+// Generate produces a response for the given tool call.
+// It accumulates context from all previous calls via the session history.
+// Returns the generated response and the number of tokens used.
+func (a *Agent) Generate(ctx context.Context, toolName string, args map[string]any) (map[string]any, int64, error) {
+	// Strip gollem trace handler to prevent mock agent LLM calls
+	// from leaking into the main agent's trace
+	ctx = trace.WithHandler(ctx, nil)
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.session == nil {
+		session, err := a.llmClient.NewSession(ctx,
+			gollem.WithSessionSystemPrompt(a.buildSystemPrompt()),
+			gollem.WithSessionContentType(gollem.ContentTypeJSON),
+		)
+		if err != nil {
+			return nil, 0, goerr.Wrap(err, "failed to create mock agent session")
+		}
+		a.session = session
+	}
+
+	argsJSON, err := json.MarshalIndent(args, "", "  ")
+	if err != nil {
+		return nil, 0, goerr.Wrap(err, "failed to marshal tool args")
+	}
+
+	prompt := fmt.Sprintf(`Tool call: %s
+Arguments:
+%s
+
+Generate a realistic JSON response that this tool would return.
+The response MUST be consistent with all previous tool call responses in this session.
+Return ONLY a valid JSON object, no markdown or explanation.`, toolName, string(argsJSON))
+
+	resp, err := a.session.Generate(ctx, []gollem.Input{gollem.Text(prompt)})
+	if err != nil {
+		return nil, 0, goerr.Wrap(err, "failed to generate mock response",
+			goerr.V("tool", toolName))
+	}
+
+	tokens := int64(resp.InputToken + resp.OutputToken)
+
+	text := strings.Join(resp.Texts, "")
+	text = strings.TrimSpace(text)
+	// Strip markdown code fence if present
+	text = stripCodeFence(text)
+
+	result, parseErr := parseJSONResponse(text)
+	if parseErr != nil {
+		return nil, tokens, goerr.Wrap(parseErr, "failed to parse mock LLM response as JSON",
+			goerr.V("tool", toolName),
+			goerr.V("raw_response", text))
+	}
+
+	return result, tokens, nil
+}
+
+func (a *Agent) buildSystemPrompt() string {
+	var sb strings.Builder
+	sb.WriteString("You are a tool response simulator for a security alert evaluation scenario.\n\n")
+	sb.WriteString("## Scenario World\n")
+	sb.WriteString(a.world.Description)
+	sb.WriteString("\n")
+
+	if len(a.world.ToolHints) > 0 {
+		sb.WriteString("\n## Tool-Specific Hints\n")
+		for tool, hint := range a.world.ToolHints {
+			fmt.Fprintf(&sb, "\n### %s\n%s\n", tool, hint)
+		}
+	}
+
+	sb.WriteString("\n## Rules\n")
+	sb.WriteString("- Generate realistic responses consistent with the scenario world above\n")
+	sb.WriteString("- Maintain consistency with ALL prior responses in this conversation\n")
+	sb.WriteString("- Return ONLY valid JSON, no markdown or explanation\n")
+	sb.WriteString("- JSON objects or arrays are both acceptable\n")
+
+	return sb.String()
+}
+
+// parseJSONResponse parses a JSON string into map[string]any.
+// If the JSON is an array, it wraps it as {"result": [...]}.
+func parseJSONResponse(text string) (map[string]any, error) {
+	// Try as object first
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(text), &obj); err == nil {
+		return obj, nil
+	}
+
+	// Try as array — wrap in {"result": [...]}
+	var arr []any
+	if err := json.Unmarshal([]byte(text), &arr); err == nil {
+		return map[string]any{"result": arr}, nil
+	}
+
+	// Neither object nor array
+	return nil, fmt.Errorf("response is neither JSON object nor array")
+}
+
+// stripCodeFence removes markdown code fences (```json ... ```) from the text.
+func stripCodeFence(text string) string {
+	if strings.HasPrefix(text, "```") {
+		lines := strings.Split(text, "\n")
+		if len(lines) >= 2 {
+			// Remove first line (```json) and last line (```)
+			start := 1
+			end := len(lines)
+			if strings.TrimSpace(lines[end-1]) == "```" {
+				end--
+			}
+			text = strings.Join(lines[start:end], "\n")
+		}
+	}
+	return strings.TrimSpace(text)
+}

--- a/pkg/usecase/eval/mock/agent.go
+++ b/pkg/usecase/eval/mock/agent.go
@@ -132,18 +132,30 @@ func parseJSONResponse(text string) (map[string]any, error) {
 }
 
 // stripCodeFence removes markdown code fences (```json ... ```) from the text.
+// Handles both multi-line and single-line fences.
 func stripCodeFence(text string) string {
-	if strings.HasPrefix(text, "```") {
-		lines := strings.Split(text, "\n")
-		if len(lines) >= 2 {
-			// Remove first line (```json) and last line (```)
-			start := 1
-			end := len(lines)
-			if strings.TrimSpace(lines[end-1]) == "```" {
-				end--
-			}
-			text = strings.Join(lines[start:end], "\n")
+	text = strings.TrimSpace(text)
+	if !strings.HasPrefix(text, "```") {
+		return text
+	}
+
+	// Single-line: ```json {"key": "value"} ```
+	if !strings.Contains(text, "\n") {
+		text = strings.TrimPrefix(text, "```")
+		text = strings.TrimSuffix(text, "```")
+		text, _ = strings.CutPrefix(text, "json")
+		return strings.TrimSpace(text)
+	}
+
+	// Multi-line
+	lines := strings.Split(text, "\n")
+	if len(lines) >= 2 {
+		start := 1
+		end := len(lines)
+		if strings.TrimSpace(lines[end-1]) == "```" {
+			end--
 		}
+		text = strings.Join(lines[start:end], "\n")
 	}
 	return strings.TrimSpace(text)
 }

--- a/pkg/usecase/eval/reporter.go
+++ b/pkg/usecase/eval/reporter.go
@@ -1,0 +1,154 @@
+package eval
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/m-mizutani/goerr/v2"
+	"github.com/m-mizutani/gollem"
+	"github.com/secmon-lab/warren/pkg/domain/model/eval"
+)
+
+// GenerateReport creates a Report from an EvalResult.
+// For JSON format, it serializes the EvalResult directly.
+// For markdown format, it uses the LLM to generate a human-readable summary.
+func GenerateReport(ctx context.Context, evalResult *eval.EvalResult, format eval.ReportFormat, llmClient gollem.LLMClient) (*eval.Report, error) {
+	report := &eval.Report{
+		Format:     format,
+		EvalResult: evalResult,
+	}
+
+	switch format {
+	case eval.ReportFormatJSON:
+		data, err := json.MarshalIndent(evalResult, "", "  ")
+		if err != nil {
+			return nil, goerr.Wrap(err, "failed to marshal eval result to JSON")
+		}
+		report.Content = string(data)
+
+	case eval.ReportFormatMarkdown:
+		content, err := generateMarkdownReport(ctx, evalResult, llmClient)
+		if err != nil {
+			return nil, goerr.Wrap(err, "failed to generate markdown report")
+		}
+		report.Content = content
+
+	default:
+		return nil, goerr.New("unknown report format", goerr.V("format", format))
+	}
+
+	return report, nil
+}
+
+func generateMarkdownReport(ctx context.Context, result *eval.EvalResult, llmClient gollem.LLMClient) (string, error) {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "# Evaluation Report: %s\n\n", result.Trace.ScenarioName)
+	fmt.Fprintf(&sb, "- **Run ID**: %s\n", result.Trace.RunID)
+	fmt.Fprintf(&sb, "- **Duration**: %s\n", result.Trace.EndTime.Sub(result.Trace.StartTime))
+	fmt.Fprintf(&sb, "- **Total Tool Calls**: %d\n", len(result.Trace.ToolCalls))
+	fmt.Fprintf(&sb, "- **Total Tokens**: %d\n\n", result.Trace.TotalTokens)
+
+	// Layer A: Outcome
+	if result.Outcome != nil {
+		sb.WriteString("## Layer A: Outcome\n\n")
+		if len(result.Outcome.FindingKeywordsFound) > 0 || len(result.Outcome.FindingKeywordsMissed) > 0 {
+			sb.WriteString("### Keywords\n")
+			for _, kw := range result.Outcome.FindingKeywordsFound {
+				fmt.Fprintf(&sb, "- [x] %s\n", kw)
+			}
+			for _, kw := range result.Outcome.FindingKeywordsMissed {
+				fmt.Fprintf(&sb, "- [ ] %s\n", kw)
+			}
+			sb.WriteString("\n")
+		}
+		fmt.Fprintf(&sb, "**Severity Match**: %v\n\n", result.Outcome.SeverityMatch)
+
+		if len(result.Outcome.CriteriaResults) > 0 {
+			sb.WriteString("### LLM Judge Criteria\n")
+			for _, cr := range result.Outcome.CriteriaResults {
+				status := "FAIL"
+				if cr.Pass {
+					status = "PASS"
+				}
+				fmt.Fprintf(&sb, "- **%s**: %s\n  - %s\n", status, cr.Criterion, cr.Reasoning)
+			}
+			sb.WriteString("\n")
+		}
+	}
+
+	// Layer B: Trajectory
+	if result.Trajectory != nil {
+		sb.WriteString("## Layer B: Trajectory\n\n")
+		sb.WriteString("### Must Call\n")
+		for tool, called := range result.Trajectory.MustCallResults {
+			mark := "[ ]"
+			if called {
+				mark = "[x]"
+			}
+			fmt.Fprintf(&sb, "- %s %s\n", mark, tool)
+		}
+		sb.WriteString("\n### Must Not Call\n")
+		for tool, violated := range result.Trajectory.MustNotCallResults {
+			status := "OK"
+			if violated {
+				status = "VIOLATED"
+			}
+			fmt.Fprintf(&sb, "- %s: %s\n", tool, status)
+		}
+		fmt.Fprintf(&sb, "\n**Ordered Calls**: %v — %s\n\n", result.Trajectory.OrderedCallsPass, result.Trajectory.OrderedCallsDetail)
+	}
+
+	// Layer C: Efficiency
+	if result.Efficiency != nil {
+		sb.WriteString("## Layer C: Efficiency\n\n")
+		fmt.Fprintf(&sb, "- Total Calls: %d (max pass: %v)\n", result.Efficiency.TotalCalls, result.Efficiency.MaxCallsPass)
+		fmt.Fprintf(&sb, "- Duplicate Calls: %d (max pass: %v)\n", result.Efficiency.DuplicateCalls, result.Efficiency.MaxDuplicatePass)
+		fmt.Fprintf(&sb, "- Duration: %s\n", result.Efficiency.Duration)
+		fmt.Fprintf(&sb, "- Total Tokens: %d\n\n", result.Efficiency.TotalTokens)
+	}
+
+	// Tool Call Trace
+	sb.WriteString("## Tool Call Trace\n\n")
+	sb.WriteString("| # | Tool | Source | Duration |\n")
+	sb.WriteString("|---|------|--------|----------|\n")
+	for _, tc := range result.Trace.ToolCalls {
+		fmt.Fprintf(&sb, "| %d | %s | %s | %s |\n", tc.Sequence, tc.ToolName, tc.Source, tc.Duration)
+	}
+	sb.WriteString("\n")
+
+	deterministicSection := sb.String()
+
+	// Use LLM to generate a summary if available
+	if llmClient != nil {
+		summary, err := generateLLMSummary(ctx, result, llmClient)
+		if err == nil && summary != "" {
+			return deterministicSection + "## Summary\n\n" + summary + "\n", nil
+		}
+	}
+
+	return deterministicSection, nil
+}
+
+func generateLLMSummary(ctx context.Context, result *eval.EvalResult, llmClient gollem.LLMClient) (string, error) {
+	resultJSON, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return "", goerr.Wrap(err, "failed to marshal eval result for LLM")
+	}
+
+	session, err := llmClient.NewSession(ctx,
+		gollem.WithSessionSystemPrompt("You are an evaluation report writer. Summarize the evaluation results concisely in markdown. Focus on what passed, what failed, and actionable insights. Be brief."),
+	)
+	if err != nil {
+		return "", goerr.Wrap(err, "failed to create LLM session for report")
+	}
+
+	prompt := fmt.Sprintf("Summarize this evaluation result:\n\n```json\n%s\n```", string(resultJSON))
+	resp, err := session.Generate(ctx, []gollem.Input{gollem.Text(prompt)})
+	if err != nil {
+		return "", goerr.Wrap(err, "failed to generate LLM summary")
+	}
+
+	return strings.TrimSpace(strings.Join(resp.Texts, "")), nil
+}

--- a/pkg/usecase/eval/response.go
+++ b/pkg/usecase/eval/response.go
@@ -44,7 +44,7 @@ func NewResponseStore(responsesDir string) (*ResponseStore, error) {
 			continue
 		}
 
-		data, err := os.ReadFile(filepath.Join(responsesDir, entry.Name())) // #nosec G304 -- path from scenario dir
+		data, err := os.ReadFile(filepath.Clean(filepath.Join(responsesDir, entry.Name())))
 		if err != nil {
 			return nil, goerr.Wrap(err, "failed to read response file",
 				goerr.V("file", entry.Name()))

--- a/pkg/usecase/eval/response.go
+++ b/pkg/usecase/eval/response.go
@@ -44,7 +44,7 @@ func NewResponseStore(responsesDir string) (*ResponseStore, error) {
 			continue
 		}
 
-		data, err := os.ReadFile(filepath.Join(responsesDir, entry.Name()))
+		data, err := os.ReadFile(filepath.Join(responsesDir, entry.Name())) // #nosec G304 -- path from scenario dir
 		if err != nil {
 			return nil, goerr.Wrap(err, "failed to read response file",
 				goerr.V("file", entry.Name()))
@@ -93,7 +93,7 @@ func (s *ResponseStore) Save(toolName string, args map[string]any, response map[
 		return goerr.Wrap(err, "failed to marshal response file")
 	}
 
-	if err := os.WriteFile(filePath, data, 0o640); err != nil {
+	if err := os.WriteFile(filePath, data, 0o600); err != nil {
 		return goerr.Wrap(err, "failed to write response file",
 			goerr.V("path", filePath))
 	}

--- a/pkg/usecase/eval/response.go
+++ b/pkg/usecase/eval/response.go
@@ -1,0 +1,161 @@
+package eval
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+
+	"github.com/m-mizutani/goerr/v2"
+	"github.com/secmon-lab/warren/pkg/domain/model/eval"
+)
+
+// ResponseStore manages tool response files in the responses/ directory.
+// It provides lookup by tool name + args, and saves newly generated responses.
+type ResponseStore struct {
+	dir   string
+	mu    sync.RWMutex
+	index map[string]*eval.ResponseFile // key: tool_name + args_hash -> response
+}
+
+// NewResponseStore creates a ResponseStore and indexes existing response files.
+func NewResponseStore(responsesDir string) (*ResponseStore, error) {
+	store := &ResponseStore{
+		dir:   responsesDir,
+		index: make(map[string]*eval.ResponseFile),
+	}
+
+	if err := os.MkdirAll(responsesDir, 0o750); err != nil {
+		return nil, goerr.Wrap(err, "failed to create responses directory",
+			goerr.V("dir", responsesDir))
+	}
+
+	entries, err := os.ReadDir(responsesDir)
+	if err != nil {
+		return nil, goerr.Wrap(err, "failed to read responses directory",
+			goerr.V("dir", responsesDir))
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+
+		data, err := os.ReadFile(filepath.Join(responsesDir, entry.Name()))
+		if err != nil {
+			return nil, goerr.Wrap(err, "failed to read response file",
+				goerr.V("file", entry.Name()))
+		}
+
+		var rf eval.ResponseFile
+		if err := json.Unmarshal(data, &rf); err != nil {
+			return nil, goerr.Wrap(err, "failed to parse response file",
+				goerr.V("file", entry.Name()))
+		}
+
+		key := responseKey(rf.ToolName, rf.Args)
+		store.index[key] = &rf
+	}
+
+	return store, nil
+}
+
+// Lookup finds a cached response for the given tool call.
+// Returns nil if no matching response exists.
+func (s *ResponseStore) Lookup(toolName string, args map[string]any) *eval.ResponseFile {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	key := responseKey(toolName, args)
+	return s.index[key]
+}
+
+// Save persists a response to the responses/ directory and adds it to the index.
+func (s *ResponseStore) Save(toolName string, args map[string]any, response map[string]any) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	rf := &eval.ResponseFile{
+		ToolName: toolName,
+		Args:     args,
+		Response: response,
+	}
+
+	key := responseKey(toolName, args)
+	filename := fmt.Sprintf("%s__%s.json", toolName, argsHash(args))
+	filePath := filepath.Join(s.dir, filename)
+
+	data, err := json.MarshalIndent(rf, "", "  ")
+	if err != nil {
+		return goerr.Wrap(err, "failed to marshal response file")
+	}
+
+	if err := os.WriteFile(filePath, data, 0o640); err != nil {
+		return goerr.Wrap(err, "failed to write response file",
+			goerr.V("path", filePath))
+	}
+
+	s.index[key] = rf
+	return nil
+}
+
+// responseKey generates a lookup key from tool name and args.
+func responseKey(toolName string, args map[string]any) string {
+	return toolName + "__" + argsHash(args)
+}
+
+// argsHash generates a deterministic hash of tool arguments.
+// Rules:
+// 1. Map keys sorted recursively
+// 2. Numbers kept as-is (float64 from JSON)
+// 3. Arrays preserve order
+// 4. nil values excluded
+// 5. Normalized JSON -> SHA256 first 8 hex chars
+func argsHash(args map[string]any) string {
+	normalized := normalizeValue(args)
+	data, err := json.Marshal(normalized)
+	if err != nil {
+		// Fallback: hash the fmt representation
+		data = fmt.Appendf(nil, "%v", args)
+	}
+	h := sha256.Sum256(data)
+	return fmt.Sprintf("%x", h[:4])
+}
+
+// normalizeValue recursively normalizes a value for deterministic JSON serialization.
+func normalizeValue(v any) any {
+	switch val := v.(type) {
+	case map[string]any:
+		return normalizeMap(val)
+	case []any:
+		result := make([]any, 0, len(val))
+		for _, item := range val {
+			result = append(result, normalizeValue(item))
+		}
+		return result
+	default:
+		return v
+	}
+}
+
+// normalizeMap returns an ordered representation of a map.
+// Keys are sorted alphabetically, nil values are excluded.
+func normalizeMap(m map[string]any) [][2]any {
+	keys := make([]string, 0, len(m))
+	for k, v := range m {
+		if v == nil {
+			continue
+		}
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	result := make([][2]any, 0, len(keys))
+	for _, k := range keys {
+		result = append(result, [2]any{k, normalizeValue(m[k])})
+	}
+	return result
+}

--- a/pkg/usecase/eval/response_test.go
+++ b/pkg/usecase/eval/response_test.go
@@ -1,0 +1,88 @@
+package eval_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/m-mizutani/gt"
+	"github.com/secmon-lab/warren/pkg/usecase/eval"
+)
+
+func TestResponseStore_LookupPreDefined(t *testing.T) {
+	dir := t.TempDir()
+	responsesDir := filepath.Join(dir, "responses")
+	gt.NoError(t, os.MkdirAll(responsesDir, 0o750))
+
+	// Write a pre-defined response file
+	content := `{"tool_name":"virustotal","args":{"ip":"1.2.3.4"},"response":{"malicious":true}}`
+	gt.NoError(t, os.WriteFile(filepath.Join(responsesDir, "virustotal__test.json"), []byte(content), 0o640))
+
+	store, err := eval.NewResponseStore(responsesDir)
+	gt.NoError(t, err)
+
+	// Lookup should find it
+	result := store.Lookup("virustotal", map[string]any{"ip": "1.2.3.4"})
+	gt.V(t, result).NotNil()
+	gt.V(t, result.Response["malicious"]).Equal(true)
+
+	// Lookup with different args should return nil
+	result = store.Lookup("virustotal", map[string]any{"ip": "5.6.7.8"})
+	gt.V(t, result).Nil()
+}
+
+func TestResponseStore_Save(t *testing.T) {
+	dir := t.TempDir()
+	responsesDir := filepath.Join(dir, "responses")
+
+	store, err := eval.NewResponseStore(responsesDir)
+	gt.NoError(t, err)
+
+	args := map[string]any{"query": "SELECT 1"}
+	response := map[string]any{"rows": []any{map[string]any{"col": 1.0}}}
+
+	gt.NoError(t, store.Save("bigquery_query", args, response))
+
+	// Should be findable after save
+	result := store.Lookup("bigquery_query", args)
+	gt.V(t, result).NotNil()
+	gt.V(t, result.ToolName).Equal("bigquery_query")
+
+	// Should persist to disk
+	entries, err := os.ReadDir(responsesDir)
+	gt.NoError(t, err)
+	gt.V(t, len(entries)).Equal(1)
+}
+
+func TestResponseStore_ArgsHashDeterministic(t *testing.T) {
+	dir := t.TempDir()
+	responsesDir := filepath.Join(dir, "responses")
+
+	store, err := eval.NewResponseStore(responsesDir)
+	gt.NoError(t, err)
+
+	// Save with one key order
+	args1 := map[string]any{"b": "2", "a": "1"}
+	gt.NoError(t, store.Save("tool", args1, map[string]any{"ok": true}))
+
+	// Lookup with different key order should still match
+	args2 := map[string]any{"a": "1", "b": "2"}
+	result := store.Lookup("tool", args2)
+	gt.V(t, result).NotNil()
+	gt.V(t, result.Response["ok"]).Equal(true)
+}
+
+func TestResponseStore_NilArgsExcluded(t *testing.T) {
+	dir := t.TempDir()
+	responsesDir := filepath.Join(dir, "responses")
+
+	store, err := eval.NewResponseStore(responsesDir)
+	gt.NoError(t, err)
+
+	// Save without nil
+	gt.NoError(t, store.Save("tool", map[string]any{"key": "val"}, map[string]any{"ok": true}))
+
+	// Lookup with extra nil key should match
+	result := store.Lookup("tool", map[string]any{"key": "val", "extra": nil})
+	gt.V(t, result).NotNil()
+}

--- a/pkg/usecase/eval/runner.go
+++ b/pkg/usecase/eval/runner.go
@@ -1,0 +1,176 @@
+package eval
+
+import (
+	"context"
+	"time"
+
+	"github.com/m-mizutani/goerr/v2"
+	"github.com/m-mizutani/gollem"
+	"github.com/secmon-lab/warren/pkg/domain/interfaces"
+	"github.com/secmon-lab/warren/pkg/domain/model/eval"
+	"github.com/secmon-lab/warren/pkg/domain/model/ticket"
+	"github.com/secmon-lab/warren/pkg/domain/types"
+	"github.com/secmon-lab/warren/pkg/usecase"
+	"github.com/secmon-lab/warren/pkg/usecase/eval/mock"
+	"github.com/secmon-lab/warren/pkg/utils/logging"
+	"github.com/secmon-lab/warren/pkg/utils/request_id"
+)
+
+// Runner executes an evaluation scenario.
+type Runner struct {
+	scenario    *eval.Scenario
+	scenarioDir string
+	uc          *usecase.UseCases
+	mockAgent   *mock.Agent
+	store       *ResponseStore
+	recorder    *TraceRecorder
+	llmClient   gollem.LLMClient // For eval (LLM judge, report generation)
+}
+
+// RunnerOption configures a Runner.
+type RunnerOption func(*Runner)
+
+// WithLLMClientForEval sets the LLM client used for evaluation (judge + report).
+func WithLLMClientForEval(client gollem.LLMClient) RunnerOption {
+	return func(r *Runner) { r.llmClient = client }
+}
+
+// NewRunner creates a new evaluation Runner.
+// It sets up the ResponseStore, MockAgent, wraps the tools, and constructs the UseCases.
+func NewRunner(
+	ctx context.Context,
+	scenario *eval.Scenario,
+	scenarioDir string,
+	mockLLM gollem.LLMClient,
+	ucOpts []usecase.Option,
+	originalTools []interfaces.ToolSet,
+	opts ...RunnerOption,
+) (*Runner, error) {
+	// Setup response store
+	store, err := NewResponseStore(ResponsesDir(scenarioDir))
+	if err != nil {
+		return nil, goerr.Wrap(err, "failed to create response store")
+	}
+
+	// Setup mock agent
+	mockAgent := mock.New(mockLLM, scenario.World)
+
+	// Setup trace recorder
+	recorder := NewTraceRecorder()
+
+	// Wrap tools for eval
+	wrappedTools := WrapForEval(originalTools, store, mockAgent, recorder)
+
+	// Replace tools in usecase options
+	ucOpts = append(ucOpts, usecase.WithTools(wrappedTools))
+
+	// Create the usecase
+	uc := usecase.New(ucOpts...)
+
+	r := &Runner{
+		scenario:    scenario,
+		scenarioDir: scenarioDir,
+		uc:          uc,
+		mockAgent:   mockAgent,
+		store:       store,
+		recorder:    recorder,
+	}
+
+	for _, opt := range opts {
+		opt(r)
+	}
+
+	return r, nil
+}
+
+// RunCLI executes the scenario in CLI mode:
+// 1. HandleAlert → pipeline + ticket creation
+// 2. ChatFromCLI → initial_message
+// 3. Evaluate + Report
+func (r *Runner) RunCLI(ctx context.Context) (*eval.EvalResult, error) {
+	logger := logging.From(ctx)
+	startTime := time.Now()
+
+	// Generate request ID and use it as both run ID and gollem trace ID
+	ctx, runID := request_id.Generate(ctx)
+
+	logger.Info("eval: starting CLI run",
+		"scenario", r.scenario.Name,
+		"run_id", runID,
+	)
+
+	// Step 1: HandleAlert
+	alerts, err := r.uc.HandleAlert(ctx, r.scenario.Alert.Schema, r.scenario.Alert.Data)
+	if err != nil {
+		return nil, goerr.Wrap(err, "HandleAlert failed during eval")
+	}
+
+	if len(alerts) == 0 {
+		logger.Warn("eval: HandleAlert produced no alerts, skipping chat phase")
+		return r.buildEvalResult(ctx, runID, startTime)
+	}
+
+	// Find the ticket for the first alert
+	firstAlert := alerts[0]
+	logger.Info("eval: alert created",
+		"alert_id", firstAlert.ID,
+		"ticket_id", firstAlert.TicketID,
+	)
+
+	// Step 2: ChatFromCLI with initial_message
+	if r.scenario.InitialMessage != "" {
+		t := &ticket.Ticket{
+			ID:       firstAlert.TicketID,
+			AlertIDs: []types.AlertID{firstAlert.ID},
+		}
+
+		logger.Info("eval: sending initial message",
+			"message", r.scenario.InitialMessage,
+			"ticket_id", t.ID,
+		)
+
+		if err := r.uc.ChatFromCLI(ctx, t, r.scenario.InitialMessage); err != nil {
+			return nil, goerr.Wrap(err, "ChatFromCLI failed during eval")
+		}
+	}
+
+	// Step 3: Build eval result
+	return r.buildEvalResult(ctx, runID, startTime)
+}
+
+// RunSlack executes the scenario in Slack simulation mode:
+// 1. Start HTTP server with Slack event handling
+// 2. HandleAlert → alert posted to Slack
+// 3. Wait for ticket close
+// 4. Evaluate + Report
+//
+// This mode requires the serve command's HTTP/Slack infrastructure.
+// Implementation pending CoreDeps shared setup extraction.
+func (r *Runner) RunSlack(_ context.Context) (*eval.EvalResult, error) {
+	return nil, goerr.New("slack simulation mode is not yet implemented; requires serve command infrastructure (CoreDeps extraction)")
+}
+
+func (r *Runner) buildEvalResult(ctx context.Context, runID string, startTime time.Time) (*eval.EvalResult, error) {
+	records := r.recorder.Records()
+
+	var totalTokens int64
+	for _, rec := range records {
+		totalTokens += rec.TokensUsed
+	}
+
+	trace := &eval.Trace{
+		ScenarioName: r.scenario.Name,
+		RunID:        runID,
+		StartTime:    startTime,
+		EndTime:      time.Now(),
+		ToolCalls:    records,
+		TotalTokens:  totalTokens,
+	}
+
+	evalResult, err := Evaluate(ctx, trace, r.scenario.Expectations, r.llmClient)
+	if err != nil {
+		return nil, goerr.Wrap(err, "evaluation failed")
+	}
+
+	return evalResult, nil
+}

--- a/pkg/usecase/eval/runner.go
+++ b/pkg/usecase/eval/runner.go
@@ -196,7 +196,7 @@ func (r *Runner) buildEvalResult(ctx context.Context, runID string, startTime ti
 // loadGollemTrace loads a gollem trace JSON file from the traces directory.
 func loadGollemTrace(tracesDir, traceID string) *gollemTrace.Trace {
 	filePath := filepath.Join(tracesDir, traceID+".json")
-	data, err := os.ReadFile(filePath) // #nosec G304 -- path from scenario dir + trace ID
+	data, err := os.ReadFile(filepath.Clean(filePath))
 	if err != nil {
 		return nil
 	}

--- a/pkg/usecase/eval/runner.go
+++ b/pkg/usecase/eval/runner.go
@@ -196,7 +196,7 @@ func (r *Runner) buildEvalResult(ctx context.Context, runID string, startTime ti
 // loadGollemTrace loads a gollem trace JSON file from the traces directory.
 func loadGollemTrace(tracesDir, traceID string) *gollemTrace.Trace {
 	filePath := filepath.Join(tracesDir, traceID+".json")
-	data, err := os.ReadFile(filePath)
+	data, err := os.ReadFile(filePath) // #nosec G304 -- path from scenario dir + trace ID
 	if err != nil {
 		return nil
 	}

--- a/pkg/usecase/eval/runner.go
+++ b/pkg/usecase/eval/runner.go
@@ -2,10 +2,17 @@ package eval
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/m-mizutani/goerr/v2"
 	"github.com/m-mizutani/gollem"
+	gollemTrace "github.com/m-mizutani/gollem/trace"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	"github.com/secmon-lab/warren/pkg/domain/model/eval"
 	"github.com/secmon-lab/warren/pkg/domain/model/ticket"
@@ -13,6 +20,7 @@ import (
 	"github.com/secmon-lab/warren/pkg/usecase"
 	"github.com/secmon-lab/warren/pkg/usecase/eval/mock"
 	"github.com/secmon-lab/warren/pkg/utils/logging"
+	"github.com/secmon-lab/warren/pkg/utils/msg"
 	"github.com/secmon-lab/warren/pkg/utils/request_id"
 )
 
@@ -94,6 +102,10 @@ func (r *Runner) RunCLI(ctx context.Context) (*eval.EvalResult, error) {
 	// Generate request ID and use it as both run ID and gollem trace ID
 	ctx, runID := request_id.Generate(ctx)
 
+	// Capture msg.Notify/Trace/Warn output for evaluation
+	capture := newMessageCapture()
+	ctx = msg.With(ctx, capture.notifyFunc(), capture.traceFunc(), capture.warnFunc())
+
 	logger.Info("eval: starting CLI run",
 		"scenario", r.scenario.Name,
 		"run_id", runID,
@@ -107,7 +119,7 @@ func (r *Runner) RunCLI(ctx context.Context) (*eval.EvalResult, error) {
 
 	if len(alerts) == 0 {
 		logger.Warn("eval: HandleAlert produced no alerts, skipping chat phase")
-		return r.buildEvalResult(ctx, runID, startTime)
+		return r.buildEvalResult(ctx, runID, startTime, capture.agentOutput())
 	}
 
 	// Find the ticket for the first alert
@@ -135,7 +147,7 @@ func (r *Runner) RunCLI(ctx context.Context) (*eval.EvalResult, error) {
 	}
 
 	// Step 3: Build eval result
-	return r.buildEvalResult(ctx, runID, startTime)
+	return r.buildEvalResult(ctx, runID, startTime, capture.agentOutput())
 }
 
 // RunSlack executes the scenario in Slack simulation mode:
@@ -150,7 +162,8 @@ func (r *Runner) RunSlack(_ context.Context) (*eval.EvalResult, error) {
 	return nil, goerr.New("slack simulation mode is not yet implemented; requires serve command infrastructure (CoreDeps extraction)")
 }
 
-func (r *Runner) buildEvalResult(ctx context.Context, runID string, startTime time.Time) (*eval.EvalResult, error) {
+func (r *Runner) buildEvalResult(ctx context.Context, runID string, startTime time.Time, agentOutput string) (*eval.EvalResult, error) {
+	logger := logging.From(ctx)
 	records := r.recorder.Records()
 
 	var totalTokens int64
@@ -164,13 +177,75 @@ func (r *Runner) buildEvalResult(ctx context.Context, runID string, startTime ti
 		StartTime:    startTime,
 		EndTime:      time.Now(),
 		ToolCalls:    records,
+		AgentOutput:  agentOutput,
 		TotalTokens:  totalTokens,
 	}
 
-	evalResult, err := Evaluate(ctx, trace, r.scenario.Expectations, r.llmClient)
-	if err != nil {
-		return nil, goerr.Wrap(err, "evaluation failed")
+	// Try to load gollem trace for agent-based evaluation
+	gollemTraceData := loadGollemTrace(filepath.Join(r.scenarioDir, "traces"), runID)
+	if gollemTraceData != nil {
+		logger.Info("eval: using agent-based evaluation with gollem trace", "trace_id", runID)
+		return EvaluateWithAgent(ctx, trace, gollemTraceData, r.scenario.Expectations, agentOutput, r.llmClient)
 	}
 
-	return evalResult, nil
+	// Fallback to basic evaluation
+	logger.Info("eval: gollem trace not found, using basic evaluation")
+	return Evaluate(ctx, trace, r.scenario.Expectations, r.llmClient)
+}
+
+// loadGollemTrace loads a gollem trace JSON file from the traces directory.
+func loadGollemTrace(tracesDir, traceID string) *gollemTrace.Trace {
+	filePath := filepath.Join(tracesDir, traceID+".json")
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil
+	}
+
+	var t gollemTrace.Trace
+	if err := json.Unmarshal(data, &t); err != nil {
+		return nil
+	}
+
+	return &t
+}
+
+// messageCapture collects msg.Notify/Trace/Warn messages during eval execution.
+type messageCapture struct {
+	mu       sync.Mutex
+	messages []string
+}
+
+func newMessageCapture() *messageCapture {
+	return &messageCapture{}
+}
+
+func (c *messageCapture) append(prefix, message string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.messages = append(c.messages, fmt.Sprintf("[%s] %s", prefix, message))
+}
+
+func (c *messageCapture) notifyFunc() msg.NotifyFunc {
+	return func(_ context.Context, message string) {
+		c.append("notify", message)
+	}
+}
+
+func (c *messageCapture) traceFunc() msg.TraceFunc {
+	return func(_ context.Context, message string) {
+		c.append("trace", message)
+	}
+}
+
+func (c *messageCapture) warnFunc() msg.WarnFunc {
+	return func(_ context.Context, message string) {
+		c.append("warn", message)
+	}
+}
+
+// agentOutput returns all captured messages joined as a single string.
+func (c *messageCapture) agentOutput() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return strings.Join(c.messages, "\n")
 }

--- a/pkg/usecase/eval/toolset.go
+++ b/pkg/usecase/eval/toolset.go
@@ -1,0 +1,143 @@
+package eval
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/m-mizutani/gollem"
+	"github.com/secmon-lab/warren/pkg/domain/interfaces"
+	"github.com/secmon-lab/warren/pkg/domain/model/eval"
+	"github.com/secmon-lab/warren/pkg/usecase/eval/mock"
+	"github.com/secmon-lab/warren/pkg/utils/logging"
+)
+
+// TraceRecorder collects tool call records during an evaluation run.
+type TraceRecorder struct {
+	mu       sync.Mutex
+	records  []eval.ToolCallRecord
+	sequence atomic.Int32
+}
+
+// NewTraceRecorder creates a new TraceRecorder.
+func NewTraceRecorder() *TraceRecorder {
+	return &TraceRecorder{}
+}
+
+// Record adds a tool call record.
+func (r *TraceRecorder) Record(record eval.ToolCallRecord) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.records = append(r.records, record)
+}
+
+// Records returns all recorded tool calls.
+func (r *TraceRecorder) Records() []eval.ToolCallRecord {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	result := make([]eval.ToolCallRecord, len(r.records))
+	copy(result, r.records)
+	return result
+}
+
+// NextSequence returns the next sequence number.
+func (r *TraceRecorder) NextSequence() int {
+	return int(r.sequence.Add(1))
+}
+
+// EvalToolSet wraps a real ToolSet and intercepts Run() calls.
+// Specs(), ID(), Description(), Prompt() are all delegated to the real tool.
+type EvalToolSet struct {
+	real      interfaces.ToolSet
+	store     *ResponseStore
+	mockAgent *mock.Agent
+	recorder  *TraceRecorder
+}
+
+// Specs delegates to the real ToolSet so the LLM sees correct tool definitions.
+func (e *EvalToolSet) Specs(ctx context.Context) ([]gollem.ToolSpec, error) {
+	return e.real.Specs(ctx)
+}
+
+// Run intercepts the tool call and resolves the response from:
+// 1. ResponseStore (pre-defined or previously generated)
+// 2. MockAgent (dynamic LLM generation, saved to ResponseStore)
+// The real tool's Run() is never called.
+func (e *EvalToolSet) Run(ctx context.Context, name string, args map[string]any) (map[string]any, error) {
+	start := time.Now()
+	seq := e.recorder.NextSequence()
+
+	// Try ResponseStore first
+	if rf := e.store.Lookup(name, args); rf != nil {
+		record := eval.ToolCallRecord{
+			Sequence: seq,
+			ToolName: name,
+			Args:     args,
+			Response: rf.Response,
+			Source:   eval.ResponseSourcePreDefined,
+			Duration: time.Since(start),
+		}
+		e.recorder.Record(record)
+		return rf.Response, nil
+	}
+
+	// Generate with MockAgent
+	response, tokens, err := e.mockAgent.Generate(ctx, name, args)
+	if err != nil {
+		logging.From(ctx).Error("mock agent generation failed",
+			"tool", name,
+			"error", err,
+		)
+		// Return error as a tool response so the Warren agent can see it
+		response = map[string]any{
+			"error": err.Error(),
+		}
+	}
+
+	// Save to ResponseStore for future runs
+	if saveErr := e.store.Save(name, args, response); saveErr != nil {
+		logging.From(ctx).Error("failed to save generated response",
+			"tool", name,
+			"error", saveErr,
+		)
+	}
+
+	record := eval.ToolCallRecord{
+		Sequence:   seq,
+		ToolName:   name,
+		Args:       args,
+		Response:   response,
+		Source:     eval.ResponseSourceGenerated,
+		Duration:   time.Since(start),
+		TokensUsed: tokens,
+	}
+	e.recorder.Record(record)
+
+	return response, nil
+}
+
+// ID delegates to the real ToolSet.
+func (e *EvalToolSet) ID() string { return e.real.ID() }
+
+// Description delegates to the real ToolSet.
+func (e *EvalToolSet) Description() string { return e.real.Description() }
+
+// Prompt delegates to the real ToolSet.
+func (e *EvalToolSet) Prompt(ctx context.Context) (string, error) { return e.real.Prompt(ctx) }
+
+// WrapForEval wraps all ToolSets with EvalToolSet for evaluation.
+// The returned ToolSets have the same Specs/ID/Description/Prompt as the originals,
+// but Run() is intercepted to use ResponseStore + MockAgent.
+func WrapForEval(tools []interfaces.ToolSet, store *ResponseStore, agent *mock.Agent, recorder *TraceRecorder) []interfaces.ToolSet {
+	wrapped := make([]interfaces.ToolSet, len(tools))
+	for i, ts := range tools {
+		wrapped[i] = &EvalToolSet{
+			real:      ts,
+			store:     store,
+			mockAgent: agent,
+			recorder:  recorder,
+		}
+	}
+	return wrapped
+}


### PR DESCRIPTION
## Summary
- Add `warren eval run` / `warren eval validate` CLI commands for scenario-based agent evaluation
- EvalToolSet wraps real ToolSets to intercept tool calls with pre-defined or LLM-generated mock responses, requiring no changes to existing chat usecase/strategy code
- 3-layer evaluation: Outcome (keywords + LLM judge), Trajectory (must_call/ordered_calls), Efficiency (call limits)
- gollem trace integration for full execution recording
- Claude Code skill (`/create-eval-scenario`) for guided scenario creation

## Test plan
- [x] Unit tests for ResponseStore, Evaluator, Loader (24 tests total)
- [x] `go vet ./...` passes
- [x] `golangci-lint` 0 issues
- [x] Manual eval run with GKE suspicious process scenario — full trace recorded, report generated
- [ ] Review trace output for completeness
- [ ] Test scenario validation catches bad scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)