### PR TITLE
fix(trace): prevent planner agent from overwriting root trace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/m-mizutani/clog v0.2.1
 	github.com/m-mizutani/fireconf v0.2.1
 	github.com/m-mizutani/goerr/v2 v2.0.1
-	github.com/m-mizutani/gollem v0.24.2
+	github.com/m-mizutani/gollem v0.24.3-0.20260414085700-70cb3cf18589
 	github.com/m-mizutani/gt v0.2.1
 	github.com/m-mizutani/harlog v0.0.3
 	github.com/m-mizutani/masq v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -268,6 +268,8 @@ github.com/m-mizutani/goerr/v2 v2.0.1 h1:Z0XZiliOcCw/qoPR8dEle0xMQw781UmvlySbDHE
 github.com/m-mizutani/goerr/v2 v2.0.1/go.mod h1:Ax59zs+j3NmzB/mPLc1w3g4yIutdrwcY7cB6IRO18EU=
 github.com/m-mizutani/gollem v0.24.2 h1:2mDHBoiFHQosj4KqDUEmQsmAR/MJKVP8UOgtneS8QOU=
 github.com/m-mizutani/gollem v0.24.2/go.mod h1:P1XLm5TS81vErrpu6hGhOL8UCkdXiFvQmSt+eayi8Hk=
+github.com/m-mizutani/gollem v0.24.3-0.20260414085700-70cb3cf18589 h1:wDHhO4naE+8Zqg7awFif5hEqXlXU0O4w5rzvphC6Ot8=
+github.com/m-mizutani/gollem v0.24.3-0.20260414085700-70cb3cf18589/go.mod h1:P1XLm5TS81vErrpu6hGhOL8UCkdXiFvQmSt+eayi8Hk=
 github.com/m-mizutani/gt v0.2.1 h1:mOl1PPIgEHoW2rQgqkfE31OGID06dO2uly8X8kvOEVY=
 github.com/m-mizutani/gt v0.2.1/go.mod h1:0MPYSfGBLmYjTduzADVmIqD58ELQ5IfBFiK/f0FmB3k=
 github.com/m-mizutani/harlog v0.0.3 h1:bL3i/xM3wWPsvoOOsuu/a4eaz+1yj1UyO7OPUzkWPyU=

--- a/pkg/usecase/chat/aster/plan.go
+++ b/pkg/usecase/chat/aster/plan.go
@@ -86,10 +86,12 @@ func (c *AsterChat) executePlannerAgent(ctx context.Context, planSession gollem.
 		opts = append(opts, gollem.WithHistory(history))
 	}
 
-	// Add trace handler if available
+	// Add trace handler if available.
+	// Use AsChildAgent so that gollem's Agent.Execute maps StartAgentExecute to
+	// StartChildAgent, avoiding overwrite of the root trace held by the Recorder.
 	handler := trace.HandlerFrom(ctx)
 	if handler != nil {
-		opts = append(opts, gollem.WithTrace(handler))
+		opts = append(opts, gollem.WithTrace(trace.AsChildAgent(handler, "planner")))
 	}
 
 	agent := gollem.New(c.llmClient, opts...)

--- a/pkg/usecase/chat/bluebell/plan.go
+++ b/pkg/usecase/chat/bluebell/plan.go
@@ -70,9 +70,11 @@ func (c *BluebellChat) executePlannerAgent(ctx context.Context, planSession goll
 		opts = append(opts, gollem.WithHistory(history))
 	}
 
+	// Use AsChildAgent so that gollem's Agent.Execute maps StartAgentExecute to
+	// StartChildAgent, avoiding overwrite of the root trace held by the Recorder.
 	handler := trace.HandlerFrom(ctx)
 	if handler != nil {
-		opts = append(opts, gollem.WithTrace(handler))
+		opts = append(opts, gollem.WithTrace(trace.AsChildAgent(handler, "planner")))
 	}
 
 	agent := gollem.New(c.llmClient, opts...)

--- a/pkg/usecase/chat/bluebell/plan_test.go
+++ b/pkg/usecase/chat/bluebell/plan_test.go
@@ -1,4 +1,4 @@
-package aster_test
+package bluebell_test
 
 import (
 	"context"
@@ -14,110 +14,8 @@ import (
 	"github.com/secmon-lab/warren/pkg/repository"
 	svcknowledge "github.com/secmon-lab/warren/pkg/service/knowledge"
 	"github.com/secmon-lab/warren/pkg/usecase/chat"
-	"github.com/secmon-lab/warren/pkg/usecase/chat/aster"
+	"github.com/secmon-lab/warren/pkg/usecase/chat/bluebell"
 )
-
-func TestAsterChat_PlanWithKnowledgeService(t *testing.T) {
-	ctx := setupTestContext(t)
-	repo := repository.NewMemory()
-	testTicket := setupTicketAndAlert(t, ctx, repo)
-
-	embeddingMock := &mock.EmbeddingClientMock{
-		EmbeddingsFunc: func(ctx context.Context, texts []string, dimensionality int) ([][]float32, error) {
-			result := make([][]float32, len(texts))
-			for i := range texts {
-				result[i] = make([]float32, dimensionality)
-			}
-			return result, nil
-		},
-	}
-	knowledgeSvc := svcknowledge.New(repo, embeddingMock)
-
-	// The mock LLM must handle multiple NewSession calls:
-	// 1. The planner agent creates its own session internally (for plan)
-	// 2. The replan/final phases also create sessions
-	// The planner agent may call knowledge_search, then return a plan JSON.
-	var mu sync.Mutex
-	sessionCount := 0
-
-	mockLLM := &mock.LLMClientMock{
-		NewSessionFunc: func(ctx context.Context, opts ...gollem.SessionOption) (gollem.Session, error) {
-			mu.Lock()
-			sessionCount++
-			sc := sessionCount
-			mu.Unlock()
-
-			ssn := newMockSession()
-			ssn.GenerateFunc = func(ctx context.Context, input []gollem.Input, opts ...gollem.GenerateOption) (*gollem.Response, error) {
-				// The agent's first session (plan) should return a direct plan
-				// (without function calls, since no knowledge entries exist).
-				if sc == 1 {
-					// This is the planSession created by executeAster (not used in agent mode)
-					return &gollem.Response{
-						Texts: []string{`{"message": "Direct response.", "tasks": []}`},
-					}, nil
-				}
-				// Agent-created session
-				return &gollem.Response{
-					Texts: []string{`{"message": "Analyzed with knowledge.", "tasks": []}`},
-				}, nil
-			}
-			return ssn, nil
-		},
-	}
-
-	chatUC := aster.New(repo, mockLLM,
-		aster.WithKnowledgeService(knowledgeSvc),
-	)
-	ssn := newDummySession(testTicket.ID)
-
-	err := chatUC.Execute(ctx, &chat.RunContext{Session: ssn, Message: "Analyze this alert", ChatCtx: &chatModel.ChatContext{Ticket: testTicket}})
-	gt.NoError(t, err)
-
-	// Verify that multiple sessions were created (planSession + agent's internal session)
-	mu.Lock()
-	gt.N(t, sessionCount).Greater(1)
-	mu.Unlock()
-}
-
-func TestAsterChat_PlanWithoutKnowledgeService(t *testing.T) {
-	// This tests the fallback path (no knowledge service) still works.
-	// Existing TestAsterChat_DirectResponse already covers this, but this
-	// explicitly verifies only one session is created.
-	ctx := setupTestContext(t)
-	repo := repository.NewMemory()
-	testTicket := setupTicketAndAlert(t, ctx, repo)
-
-	var mu sync.Mutex
-	sessionCount := 0
-
-	mockLLM := &mock.LLMClientMock{
-		NewSessionFunc: func(ctx context.Context, opts ...gollem.SessionOption) (gollem.Session, error) {
-			mu.Lock()
-			sessionCount++
-			mu.Unlock()
-
-			ssn := newMockSession()
-			ssn.GenerateFunc = func(ctx context.Context, input []gollem.Input, opts ...gollem.GenerateOption) (*gollem.Response, error) {
-				return &gollem.Response{
-					Texts: []string{`{"message": "Direct response.", "tasks": []}`},
-				}, nil
-			}
-			return ssn, nil
-		},
-	}
-
-	chatUC := aster.New(repo, mockLLM)
-	ssn := newDummySession(testTicket.ID)
-
-	err := chatUC.Execute(ctx, &chat.RunContext{Session: ssn, Message: "Analyze this alert", ChatCtx: &chatModel.ChatContext{Ticket: testTicket}})
-	gt.NoError(t, err)
-
-	// Without knowledge service, only one session should be created (planSession).
-	mu.Lock()
-	gt.V(t, sessionCount).Equal(1)
-	mu.Unlock()
-}
 
 // mockTraceRepo captures saved traces for assertion.
 type mockTraceRepo struct {
@@ -141,10 +39,12 @@ func (r *mockTraceRepo) last() *gollemtrace.Trace {
 	return r.traces[len(r.traces)-1]
 }
 
-// traceAwareSession wraps a generate function and records LLM call spans via trace handler.
+// traceAwareSession wraps a mock session and records LLM call spans via trace handler.
 // This simulates what real LLM clients (vertex_client, etc.) do internally.
 type traceAwareSession struct {
-	generateFunc func(ctx context.Context, input []gollem.Input, opts ...gollem.GenerateOption) (*gollem.Response, error)
+	generateFunc   func(ctx context.Context, input []gollem.Input, opts ...gollem.GenerateOption) (*gollem.Response, error)
+	historyFunc    func() (*gollem.History, error)
+	appendHistFunc func(h *gollem.History) error
 }
 
 func (s *traceAwareSession) Generate(ctx context.Context, input []gollem.Input, opts ...gollem.GenerateOption) (*gollem.Response, error) {
@@ -160,7 +60,9 @@ func (s *traceAwareSession) Generate(ctx context.Context, input []gollem.Input, 
 				InputTokens:  100,
 				OutputTokens: 50,
 				Request:      &gollemtrace.LLMRequest{},
-				Response:     &gollemtrace.LLMResponse{Texts: resp.Texts},
+				Response: &gollemtrace.LLMResponse{
+					Texts: resp.Texts,
+				},
 			}
 		}
 		h.EndLLMCall(ctx, data, err)
@@ -181,39 +83,39 @@ func (s *traceAwareSession) GenerateStream(_ context.Context, _ ...gollem.Input)
 }
 
 func (s *traceAwareSession) History() (*gollem.History, error) {
+	if s.historyFunc != nil {
+		return s.historyFunc()
+	}
 	return &gollem.History{
 		Version:  gollem.HistoryVersion,
 		Messages: []gollem.Message{{Role: gollem.RoleUser}},
 	}, nil
 }
 
-func (s *traceAwareSession) AppendHistory(_ *gollem.History) error { return nil }
+func (s *traceAwareSession) AppendHistory(h *gollem.History) error {
+	if s.appendHistFunc != nil {
+		return s.appendHistFunc(h)
+	}
+	return nil
+}
 
 func (s *traceAwareSession) CountToken(_ context.Context, _ ...gollem.Input) (int, error) {
 	return 0, nil
 }
 
-func TestAsterChat_PlannerTraceNotOverwritten(t *testing.T) {
+func TestBluebellChat_PlannerTraceNotOverwritten(t *testing.T) {
 	// Verify that executePlannerAgent creates child spans (via AsChildAgent)
 	// rather than overwriting the root trace. When tasks are executed, the task
 	// spans should persist across replan calls.
 	ctx := setupTestContext(t)
 	repo := repository.NewMemory()
 	testTicket := setupTicketAndAlert(t, ctx, repo)
-
-	embeddingMock := &mock.EmbeddingClientMock{
-		EmbeddingsFunc: func(ctx context.Context, texts []string, dimensionality int) ([][]float32, error) {
-			result := make([][]float32, len(texts))
-			for i := range texts {
-				result[i] = make([]float32, dimensionality)
-			}
-			return result, nil
-		},
-	}
-	knowledgeSvc := svcknowledge.New(repo, embeddingMock)
+	knowledgeSvc := svcknowledge.New(repo, newMockEmbeddingClient())
 
 	var mu sync.Mutex
 	sessionCount := 0
+
+	planJSON := `{"message": "Analyzing.", "tasks": [{"id": "t1", "title": "Check IP", "description": "Look up IP", "tools": []}]}`
 
 	mockLLM := &mock.LLMClientMock{
 		NewSessionFunc: func(ctx context.Context, opts ...gollem.SessionOption) (gollem.Session, error) {
@@ -222,36 +124,46 @@ func TestAsterChat_PlannerTraceNotOverwritten(t *testing.T) {
 			sc := sessionCount
 			mu.Unlock()
 
-			return &traceAwareSession{
+			ssn := &traceAwareSession{
 				generateFunc: func(ctx context.Context, input []gollem.Input, opts ...gollem.GenerateOption) (*gollem.Response, error) {
 					switch {
-					case sc <= 2:
+					// Session 1: intent resolver → return selector JSON
+					case sc == 1:
 						return &gollem.Response{
-							Texts: []string{`{"message": "Analyzing.", "tasks": [{"id": "t1", "title": "Check IP", "description": "Look up IP", "tools": [], "sub_agents": []}]}`},
+							Texts: []string{`{"prompt_id":"default","intent":"Investigate the alert."}`},
 						}, nil
-					case sc == 3:
+					// Session 2: planSession (created by executeBluebell, not used in agent mode)
+					// Session 3: planner agent's internal session → return plan with a task
+					case sc <= 3:
+						return &gollem.Response{
+							Texts: []string{planJSON},
+						}, nil
+					// Session 4: task agent's session → return task result
+					case sc == 4:
 						return &gollem.Response{
 							Texts: []string{"IP is benign."},
 						}, nil
+					// Session 5+: replan agent / final response → no more tasks
 					default:
 						return &gollem.Response{
 							Texts: []string{`{"tasks": []}`},
 						}, nil
 					}
 				},
-			}, nil
+			}
+			return ssn, nil
 		},
 	}
 
 	traceRepo := &mockTraceRepo{}
-	chatUC := aster.New(repo, mockLLM,
-		aster.WithKnowledgeService(knowledgeSvc),
-		aster.WithTraceRepository(traceRepo),
+	chatUC, err := bluebell.New(repo, mockLLM,
+		bluebell.WithKnowledgeService(knowledgeSvc),
+		bluebell.WithTraceRepository(traceRepo),
 	)
-	ssn := newDummySession(testTicket.ID)
+	gt.NoError(t, err)
 
-	err := chatUC.Execute(ctx, &chat.RunContext{
-		Session: ssn,
+	err = chatUC.Execute(ctx, &chat.RunContext{
+		Session: newDummySession(testTicket.ID),
 		Message: "Analyze this alert",
 		ChatCtx: &chatModel.ChatContext{Ticket: testTicket},
 	})
@@ -283,7 +195,7 @@ func TestAsterChat_PlannerTraceNotOverwritten(t *testing.T) {
 	// Verify "replan-phase-1" child span also exists alongside "planning" and task spans.
 	gt.V(t, findSpan(trace.RootSpan, "replan-phase-1", gollemtrace.SpanKindAgentExecute)).NotNil()
 
-	// Verify LLM call spans are recorded (plan + task + replan + final = at least 3).
+	// Verify LLM call spans are recorded (plan + task + replan + final = at least 4).
 	llmCalls := collectSpans(trace.RootSpan, gollemtrace.SpanKindLLMCall)
 	gt.N(t, len(llmCalls)).GreaterOrEqual(3)
 
@@ -341,29 +253,4 @@ func collectSpans(root *gollemtrace.Span, kind gollemtrace.SpanKind) []*gollemtr
 		result = append(result, collectSpans(child, kind)...)
 	}
 	return result
-}
-
-func TestFetchKnowledgeTags_NilService(t *testing.T) {
-	ctx := setupTestContext(t)
-	tags := aster.FetchKnowledgeTags(ctx, nil)
-	gt.V(t, tags).Nil()
-}
-
-func TestFetchKnowledgeTags_WithService(t *testing.T) {
-	ctx := setupTestContext(t)
-	repo := repository.NewMemory()
-	embeddingMock := &mock.EmbeddingClientMock{
-		EmbeddingsFunc: func(ctx context.Context, texts []string, dimensionality int) ([][]float32, error) {
-			return make([][]float32, len(texts)), nil
-		},
-	}
-	knowledgeSvc := svcknowledge.New(repo, embeddingMock)
-
-	// Create a tag
-	_, err := knowledgeSvc.CreateTag(ctx, "test-tag", "A test tag")
-	gt.NoError(t, err)
-
-	tags := aster.FetchKnowledgeTags(ctx, knowledgeSvc)
-	gt.A(t, tags).Length(1)
-	gt.V(t, tags[0].Name).Equal("test-tag")
 }


### PR DESCRIPTION
## Summary
- `executePlannerAgent` passed the raw `trace.Recorder` to gollem via `gollem.WithTrace(handler)`, causing `Agent.Execute`'s internal `StartAgentExecute` to overwrite the root trace and silently destroy all previously recorded spans (task executions, tool calls, LLM calls)
- Wrap with `trace.AsChildAgent(handler, "planner")` to match the established pattern already used in `exec.go` for task agents
- Update gollem to a pre-release (`70cb3cf`) that includes defense-in-depth: `Recorder.StartAgentExecute` now falls back to a child span when a trace already exists
- Add tests with trace-aware mock sessions that verify span tree structure, LLM call recording, and response content preservation

## Root Cause
Commit `ef756fb` (2026-03-31) switched the planner to Agent mode (with knowledge_search tool) but passed the raw Recorder to `gollem.WithTrace()`. `gollem.Agent.Execute` calls `handler.StartAgentExecute` internally, which replaces `Recorder.trace` with a new Trace object. During the plan → task execution → replan cycle, the replan call overwrites the trace again, destroying all task spans recorded in between.

## Test plan
- [x] `TestAsterChat_PlannerTraceNotOverwritten` — verifies planner/task/replan span structure, LLM call token counts, and response content recording
- [x] `TestBluebellChat_PlannerTraceNotOverwritten` — same, including intent resolver session
- [x] All existing tests pass (`go test ./...`)
- [x] `golangci-lint`, `gosec` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)