### PR TITLE
feat: improve Slack status display with prompt name and intent

### DIFF
--- a/pkg/usecase/chat/bluebell/bluebell.go
+++ b/pkg/usecase/chat/bluebell/bluebell.go
@@ -3,6 +3,7 @@ package bluebell
 import (
 	"context"
 	"fmt"
+	"math/rand/v2"
 	"strings"
 	"time"
 
@@ -209,7 +210,12 @@ func (c *BluebellChat) executeBluebell(ctx context.Context, ssn *session.Session
 			if requestID == "" {
 				requestID = "unknown"
 			}
-			if postErr := threadSvc.PostContextBlock(ctx, fmt.Sprintf("Executing as `%s` ... (ID: `%s`)", promptLabel, requestID)); postErr != nil {
+			verbs := []string{
+				"Executing as", "Running as", "Processing as", "Operating as",
+				"Engaging as", "Launching as", "Activating as", "Invoking as",
+			}
+			verb := verbs[rand.IntN(len(verbs))] // #nosec G404 -- not security-sensitive, just picking a random UI verb
+			if postErr := threadSvc.PostContextBlock(ctx, fmt.Sprintf("%s `%s` ... (ID: `%s`)", verb, promptLabel, requestID)); postErr != nil {
 				logging.From(ctx).Error("failed to post execution status", "error", postErr)
 			}
 			if resolvedIntent != "" {

--- a/pkg/usecase/chat/bluebell/bluebell.go
+++ b/pkg/usecase/chat/bluebell/bluebell.go
@@ -198,15 +198,24 @@ func (c *BluebellChat) executeBluebell(ctx context.Context, ssn *session.Session
 	var resolvedIntent string
 	if resolved != nil {
 		resolvedIntent = resolved.Intent
-		// Post context block showing which prompt was selected
+		// Post context blocks showing execution status and intent
 		if c.slackService != nil && target.SlackThread != nil {
 			threadSvc := c.slackService.NewThread(*target.SlackThread)
 			promptLabel := resolved.PromptName
 			if promptLabel == "" {
 				promptLabel = "(default)"
 			}
-			if postErr := threadSvc.PostContextBlock(ctx, fmt.Sprintf("📋 Prompt: `%s`", promptLabel)); postErr != nil {
-				logging.From(ctx).Error("failed to post prompt selection", "error", postErr)
+			requestID := request_id.FromContext(ctx)
+			if requestID == "" {
+				requestID = "unknown"
+			}
+			if postErr := threadSvc.PostContextBlock(ctx, fmt.Sprintf("Executing as `%s` ... (ID: `%s`)", promptLabel, requestID)); postErr != nil {
+				logging.From(ctx).Error("failed to post execution status", "error", postErr)
+			}
+			if resolvedIntent != "" {
+				if postErr := threadSvc.PostContextBlock(ctx, fmt.Sprintf("💬 %s", resolvedIntent)); postErr != nil {
+					logging.From(ctx).Error("failed to post intent", "error", postErr)
+				}
 			}
 		}
 	}

--- a/pkg/usecase/chat/bluebell/bluebell.go
+++ b/pkg/usecase/chat/bluebell/bluebell.go
@@ -206,10 +206,6 @@ func (c *BluebellChat) executeBluebell(ctx context.Context, ssn *session.Session
 			if promptLabel == "" {
 				promptLabel = "(default)"
 			}
-			requestID := request_id.FromContext(ctx)
-			if requestID == "" {
-				requestID = "unknown"
-			}
 			verbs := []string{
 				"Executing as", "Running as", "Processing as", "Operating as",
 				"Engaging as", "Launching as", "Activating as", "Invoking as",

--- a/pkg/usecase/chat/bluebell/bluebell_test.go
+++ b/pkg/usecase/chat/bluebell/bluebell_test.go
@@ -472,11 +472,11 @@ func TestBluebellChat_ContextBlock_ZeroEntries(t *testing.T) {
 	})
 	gt.NoError(t, err)
 
-	// Verify context block with "(default)" was posted
+	// Verify context block with "Executing as (default)" was posted
 	found := false
 	for _, opt := range *postedOptions {
 		rendered := renderMsgOption(opt)
-		if strings.Contains(rendered, "Prompt:") && strings.Contains(rendered, "(default)") {
+		if strings.Contains(rendered, "Executing as") && strings.Contains(rendered, "(default)") {
 			found = true
 			break
 		}
@@ -542,7 +542,7 @@ func TestBluebellChat_ContextBlock_WithPromptEntry(t *testing.T) {
 	found := false
 	for _, opt := range *postedOptions {
 		rendered := renderMsgOption(opt)
-		if strings.Contains(rendered, "Prompt:") && strings.Contains(rendered, "Security Investigation") {
+		if strings.Contains(rendered, "Executing as") && strings.Contains(rendered, "Security Investigation") {
 			found = true
 			break
 		}
@@ -586,7 +586,7 @@ func TestBluebellChat_ContextBlock_NoSlackThread(t *testing.T) {
 	// No context block should be posted (no SlackThread)
 	for _, opt := range *postedOptions {
 		rendered := renderMsgOption(opt)
-		gt.V(t, strings.Contains(rendered, "Prompt:")).Equal(false)
+		gt.V(t, strings.Contains(rendered, "Executing as")).Equal(false)
 	}
 }
 

--- a/pkg/usecase/chat/bluebell/bluebell_test.go
+++ b/pkg/usecase/chat/bluebell/bluebell_test.go
@@ -476,7 +476,7 @@ func TestBluebellChat_ContextBlock_ZeroEntries(t *testing.T) {
 	found := false
 	for _, opt := range *postedOptions {
 		rendered := renderMsgOption(opt)
-		if strings.Contains(rendered, "Executing as") && strings.Contains(rendered, "(default)") {
+		if strings.Contains(rendered, " as ") && strings.Contains(rendered, "(default)") {
 			found = true
 			break
 		}
@@ -542,7 +542,7 @@ func TestBluebellChat_ContextBlock_WithPromptEntry(t *testing.T) {
 	found := false
 	for _, opt := range *postedOptions {
 		rendered := renderMsgOption(opt)
-		if strings.Contains(rendered, "Executing as") && strings.Contains(rendered, "Security Investigation") {
+		if strings.Contains(rendered, " as ") && strings.Contains(rendered, "Security Investigation") {
 			found = true
 			break
 		}
@@ -586,7 +586,7 @@ func TestBluebellChat_ContextBlock_NoSlackThread(t *testing.T) {
 	// No context block should be posted (no SlackThread)
 	for _, opt := range *postedOptions {
 		rendered := renderMsgOption(opt)
-		gt.V(t, strings.Contains(rendered, "Executing as")).Equal(false)
+		gt.V(t, strings.Contains(rendered, " as ")).Equal(false)
 	}
 }
 

--- a/pkg/usecase/chat/usecase.go
+++ b/pkg/usecase/chat/usecase.go
@@ -172,11 +172,7 @@ func (u *UseCase) setupMessageRouting(ctx context.Context, ssn *session.Session,
 		notifyFunc, traceFunc, warnFunc := u.setupSlackMessageFuncs(ctx, ssn, target)
 		ctx = msg.With(ctx, notifyFunc, traceFunc, warnFunc)
 
-		// Post request ID as a context block immediately
-		requestID := request_id.FromContext(ctx)
-		if requestID == "" {
-			requestID = "unknown"
-		}
+		// Post a brief status indicator as a context block immediately
 		verbs := []string{
 			"Investigating", "Analyzing", "Processing", "Inspecting",
 			"Examining", "Scanning", "Assessing", "Evaluating",
@@ -186,8 +182,8 @@ func (u *UseCase) setupMessageRouting(ctx context.Context, ssn *session.Session,
 		}
 		verb := verbs[rand.IntN(len(verbs))] // #nosec G404 -- not security-sensitive, just picking a random UI verb
 		threadSvc := u.slackService.NewThread(*target.SlackThread)
-		if err := threadSvc.PostContextBlock(ctx, fmt.Sprintf("%s ... (ID: `%s`)", verb, requestID)); err != nil {
-			logging.From(ctx).Error("failed to post request ID", "error", err)
+		if err := threadSvc.PostContextBlock(ctx, fmt.Sprintf("%s ...", verb)); err != nil {
+			logging.From(ctx).Error("failed to post status", "error", err)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Simplify initial Slack status message to show only a random verb (e.g., "Assessing ...") without request ID
- Add detailed execution context in bluebell: `Executing as (default) ... (ID: xxx)` with prompt name and request ID
- Show resolved intent on a separate line with 💬 emoji for visual distinction

## Test plan
- [x] Existing bluebell context block tests updated and passing
- [x] `go vet`, `golangci-lint`, `gosec` all pass
- [ ] Manual verification in Slack thread to confirm display format

🤖 Generated with [Claude Code](https://claude.com/claude-code)