### PR TITLE
fix: unify Slack resolve modal tag selection to multi-select

### DIFF
--- a/pkg/service/slack/blocks.go
+++ b/pkg/service/slack/blocks.go
@@ -456,26 +456,34 @@ func buildResolveTicketModalViewRequest(callbackID model.CallbackID, ticket *tic
 	// Add tag selection if tags are available
 	if len(availableTags) > 0 {
 		tagOptions := make([]*slack.OptionBlockObject, 0, len(availableTags))
+		var initialOptions []*slack.OptionBlockObject
 		for _, tag := range availableTags {
-			tagOptions = append(tagOptions,
-				slack.NewOptionBlockObject(
-					tag.ID,
-					slack.NewTextBlockObject(slack.PlainTextType, tag.Name, false, false),
-					nil,
-				),
+			option := slack.NewOptionBlockObject(
+				tag.ID,
+				slack.NewTextBlockObject(slack.PlainTextType, tag.Name, false, false),
+				nil,
 			)
+			tagOptions = append(tagOptions, option)
+			if ticket.TagIDs[tag.ID] {
+				initialOptions = append(initialOptions, option)
+			}
+		}
+
+		tagElement := slack.NewOptionsMultiSelectBlockElement(
+			slack.OptTypeStatic,
+			slack.NewTextBlockObject(slack.PlainTextType, "Select tags", false, false),
+			model.BlockActionIDTicketTags.String(),
+			tagOptions...,
+		)
+		if len(initialOptions) > 0 {
+			tagElement.InitialOptions = initialOptions
 		}
 
 		blockSet = append(blockSet, slack.NewInputBlock(
 			model.BlockIDTicketTags.String(),
 			slack.NewTextBlockObject(slack.PlainTextType, "Tags", false, false),
 			slack.NewTextBlockObject(slack.PlainTextType, "Select tags for this ticket", false, false),
-			slack.NewOptionsMultiSelectBlockElement(
-				slack.OptTypeStatic,
-				slack.NewTextBlockObject(slack.PlainTextType, "Select tags", false, false),
-				model.BlockActionIDTicketTags.String(),
-				tagOptions...,
-			),
+			tagElement,
 		).WithOptional(true))
 	}
 

--- a/pkg/service/slack/blocks.go
+++ b/pkg/service/slack/blocks.go
@@ -455,59 +455,28 @@ func buildResolveTicketModalViewRequest(callbackID model.CallbackID, ticket *tic
 
 	// Add tag selection if tags are available
 	if len(availableTags) > 0 {
-		// Use checkboxes if 10 or fewer tags, otherwise use multi-select dropdown
-		if len(availableTags) <= 10 {
-			// Create checkbox options for tags
-			checkboxOptions := make([]*slack.OptionBlockObject, 0, len(availableTags))
-			for _, tag := range availableTags {
-				checkboxOptions = append(checkboxOptions,
-					slack.NewOptionBlockObject(
-						tag.ID, // Use Tag ID as value
-						slack.NewTextBlockObject(slack.PlainTextType, tag.Name, false, false), // Use Tag name for display
-						nil,
-					),
-				)
-			}
-
-			// Add checkboxes for tags
-			blockSet = append(blockSet, slack.NewInputBlock(
-				model.BlockIDTicketTags.String(),
-				slack.NewTextBlockObject(slack.PlainTextType, "Tags", false, false),
-				slack.NewTextBlockObject(slack.PlainTextType, "Select tags for this ticket", false, false),
-				slack.NewCheckboxGroupsBlockElement(
-					model.BlockActionIDTicketTags.String(),
-					checkboxOptions...,
+		tagOptions := make([]*slack.OptionBlockObject, 0, len(availableTags))
+		for _, tag := range availableTags {
+			tagOptions = append(tagOptions,
+				slack.NewOptionBlockObject(
+					tag.ID,
+					slack.NewTextBlockObject(slack.PlainTextType, tag.Name, false, false),
+					nil,
 				),
-			).WithOptional(true))
-		} else {
-			// Use multi-select dropdown for more than 10 tags
-			tagOptions := make([]*slack.OptionBlockObject, 0, len(availableTags))
-
-			// Create tag options
-			for _, tag := range availableTags {
-				tagOptions = append(tagOptions,
-					slack.NewOptionBlockObject(
-						tag.ID, // Use Tag ID as value
-						slack.NewTextBlockObject(slack.PlainTextType, tag.Name, false, false), // Use Tag name for display
-						nil,
-					),
-				)
-			}
-
-			// Add multi-select for tags
-			// Note: initial_options is not supported in modal views for multi_select elements
-			blockSet = append(blockSet, slack.NewInputBlock(
-				model.BlockIDTicketTags.String(),
-				slack.NewTextBlockObject(slack.PlainTextType, "Tags", false, false),
-				slack.NewTextBlockObject(slack.PlainTextType, "Select tags for this ticket", false, false),
-				slack.NewOptionsMultiSelectBlockElement(
-					slack.OptTypeStatic,
-					slack.NewTextBlockObject(slack.PlainTextType, "Select tags", false, false),
-					model.BlockActionIDTicketTags.String(),
-					tagOptions...,
-				),
-			).WithOptional(true))
+			)
 		}
+
+		blockSet = append(blockSet, slack.NewInputBlock(
+			model.BlockIDTicketTags.String(),
+			slack.NewTextBlockObject(slack.PlainTextType, "Tags", false, false),
+			slack.NewTextBlockObject(slack.PlainTextType, "Select tags for this ticket", false, false),
+			slack.NewOptionsMultiSelectBlockElement(
+				slack.OptTypeStatic,
+				slack.NewTextBlockObject(slack.PlainTextType, "Select tags", false, false),
+				model.BlockActionIDTicketTags.String(),
+				tagOptions...,
+			),
+		).WithOptional(true))
 	}
 
 	return slack.ModalViewRequest{

--- a/pkg/service/slack/blocks_test.go
+++ b/pkg/service/slack/blocks_test.go
@@ -107,6 +107,54 @@ func TestBuildResolveTicketModalViewRequest_WithTags(t *testing.T) {
 		gt.V(t, multiSelect.Options[0].Text.Text).Equal("double check")
 		gt.V(t, multiSelect.Options[1].Value).Equal("tag-2")
 		gt.V(t, multiSelect.Options[2].Value).Equal("tag-3")
+
+		// No initial options when ticket has no tags
+		gt.V(t, len(multiSelect.InitialOptions)).Equal(0)
+	}
+	gt.V(t, found).Equal(true)
+}
+
+func TestBuildResolveTicketModalViewRequest_WithExistingTags(t *testing.T) {
+	tk := &ticket.Ticket{
+		ID: types.TicketID("ticket-1"),
+		Metadata: ticket.Metadata{
+			Title: "Test Ticket",
+		},
+		TagIDs: map[string]bool{
+			"tag-1": true,
+			"tag-3": true,
+		},
+	}
+	availableTags := []*tag.Tag{
+		{ID: "tag-1", Name: "double check"},
+		{ID: "tag-2", Name: "debug"},
+		{ID: "tag-3", Name: "refine"},
+	}
+
+	result := buildResolveTicketModalViewRequest(model.CallbackSubmitResolveTicket, tk, availableTags)
+
+	// Find the tags input block
+	var found bool
+	for _, block := range result.Blocks.BlockSet {
+		inputBlock, ok := block.(*slack_sdk.InputBlock)
+		if !ok {
+			continue
+		}
+		if inputBlock.BlockID != model.BlockIDTicketTags.String() {
+			continue
+		}
+		found = true
+
+		multiSelect, ok := inputBlock.Element.(*slack_sdk.MultiSelectBlockElement)
+		gt.V(t, ok).Equal(true)
+
+		// All 3 tags should be available as options
+		gt.V(t, len(multiSelect.Options)).Equal(3)
+
+		// 2 tags should be pre-selected (tag-1 and tag-3)
+		gt.V(t, len(multiSelect.InitialOptions)).Equal(2)
+		gt.V(t, multiSelect.InitialOptions[0].Value).Equal("tag-1")
+		gt.V(t, multiSelect.InitialOptions[1].Value).Equal("tag-3")
 	}
 	gt.V(t, found).Equal(true)
 }

--- a/pkg/service/slack/blocks_test.go
+++ b/pkg/service/slack/blocks_test.go
@@ -4,6 +4,10 @@ import (
 	"testing"
 
 	"github.com/m-mizutani/gt"
+	model "github.com/secmon-lab/warren/pkg/domain/model/slack"
+	"github.com/secmon-lab/warren/pkg/domain/model/tag"
+	"github.com/secmon-lab/warren/pkg/domain/model/ticket"
+	"github.com/secmon-lab/warren/pkg/domain/types"
 	slack_sdk "github.com/slack-go/slack"
 )
 
@@ -65,4 +69,64 @@ func TestContextBlockVsRegularMessage(t *testing.T) {
 	// This difference is crucial - context blocks appear differently in Slack
 	// (as smaller, grayed-out context information) vs section blocks
 	// (as regular message content)
+}
+
+func TestBuildResolveTicketModalViewRequest_WithTags(t *testing.T) {
+	tk := &ticket.Ticket{
+		ID: types.TicketID("ticket-1"),
+		Metadata: ticket.Metadata{
+			Title: "Test Ticket",
+		},
+	}
+	availableTags := []*tag.Tag{
+		{ID: "tag-1", Name: "double check"},
+		{ID: "tag-2", Name: "debug"},
+		{ID: "tag-3", Name: "refine"},
+	}
+
+	result := buildResolveTicketModalViewRequest(model.CallbackSubmitResolveTicket, tk, availableTags)
+
+	// Find the tags input block
+	var found bool
+	for _, block := range result.Blocks.BlockSet {
+		inputBlock, ok := block.(*slack_sdk.InputBlock)
+		if !ok {
+			continue
+		}
+		if inputBlock.BlockID != model.BlockIDTicketTags.String() {
+			continue
+		}
+		found = true
+
+		// Verify it uses multi-select, not checkboxes
+		multiSelect, ok := inputBlock.Element.(*slack_sdk.MultiSelectBlockElement)
+		gt.V(t, ok).Equal(true)
+		gt.V(t, multiSelect.Type).Equal(string(slack_sdk.OptTypeStatic))
+		gt.V(t, len(multiSelect.Options)).Equal(3)
+		gt.V(t, multiSelect.Options[0].Value).Equal("tag-1")
+		gt.V(t, multiSelect.Options[0].Text.Text).Equal("double check")
+		gt.V(t, multiSelect.Options[1].Value).Equal("tag-2")
+		gt.V(t, multiSelect.Options[2].Value).Equal("tag-3")
+	}
+	gt.V(t, found).Equal(true)
+}
+
+func TestBuildResolveTicketModalViewRequest_NoTags(t *testing.T) {
+	tk := &ticket.Ticket{
+		ID: types.TicketID("ticket-1"),
+		Metadata: ticket.Metadata{
+			Title: "Test Ticket",
+		},
+	}
+
+	result := buildResolveTicketModalViewRequest(model.CallbackSubmitResolveTicket, tk, nil)
+
+	// Verify no tags block exists
+	for _, block := range result.Blocks.BlockSet {
+		inputBlock, ok := block.(*slack_sdk.InputBlock)
+		if !ok {
+			continue
+		}
+		gt.V(t, inputBlock.BlockID).NotEqual(model.BlockIDTicketTags.String())
+	}
 }


### PR DESCRIPTION
## Summary
- Unify Slack Resolve Ticket modal tag selection UI to always use multi-select dropdown, removing the conditional branch that used checkboxes for ≤10 tags and multi-select for >10 tags
- Tag section remains hidden when no tags are configured (existing behavior preserved)

## Test plan
- [x] `TestBuildResolveTicketModalViewRequest_WithTags` — verifies multi-select is generated when tags exist
- [x] `TestBuildResolveTicketModalViewRequest_NoTags` — verifies no tag block is included when no tags exist
- [ ] Open Resolve modal in Slack and confirm tags are displayed as multi-select dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)