### PR TITLE
feat: add commit history and file blame to GitHub tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Visit http://127.0.0.1:8080 to access the dashboard.
 
 ### Code & Device Tools
 
-- [**GitHub App**](./pkg/tool/github/README.md) — code search, issue search, file content retrieval
+- [**GitHub App**](./pkg/tool/github/README.md) — code search, issue search, file content retrieval, commit history, file blame
 - [**Microsoft Intune**](./pkg/tool/intune/README.md) — device compliance status, sign-in history
 - [**Slack Message Search**](./pkg/tool/slack/README.md) — search workspace messages for context
 

--- a/doc/operation/alert-investigation.md
+++ b/doc/operation/alert-investigation.md
@@ -140,7 +140,7 @@ Warren's AI agent has access to the following tools during investigation. Tools 
 
 | Tool | Description | Details |
 |------|-------------|---------|
-| GitHub | Code search, issue search, file content | [README](../../pkg/tool/github/README.md) |
+| GitHub | Code search, issue search, file content, commit history, file blame | [README](../../pkg/tool/github/README.md) |
 | Microsoft Intune | Device compliance, sign-in history | [README](../../pkg/tool/intune/README.md) |
 
 ### Other Tools

--- a/pkg/tool/github/README.md
+++ b/pkg/tool/github/README.md
@@ -1,6 +1,6 @@
-# GitHub Code Search
+# GitHub
 
-Search code, issues, and pull requests across configured GitHub repositories using a GitHub App for authentication.
+Search code, issues, and pull requests, list commit history, and get file blame across configured GitHub repositories using a GitHub App for authentication.
 
 ## Configuration
 
@@ -18,6 +18,8 @@ Search code, issues, and pull requests across configured GitHub repositories usi
 | `github_code_search` | Search for code across repositories. Supports filters: `language`, `path`, `filename`, `repo_filter` |
 | `github_issue_search` | Search issues and pull requests. Supports filters: `state`, `labels`, `author`, `type`, `repo_filter` |
 | `github_get_content` | Get file content from a specific repository by owner, repo, path, and ref |
+| `github_list_commits` | List commits for a repository. Supports filters: `sha`, `path`, `author`, `per_page`, `page` |
+| `github_get_blame` | Get git blame for a file, showing which commit last modified each line. Uses GraphQL API |
 
 ## Setup
 

--- a/pkg/tool/github/action.go
+++ b/pkg/tool/github/action.go
@@ -42,7 +42,7 @@ func (x *Action) ID() string {
 }
 
 func (x *Action) Description() string {
-	return "GitHub code and issue search"
+	return "GitHub code and issue search, commit history, and file blame"
 }
 
 func (x *Action) Flags() []cli.Flag {
@@ -306,6 +306,81 @@ func (x *Action) Specs(ctx context.Context) ([]gollem.ToolSpec, error) {
 				},
 			},
 		},
+		{
+			Name:        "github_list_commits",
+			Description: "List commits for a repository. Supports filtering by file path, author, and branch/SHA. Useful for understanding change history and identifying who changed what and when.",
+			Parameters: map[string]*gollem.Parameter{
+				"owner": {
+					Type:        gollem.TypeString,
+					Description: "Repository owner (organization or username)",
+					Required:    true,
+					Pattern:     "^[a-zA-Z0-9][a-zA-Z0-9-]*$",
+					MinLength:   github.Ptr(1),
+					MaxLength:   github.Ptr(39),
+				},
+				"repo": {
+					Type:        gollem.TypeString,
+					Description: "Repository name",
+					Required:    true,
+					Pattern:     "^[a-zA-Z0-9_.-]+$",
+					MinLength:   github.Ptr(1),
+					MaxLength:   github.Ptr(100),
+				},
+				"sha": {
+					Type:        gollem.TypeString,
+					Description: "SHA or branch to start listing commits from. Defaults to the default branch.",
+				},
+				"path": {
+					Type:        gollem.TypeString,
+					Description: "Only commits containing this file path will be returned (e.g., 'src/main.go')",
+				},
+				"author": {
+					Type:        gollem.TypeString,
+					Description: "GitHub login or email address to filter commits by author",
+				},
+				"per_page": {
+					Type:        gollem.TypeInteger,
+					Description: "Number of commits per page (default: 30, max: 100)",
+				},
+				"page": {
+					Type:        gollem.TypeInteger,
+					Description: "Page number for pagination (default: 1)",
+				},
+			},
+		},
+		{
+			Name:        "github_get_blame",
+			Description: "Get git blame information for a file, showing which commit last modified each line. Useful for identifying who wrote specific code and when.",
+			Parameters: map[string]*gollem.Parameter{
+				"owner": {
+					Type:        gollem.TypeString,
+					Description: "Repository owner (organization or username)",
+					Required:    true,
+					Pattern:     "^[a-zA-Z0-9][a-zA-Z0-9-]*$",
+					MinLength:   github.Ptr(1),
+					MaxLength:   github.Ptr(39),
+				},
+				"repo": {
+					Type:        gollem.TypeString,
+					Description: "Repository name",
+					Required:    true,
+					Pattern:     "^[a-zA-Z0-9_.-]+$",
+					MinLength:   github.Ptr(1),
+					MaxLength:   github.Ptr(100),
+				},
+				"path": {
+					Type:        gollem.TypeString,
+					Description: "File path in the repository (e.g., 'src/main.go')",
+					Required:    true,
+					MinLength:   github.Ptr(1),
+				},
+				"ref": {
+					Type:        gollem.TypeString,
+					Description: "Git reference: branch name, tag, or commit SHA. Defaults to the repository's default branch.",
+					Pattern:     "^[a-zA-Z0-9/_.-]+$",
+				},
+			},
+		},
 	}, nil
 }
 
@@ -322,6 +397,10 @@ func (x *Action) Run(ctx context.Context, name string, args map[string]any) (map
 		return x.runIssueSearch(ctx, args)
 	case "github_get_content":
 		return x.runGetContent(ctx, args)
+	case "github_list_commits":
+		return x.runListCommits(ctx, args)
+	case "github_get_blame":
+		return x.runGetBlame(ctx, args)
 	default:
 		return nil, goerr.New("unknown tool name", goerr.V("name", name))
 	}
@@ -349,7 +428,7 @@ func (x *Action) Prompt(ctx context.Context) (string, error) {
 	}
 
 	sb.WriteString("\n")
-	sb.WriteString("Use the GitHub tools to search code, issues/PRs, or retrieve file contents from these repositories.\n")
+	sb.WriteString("Use the GitHub tools to search code, issues/PRs, retrieve file contents, list commit history, or get file blame from these repositories.\n")
 
 	return sb.String(), nil
 }

--- a/pkg/tool/github/action_test.go
+++ b/pkg/tool/github/action_test.go
@@ -402,12 +402,10 @@ func TestGitHubListCommits(t *testing.T) {
 	gt.S(t, commits[0].Message).Equal("Fix security vulnerability in auth handler")
 	gt.S(t, commits[0].Author).Equal("testuser")
 	gt.S(t, commits[0].HTMLURL).Equal("https://github.com/test/repo/commit/abc123def456")
-	gt.Number(t, commits[0].FilesChanged).Equal(2)
 
 	// Check second commit
 	gt.S(t, commits[1].SHA).Equal("789xyz")
 	gt.S(t, commits[1].Author).Equal("anotheruser")
-	gt.Number(t, commits[1].FilesChanged).Equal(0)
 }
 
 func TestGitHubListCommitsUnauthorizedRepo(t *testing.T) {

--- a/pkg/tool/github/action_test.go
+++ b/pkg/tool/github/action_test.go
@@ -2,9 +2,11 @@ package github_test
 
 import (
 	"context"
+	"net/http"
 	"os"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/google/go-github/v74/github"
 	"github.com/m-mizutani/gt"
@@ -320,6 +322,243 @@ func TestConfigureValidation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGitHubListCommits(t *testing.T) {
+	commitDate := time.Date(2024, 6, 15, 10, 30, 0, 0, time.UTC)
+
+	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatch(
+			mock.GetReposCommitsByOwnerByRepo,
+			[]*github.RepositoryCommit{
+				{
+					SHA:     github.Ptr("abc123def456"),
+					HTMLURL: github.Ptr("https://github.com/test/repo/commit/abc123def456"),
+					Commit: &github.Commit{
+						Message: github.Ptr("Fix security vulnerability in auth handler"),
+						Author: &github.CommitAuthor{
+							Name: github.Ptr("Test User"),
+							Date: &github.Timestamp{Time: commitDate},
+						},
+					},
+					Author: &github.User{
+						Login: github.Ptr("testuser"),
+					},
+					Files: []*github.CommitFile{
+						{Filename: github.Ptr("auth.go")},
+						{Filename: github.Ptr("auth_test.go")},
+					},
+				},
+				{
+					SHA:     github.Ptr("789xyz"),
+					HTMLURL: github.Ptr("https://github.com/test/repo/commit/789xyz"),
+					Commit: &github.Commit{
+						Message: github.Ptr("Initial commit"),
+						Author: &github.CommitAuthor{
+							Name: github.Ptr("Another User"),
+							Date: &github.Timestamp{Time: commitDate.Add(-24 * time.Hour)},
+						},
+					},
+					Author: &github.User{
+						Login: github.Ptr("anotheruser"),
+					},
+				},
+			},
+		),
+	)
+
+	client := github.NewClient(mockedHTTPClient)
+
+	action := &githubtool.Action{}
+	action.SetGitHubClient(client)
+	action.SetConfigs([]*githubtool.RepositoryConfig{
+		{
+			Owner:       "test",
+			Repository:  "repo",
+			Description: "Test repository",
+		},
+	})
+
+	ctx := context.Background()
+	args := map[string]any{
+		"owner":    "test",
+		"repo":     "repo",
+		"per_page": float64(10),
+	}
+
+	result, err := action.Run(ctx, "github_list_commits", args)
+	gt.NoError(t, err)
+	gt.NotNil(t, result)
+
+	// Validate results
+	gt.S(t, result["repository"].(string)).Equal("test/repo")
+	gt.Number(t, result["count"].(int)).Equal(2)
+
+	commits := gt.Cast[[]githubtool.CommitResult](t, result["commits"])
+	gt.A(t, commits).Length(2)
+
+	// Check first commit
+	gt.S(t, commits[0].SHA).Equal("abc123def456")
+	gt.S(t, commits[0].Message).Equal("Fix security vulnerability in auth handler")
+	gt.S(t, commits[0].Author).Equal("testuser")
+	gt.S(t, commits[0].HTMLURL).Equal("https://github.com/test/repo/commit/abc123def456")
+	gt.Number(t, commits[0].FilesChanged).Equal(2)
+
+	// Check second commit
+	gt.S(t, commits[1].SHA).Equal("789xyz")
+	gt.S(t, commits[1].Author).Equal("anotheruser")
+	gt.Number(t, commits[1].FilesChanged).Equal(0)
+}
+
+func TestGitHubListCommitsUnauthorizedRepo(t *testing.T) {
+	mockedHTTPClient := mock.NewMockedHTTPClient()
+	client := github.NewClient(mockedHTTPClient)
+
+	action := &githubtool.Action{}
+	action.SetGitHubClient(client)
+	action.SetConfigs([]*githubtool.RepositoryConfig{
+		{
+			Owner:      "allowed",
+			Repository: "repo",
+		},
+	})
+
+	ctx := context.Background()
+	args := map[string]any{
+		"owner": "unauthorized",
+		"repo":  "secret-repo",
+	}
+
+	_, err := action.Run(ctx, "github_list_commits", args)
+	gt.Error(t, err)
+	gt.S(t, err.Error()).Contains("repository not in configured list")
+}
+
+func TestGitHubGetBlame(t *testing.T) {
+	blameResponse := githubtool.GraphQLBlameResponse{
+		Data: githubtool.GraphQLBlameData{
+			Repository: githubtool.GraphQLRepository{
+				Object: &githubtool.GraphQLObject{
+					Blame: &githubtool.GraphQLBlame{
+						Ranges: []githubtool.GraphQLBlameRange{
+							{
+								StartingLine: 1,
+								EndingLine:   10,
+								Commit: githubtool.GraphQLCommitRef{
+									OID:     "abc123",
+									Message: "Initial commit",
+									Author: githubtool.GraphQLCommitAuthor{
+										Name: "testuser",
+										Date: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+									},
+								},
+							},
+							{
+								StartingLine: 11,
+								EndingLine:   25,
+								Commit: githubtool.GraphQLCommitRef{
+									OID:     "def456",
+									Message: "Add error handling",
+									Author: githubtool.GraphQLCommitAuthor{
+										Name: "anotheruser",
+										Date: time.Date(2024, 3, 15, 12, 0, 0, 0, time.UTC),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	graphQLEndpoint := mock.EndpointPattern{
+		Pattern: "/graphql",
+		Method:  "POST",
+	}
+
+	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatchHandler(
+			graphQLEndpoint,
+			http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write(mock.MustMarshal(blameResponse))
+			}),
+		),
+	)
+
+	client := github.NewClient(mockedHTTPClient)
+
+	action := &githubtool.Action{}
+	action.SetGitHubClient(client)
+	action.SetHTTPClient(mockedHTTPClient)
+	action.SetConfigs([]*githubtool.RepositoryConfig{
+		{
+			Owner:         "test",
+			Repository:    "repo",
+			Description:   "Test repository",
+			DefaultBranch: "main",
+		},
+	})
+
+	ctx := context.Background()
+	args := map[string]any{
+		"owner": "test",
+		"repo":  "repo",
+		"path":  "src/main.go",
+	}
+
+	result, err := action.Run(ctx, "github_get_blame", args)
+	gt.NoError(t, err)
+	gt.NotNil(t, result)
+
+	// Validate results
+	gt.S(t, result["repository"].(string)).Equal("test/repo")
+	gt.S(t, result["path"].(string)).Equal("src/main.go")
+	gt.S(t, result["ref"].(string)).Equal("main")
+	gt.Number(t, result["count"].(int)).Equal(2)
+
+	ranges := gt.Cast[[]githubtool.BlameRange](t, result["ranges"])
+	gt.A(t, ranges).Length(2)
+
+	// Check first range
+	gt.Number(t, ranges[0].StartLine).Equal(1)
+	gt.Number(t, ranges[0].EndLine).Equal(10)
+	gt.S(t, ranges[0].CommitSHA).Equal("abc123")
+	gt.S(t, ranges[0].CommitMessage).Equal("Initial commit")
+	gt.S(t, ranges[0].Author).Equal("testuser")
+
+	// Check second range
+	gt.Number(t, ranges[1].StartLine).Equal(11)
+	gt.Number(t, ranges[1].EndLine).Equal(25)
+	gt.S(t, ranges[1].CommitSHA).Equal("def456")
+	gt.S(t, ranges[1].Author).Equal("anotheruser")
+}
+
+func TestGitHubGetBlameUnauthorizedRepo(t *testing.T) {
+	mockedHTTPClient := mock.NewMockedHTTPClient()
+	client := github.NewClient(mockedHTTPClient)
+
+	action := &githubtool.Action{}
+	action.SetGitHubClient(client)
+	action.SetHTTPClient(mockedHTTPClient)
+	action.SetConfigs([]*githubtool.RepositoryConfig{
+		{
+			Owner:      "allowed",
+			Repository: "repo",
+		},
+	})
+
+	ctx := context.Background()
+	args := map[string]any{
+		"owner": "unauthorized",
+		"repo":  "secret-repo",
+		"path":  "main.go",
+	}
+
+	_, err := action.Run(ctx, "github_get_blame", args)
+	gt.Error(t, err)
+	gt.S(t, err.Error()).Contains("repository not in configured list")
 }
 
 func TestGitHubIntegration(t *testing.T) {

--- a/pkg/tool/github/blame.go
+++ b/pkg/tool/github/blame.go
@@ -138,6 +138,7 @@ func (x *Action) runGetBlame(ctx context.Context, args map[string]any) (map[stri
 		return nil, goerr.Wrap(err, "failed to create GraphQL request")
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("User-Agent", "warren")
 
 	resp, err := x.httpClient.Do(httpReq)
 	if err != nil {
@@ -180,10 +181,10 @@ func (x *Action) runGetBlame(ctx context.Context, args map[string]any) (map[stri
 	// Convert to BlameResult
 	ranges := make([]BlameRange, 0, len(gqlResp.Data.Repository.Object.Blame.Ranges))
 	for _, r := range gqlResp.Data.Repository.Object.Blame.Ranges {
-		// Truncate long commit messages
+		// Truncate long commit messages (UTF-8 safe)
 		message := r.Commit.Message
-		if len(message) > 200 {
-			message = message[:200] + "..."
+		if runes := []rune(message); len(runes) > 200 {
+			message = string(runes[:200]) + "..."
 		}
 
 		ranges = append(ranges, BlameRange{

--- a/pkg/tool/github/blame.go
+++ b/pkg/tool/github/blame.go
@@ -1,0 +1,219 @@
+package github
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/m-mizutani/goerr/v2"
+	"github.com/secmon-lab/warren/pkg/utils/safe"
+)
+
+// graphQLRequest represents a GitHub GraphQL API request
+type graphQLRequest struct {
+	Query     string         `json:"query"`
+	Variables map[string]any `json:"variables,omitempty"`
+}
+
+// graphQLResponse represents the top-level GraphQL response
+type graphQLResponse struct {
+	Data   graphQLBlameData `json:"data"`
+	Errors []graphQLError   `json:"errors,omitempty"`
+}
+
+type graphQLError struct {
+	Message string `json:"message"`
+}
+
+type graphQLBlameData struct {
+	Repository graphQLRepository `json:"repository"`
+}
+
+type graphQLRepository struct {
+	Object *graphQLObject `json:"object"`
+}
+
+type graphQLObject struct {
+	Blame *graphQLBlame `json:"blame"`
+}
+
+type graphQLBlame struct {
+	Ranges []graphQLBlameRange `json:"ranges"`
+}
+
+type graphQLBlameRange struct {
+	StartingLine int              `json:"startingLine"`
+	EndingLine   int              `json:"endingLine"`
+	Commit       graphQLCommitRef `json:"commit"`
+}
+
+type graphQLCommitRef struct {
+	OID     string              `json:"oid"`
+	Message string              `json:"message"`
+	Author  graphQLCommitAuthor `json:"author"`
+}
+
+type graphQLCommitAuthor struct {
+	Name string    `json:"name"`
+	Date time.Time `json:"date"`
+}
+
+const blameQuery = `query($owner: String!, $name: String!, $expression: String!) {
+  repository(owner: $owner, name: $name) {
+    object(expression: $expression) {
+      ... on Blob {
+        blame(startingLine: 1) {
+          ranges {
+            startingLine
+            endingLine
+            commit {
+              oid
+              message
+              author {
+                name
+                date
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}`
+
+func (x *Action) runGetBlame(ctx context.Context, args map[string]any) (map[string]any, error) {
+	// Parse required parameters
+	owner, ok := args["owner"].(string)
+	if !ok || owner == "" {
+		return nil, goerr.New("owner is required")
+	}
+
+	repo, ok := args["repo"].(string)
+	if !ok || repo == "" {
+		return nil, goerr.New("repo is required")
+	}
+
+	path, ok := args["path"].(string)
+	if !ok || path == "" {
+		return nil, goerr.New("path is required")
+	}
+
+	// Check if the repository is in our configured list
+	if !x.isAllowedRepo(owner, repo) {
+		return nil, goerr.New("repository not in configured list",
+			goerr.V("owner", owner),
+			goerr.V("repo", repo))
+	}
+
+	// Determine ref
+	ref := x.getDefaultBranch(owner, repo)
+	if r, ok := args["ref"].(string); ok && r != "" {
+		ref = r
+	}
+
+	// Build GraphQL expression: "ref:path"
+	expression := fmt.Sprintf("%s:%s", ref, path)
+
+	// Execute GraphQL request
+	reqBody := graphQLRequest{
+		Query: blameQuery,
+		Variables: map[string]any{
+			"owner":      owner,
+			"name":       repo,
+			"expression": expression,
+		},
+	}
+
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, goerr.Wrap(err, "failed to marshal GraphQL request")
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://api.github.com/graphql", bytes.NewReader(bodyBytes))
+	if err != nil {
+		return nil, goerr.Wrap(err, "failed to create GraphQL request")
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := x.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, goerr.Wrap(err, "failed to execute GraphQL request",
+			goerr.V("owner", owner),
+			goerr.V("repo", repo),
+			goerr.V("path", path))
+	}
+	defer safe.Close(ctx, resp.Body)
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, goerr.Wrap(err, "failed to read GraphQL response")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, goerr.New("GraphQL request failed",
+			goerr.V("status", resp.StatusCode),
+			goerr.V("body", string(respBody)))
+	}
+
+	var gqlResp graphQLResponse
+	if err := json.Unmarshal(respBody, &gqlResp); err != nil {
+		return nil, goerr.Wrap(err, "failed to parse GraphQL response")
+	}
+
+	if len(gqlResp.Errors) > 0 {
+		return nil, goerr.New("GraphQL errors",
+			goerr.V("errors", gqlResp.Errors))
+	}
+
+	if gqlResp.Data.Repository.Object == nil || gqlResp.Data.Repository.Object.Blame == nil {
+		return nil, goerr.New("no blame data found",
+			goerr.V("owner", owner),
+			goerr.V("repo", repo),
+			goerr.V("path", path),
+			goerr.V("ref", ref))
+	}
+
+	// Convert to BlameResult
+	ranges := make([]BlameRange, 0, len(gqlResp.Data.Repository.Object.Blame.Ranges))
+	for _, r := range gqlResp.Data.Repository.Object.Blame.Ranges {
+		// Truncate long commit messages
+		message := r.Commit.Message
+		if len(message) > 200 {
+			message = message[:200] + "..."
+		}
+
+		ranges = append(ranges, BlameRange{
+			StartLine:     r.StartingLine,
+			EndLine:       r.EndingLine,
+			CommitSHA:     r.Commit.OID,
+			CommitMessage: message,
+			Author:        r.Commit.Author.Name,
+			Date:          r.Commit.Author.Date,
+		})
+	}
+
+	return map[string]any{
+		"repository": fmt.Sprintf("%s/%s", owner, repo),
+		"path":       path,
+		"ref":        ref,
+		"ranges":     ranges,
+		"count":      len(ranges),
+	}, nil
+}
+
+// getDefaultBranch returns the default branch for a configured repository
+func (x *Action) getDefaultBranch(owner, repo string) string {
+	for _, config := range x.configs {
+		if config.Owner == owner && config.Repository == repo {
+			if config.DefaultBranch != "" {
+				return config.DefaultBranch
+			}
+			break
+		}
+	}
+	return "main"
+}

--- a/pkg/tool/github/commits.go
+++ b/pkg/tool/github/commits.go
@@ -100,8 +100,6 @@ func (x *Action) runListCommits(ctx context.Context, args map[string]any) (map[s
 			cr.Author = *commit.Author.Login
 		}
 
-		cr.FilesChanged = len(commit.Files)
-
 		results = append(results, cr)
 	}
 

--- a/pkg/tool/github/commits.go
+++ b/pkg/tool/github/commits.go
@@ -1,0 +1,123 @@
+package github
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-github/v74/github"
+	"github.com/m-mizutani/goerr/v2"
+)
+
+func (x *Action) runListCommits(ctx context.Context, args map[string]any) (map[string]any, error) {
+	// Parse required parameters
+	owner, ok := args["owner"].(string)
+	if !ok || owner == "" {
+		return nil, goerr.New("owner is required")
+	}
+
+	repo, ok := args["repo"].(string)
+	if !ok || repo == "" {
+		return nil, goerr.New("repo is required")
+	}
+
+	// Check if the repository is in our configured list
+	if !x.isAllowedRepo(owner, repo) {
+		return nil, goerr.New("repository not in configured list",
+			goerr.V("owner", owner),
+			goerr.V("repo", repo))
+	}
+
+	// Build options
+	opts := &github.CommitsListOptions{
+		ListOptions: github.ListOptions{
+			PerPage: 30,
+		},
+	}
+
+	// Optional parameters
+	if sha, ok := args["sha"].(string); ok && sha != "" {
+		opts.SHA = sha
+	}
+
+	if path, ok := args["path"].(string); ok && path != "" {
+		opts.Path = path
+	}
+
+	if author, ok := args["author"].(string); ok && author != "" {
+		opts.Author = author
+	}
+
+	if perPage, ok := args["per_page"].(float64); ok && perPage > 0 {
+		pp := int(perPage)
+		if pp > 100 {
+			pp = 100
+		}
+		opts.PerPage = pp
+	}
+
+	if page, ok := args["page"].(float64); ok && page > 0 {
+		opts.Page = int(page)
+	}
+
+	// Execute API call
+	commits, _, err := x.githubClient.Repositories.ListCommits(ctx, owner, repo, opts)
+	if err != nil {
+		return nil, goerr.Wrap(err, "failed to list commits",
+			goerr.V("owner", owner),
+			goerr.V("repo", repo))
+	}
+
+	// Format results
+	results := make([]CommitResult, 0, len(commits))
+	for _, commit := range commits {
+		cr := CommitResult{}
+
+		if commit.SHA != nil {
+			cr.SHA = *commit.SHA
+		}
+
+		if commit.HTMLURL != nil {
+			cr.HTMLURL = *commit.HTMLURL
+		}
+
+		if commit.Commit != nil {
+			if commit.Commit.Message != nil {
+				cr.Message = *commit.Commit.Message
+			}
+
+			if commit.Commit.Author != nil {
+				if commit.Commit.Author.Name != nil {
+					cr.Author = *commit.Commit.Author.Name
+				}
+				if commit.Commit.Author.Date != nil {
+					cr.Date = commit.Commit.Author.Date.Time
+				}
+			}
+		}
+
+		// Use login name if available (preferred over commit author name)
+		if commit.Author != nil && commit.Author.Login != nil {
+			cr.Author = *commit.Author.Login
+		}
+
+		cr.FilesChanged = len(commit.Files)
+
+		results = append(results, cr)
+	}
+
+	return map[string]any{
+		"repository": fmt.Sprintf("%s/%s", owner, repo),
+		"commits":    results,
+		"count":      len(results),
+	}, nil
+}
+
+// isAllowedRepo checks if the repository is in the configured list
+func (x *Action) isAllowedRepo(owner, repo string) bool {
+	for _, config := range x.configs {
+		if config.Owner == owner && config.Repository == repo {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/tool/github/content.go
+++ b/pkg/tool/github/content.go
@@ -27,15 +27,7 @@ func (x *Action) runGetContent(ctx context.Context, args map[string]any) (map[st
 	}
 
 	// Check if the repository is in our configured list
-	allowed := false
-	for _, config := range x.configs {
-		if config.Owner == owner && config.Repository == repo {
-			allowed = true
-			break
-		}
-	}
-
-	if !allowed {
+	if !x.isAllowedRepo(owner, repo) {
 		return nil, goerr.New("repository not in configured list",
 			goerr.V("owner", owner),
 			goerr.V("repo", repo))

--- a/pkg/tool/github/export_test.go
+++ b/pkg/tool/github/export_test.go
@@ -1,0 +1,32 @@
+package github
+
+import "net/http"
+
+// GraphQLBlameResponse is exported for testing
+type GraphQLBlameResponse = graphQLResponse
+
+// GraphQLBlameData is exported for testing
+type GraphQLBlameData = graphQLBlameData
+
+// GraphQLRepository is exported for testing
+type GraphQLRepository = graphQLRepository
+
+// GraphQLObject is exported for testing
+type GraphQLObject = graphQLObject
+
+// GraphQLBlame is exported for testing
+type GraphQLBlame = graphQLBlame
+
+// GraphQLBlameRange is exported for testing
+type GraphQLBlameRange = graphQLBlameRange
+
+// GraphQLCommitRef is exported for testing
+type GraphQLCommitRef = graphQLCommitRef
+
+// GraphQLCommitAuthor is exported for testing
+type GraphQLCommitAuthor = graphQLCommitAuthor
+
+// SetHTTPClient sets the HTTP client for testing
+func (x *Action) SetHTTPClient(client *http.Client) {
+	x.httpClient = client
+}

--- a/pkg/tool/github/types.go
+++ b/pkg/tool/github/types.go
@@ -51,3 +51,31 @@ type ContentResult struct {
 	HTMLURL    string `json:"html_url"`
 	Size       int    `json:"size"`
 }
+
+// CommitResult represents a commit in the list commits response
+type CommitResult struct {
+	SHA          string    `json:"sha"`
+	Message      string    `json:"message"`
+	Author       string    `json:"author"`
+	Date         time.Time `json:"date"`
+	HTMLURL      string    `json:"html_url"`
+	FilesChanged int       `json:"files_changed"`
+}
+
+// BlameRange represents a blame range for a set of lines
+type BlameRange struct {
+	StartLine     int       `json:"start_line"`
+	EndLine       int       `json:"end_line"`
+	CommitSHA     string    `json:"commit_sha"`
+	CommitMessage string    `json:"commit_message"`
+	Author        string    `json:"author"`
+	Date          time.Time `json:"date"`
+}
+
+// BlameResult represents the full blame result for a file
+type BlameResult struct {
+	Repository string       `json:"repository"`
+	Path       string       `json:"path"`
+	Ref        string       `json:"ref"`
+	Ranges     []BlameRange `json:"ranges"`
+}

--- a/pkg/tool/github/types.go
+++ b/pkg/tool/github/types.go
@@ -54,12 +54,11 @@ type ContentResult struct {
 
 // CommitResult represents a commit in the list commits response
 type CommitResult struct {
-	SHA          string    `json:"sha"`
-	Message      string    `json:"message"`
-	Author       string    `json:"author"`
-	Date         time.Time `json:"date"`
-	HTMLURL      string    `json:"html_url"`
-	FilesChanged int       `json:"files_changed"`
+	SHA     string    `json:"sha"`
+	Message string    `json:"message"`
+	Author  string    `json:"author"`
+	Date    time.Time `json:"date"`
+	HTMLURL string    `json:"html_url"`
 }
 
 // BlameRange represents a blame range for a set of lines


### PR DESCRIPTION
## Summary
- Add `github_list_commits` tool using go-github REST API with pagination, path/author/branch filtering
- Add `github_get_blame` tool using GitHub GraphQL API to show per-line commit attribution
- Refactor repo access control into shared `isAllowedRepo` helper

## Test plan
- [x] Unit tests for `github_list_commits` (mock, 2 tests)
- [x] Unit tests for `github_get_blame` (GraphQL mock, 2 tests)
- [x] Unauthorized repo access rejection tests
- [x] All existing tests pass
- [x] `go vet`, `golangci-lint`, `gosec` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)