### PR TITLE
fix: use resolved channel ID for notice file upload

### DIFF
--- a/pkg/service/notifier/slack.go
+++ b/pkg/service/notifier/slack.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/m-mizutani/goerr/v2"
 	"github.com/secmon-lab/warren/pkg/domain/event"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	"github.com/secmon-lab/warren/pkg/domain/model/alert"
@@ -330,7 +331,7 @@ func (n *SlackNotifier) PublishAlert(ctx context.Context, slackService SlackServ
 
 // SlackServiceNotice is an interface for posting notices to Slack
 type SlackServiceNotice interface {
-	PostNotice(ctx context.Context, channelID, message string, noticeID fmt.Stringer) (string, error)
+	PostNotice(ctx context.Context, channelID, message string, noticeID fmt.Stringer) (string, string, error)
 	PostNoticeThreadDetails(ctx context.Context, channelID, threadTS string, alert *alert.Alert, llmResponse *alert.GenAIResponse) error
 	NewThread(thread slack.Thread) interfaces.SlackThreadService
 }
@@ -350,20 +351,22 @@ func (n *SlackNotifier) PublishNotice(ctx context.Context, slackService SlackSer
 		mainMessage = "🔔 Security Notice"
 	}
 
-	// Post main notice message
-	timestamp, err := slackService.PostNotice(ctx, channel, mainMessage, notice.ID)
+	// Post main notice message and get the resolved channel ID
+	resolvedChannelID, timestamp, err := slackService.PostNotice(ctx, channel, mainMessage, notice.ID)
 	if err != nil {
 		return "", err
 	}
 
-	// Post detailed information in thread
-	if err := slackService.PostNoticeThreadDetails(ctx, channel, timestamp, alertData, llmResponse); err != nil {
-		logger.Warn("failed to post notice thread details", "error", err, "channel", channel)
+	// Post detailed information in thread using resolved channel ID
+	if err := slackService.PostNoticeThreadDetails(ctx, resolvedChannelID, timestamp, alertData, llmResponse); err != nil {
+		return "", goerr.Wrap(err, "failed to post notice thread details",
+			goerr.V("channel", resolvedChannelID),
+			goerr.V("notice_id", notice.ID))
 	}
 
-	// Create thread service
+	// Create thread service using resolved channel ID
 	thread := slackService.NewThread(slack.Thread{
-		ChannelID: channel,
+		ChannelID: resolvedChannelID,
 		ThreadID:  timestamp,
 	})
 

--- a/pkg/service/slack/slack.go
+++ b/pkg/service/slack/slack.go
@@ -1442,7 +1442,7 @@ func (x *Service) ToTicketURL(ticketID string) string {
 }
 
 // PostNotice posts a notice message to Slack with an escalate button
-func (x *Service) PostNotice(ctx context.Context, channelID, message string, noticeID fmt.Stringer) (string, error) {
+func (x *Service) PostNotice(ctx context.Context, channelID, message string, noticeID fmt.Stringer) (string, string, error) {
 	// Use default channel if channelID is empty
 	if channelID == "" {
 		channelID = x.channelID
@@ -1472,16 +1472,16 @@ func (x *Service) PostNotice(ctx context.Context, channelID, message string, not
 		},
 	}
 
-	_, timestamp, err := x.client.PostMessageContext(ctx, channelID,
+	resolvedChannelID, timestamp, err := x.client.PostMessageContext(ctx, channelID,
 		slack.MsgOptionBlocks(blocks...),
 	)
 	if err != nil {
-		return "", goerr.Wrap(err, "failed to post notice to Slack",
+		return "", "", goerr.Wrap(err, "failed to post notice to Slack",
 			goerr.V("channel", channelID),
 			goerr.V("notice_id", noticeID))
 	}
 
-	return timestamp, nil
+	return resolvedChannelID, timestamp, nil
 }
 
 // PostNoticeThreadDetails posts detailed information about the notice in a thread

--- a/pkg/usecase/alert.go
+++ b/pkg/usecase/alert.go
@@ -409,7 +409,7 @@ func (uc *UseCases) sendSimpleNotification(ctx context.Context, notice *notice.N
 	}
 
 	if err := uc.slackService.PostNoticeThreadDetails(ctx, resolvedChannelID, timestamp, alertData, llmResponse); err != nil {
-		return "", goerr.Wrap(err, "failed to post notice thread details", goerr.V("channel", resolvedChannelID))
+		return "", goerr.Wrap(err, "failed to post notice thread details", goerr.V("channel", resolvedChannelID), goerr.V("notice_id", notice.ID))
 	}
 
 	return timestamp, nil

--- a/pkg/usecase/alert.go
+++ b/pkg/usecase/alert.go
@@ -355,16 +355,16 @@ func (uc *UseCases) handleNotice(ctx context.Context, alert *alert.Alert, channe
 	if uc.slackService != nil {
 		slackTS, err := uc.sendSimpleNotification(ctx, notice, channel, llmResponse, notifier)
 		if err != nil {
-			logger.Warn("failed to send simple notification", "error", err, "notice_id", notice.ID)
-		} else {
-			// Update notice with Slack timestamp
-			notice.SlackTS = slackTS
-			if err := uc.repository.UpdateNotice(ctx, notice); err != nil {
-				if data, jsonErr := json.Marshal(notice); jsonErr == nil {
-					logger.Warn("failed to update notice with slack timestamp", "error", err, "notice", string(data))
-				} else {
-					logger.Warn("failed to update notice with slack timestamp", "error", err, "notice_id", notice.ID)
-				}
+			return goerr.Wrap(err, "failed to send notice to Slack", goerr.V("notice_id", notice.ID))
+		}
+
+		// Update notice with Slack timestamp
+		notice.SlackTS = slackTS
+		if err := uc.repository.UpdateNotice(ctx, notice); err != nil {
+			if data, jsonErr := json.Marshal(notice); jsonErr == nil {
+				logger.Warn("failed to update notice with slack timestamp", "error", err, "notice", string(data))
+			} else {
+				logger.Warn("failed to update notice with slack timestamp", "error", err, "notice_id", notice.ID)
 			}
 		}
 	}
@@ -403,13 +403,13 @@ func (uc *UseCases) sendSimpleNotification(ctx context.Context, notice *notice.N
 		mainMessage = "🔔 Security Notice"
 	}
 
-	timestamp, err := uc.slackService.PostNotice(ctx, targetChannel, mainMessage, notice.ID)
+	resolvedChannelID, timestamp, err := uc.slackService.PostNotice(ctx, targetChannel, mainMessage, notice.ID)
 	if err != nil {
 		return "", goerr.Wrap(err, "failed to post notice to Slack", goerr.V("channel", targetChannel))
 	}
 
-	if err := uc.slackService.PostNoticeThreadDetails(ctx, targetChannel, timestamp, alertData, llmResponse); err != nil {
-		logging.From(ctx).Warn("failed to post notice thread details", "error", err, "channel", targetChannel)
+	if err := uc.slackService.PostNoticeThreadDetails(ctx, resolvedChannelID, timestamp, alertData, llmResponse); err != nil {
+		return "", goerr.Wrap(err, "failed to post notice thread details", goerr.V("channel", resolvedChannelID))
 	}
 
 	return timestamp, nil

--- a/pkg/usecase/alert_test.go
+++ b/pkg/usecase/alert_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/secmon-lab/warren/pkg/domain/types"
 	"github.com/secmon-lab/warren/pkg/repository"
 	"github.com/secmon-lab/warren/pkg/service/circuitbreaker"
+	notifierSvc "github.com/secmon-lab/warren/pkg/service/notifier"
 	slack_svc "github.com/secmon-lab/warren/pkg/service/slack"
 	"github.com/secmon-lab/warren/pkg/usecase"
 	"github.com/secmon-lab/warren/pkg/utils/clock"
@@ -1271,6 +1272,120 @@ func TestHandleNotice(t *testing.T) {
 		gt.Equal(t, uploadCalls[0].Params.Channel, "test-channel")
 	})
 
+	t.Run("uses resolved channel ID for file upload", func(t *testing.T) {
+		// Simulate Slack resolving a channel name to a channel ID.
+		// PostMessageContext accepts channel names but UploadFileContext
+		// (files.completeUploadExternal) requires the resolved channel ID.
+		repoMock := &mock.RepositoryMock{
+			CreateNoticeFunc: func(ctx context.Context, notice *notice.Notice) error {
+				return nil
+			},
+			UpdateNoticeFunc: func(ctx context.Context, notice *notice.Notice) error {
+				return nil
+			},
+		}
+
+		slackMock := &mock.SlackClientMock{
+			PostMessageContextFunc: func(ctx context.Context, channelID string, options ...slack_sdk.MsgOption) (string, string, error) {
+				// Simulate Slack resolving "#channel-name" to "C_RESOLVED_ID"
+				return "C_RESOLVED_ID", "test-timestamp", nil
+			},
+			UploadFileContextFunc: func(ctx context.Context, params slack_sdk.UploadFileParameters) (*slack_sdk.FileSummary, error) {
+				return &slack_sdk.FileSummary{}, nil
+			},
+			AuthTestFunc: func() (*slack_sdk.AuthTestResponse, error) {
+				return &slack_sdk.AuthTestResponse{
+					UserID: "test-user",
+				}, nil
+			},
+			GetTeamInfoFunc: func() (*slack_sdk.TeamInfo, error) {
+				return &slack_sdk.TeamInfo{
+					Domain: "test-workspace",
+				}, nil
+			},
+		}
+
+		slackSvc, err := slack_svc.New(slackMock, "#channel-name")
+		gt.NoError(t, err)
+
+		uc := usecase.New(
+			usecase.WithRepository(repoMock),
+			usecase.WithSlackService(slackSvc),
+		)
+		testAlert := &alert.Alert{
+			ID: types.NewAlertID(),
+			Metadata: alert.Metadata{
+				Title: "Channel Resolution Test",
+			},
+			Data:   map[string]interface{}{"key": "value"},
+			Schema: "test.schema",
+		}
+
+		err = uc.HandleNotice(ctx, testAlert, "#channel-name", &mock.NotifierMock{})
+		gt.NoError(t, err)
+
+		// Verify file upload uses the RESOLVED channel ID, not the original channel name
+		uploadCalls := slackMock.UploadFileContextCalls()
+		gt.Array(t, uploadCalls).Length(1)
+		gt.Equal(t, uploadCalls[0].Params.Channel, "C_RESOLVED_ID")
+
+		// Verify thread details message also uses the resolved channel ID
+		postCalls := slackMock.PostMessageContextCalls()
+		gt.Array(t, postCalls).Length(2)
+		// Second PostMessage (thread details) should use resolved channel ID
+		gt.Equal(t, postCalls[1].ChannelID, "C_RESOLVED_ID")
+	})
+
+	t.Run("returns error when file upload fails", func(t *testing.T) {
+		repoMock := &mock.RepositoryMock{
+			CreateNoticeFunc: func(ctx context.Context, notice *notice.Notice) error {
+				return nil
+			},
+			UpdateNoticeFunc: func(ctx context.Context, notice *notice.Notice) error {
+				return nil
+			},
+		}
+
+		slackMock := &mock.SlackClientMock{
+			PostMessageContextFunc: func(ctx context.Context, channelID string, options ...slack_sdk.MsgOption) (string, string, error) {
+				return channelID, "test-timestamp", nil
+			},
+			UploadFileContextFunc: func(ctx context.Context, params slack_sdk.UploadFileParameters) (*slack_sdk.FileSummary, error) {
+				return nil, fmt.Errorf("upload failed: invalid channel")
+			},
+			AuthTestFunc: func() (*slack_sdk.AuthTestResponse, error) {
+				return &slack_sdk.AuthTestResponse{
+					UserID: "test-user",
+				}, nil
+			},
+			GetTeamInfoFunc: func() (*slack_sdk.TeamInfo, error) {
+				return &slack_sdk.TeamInfo{
+					Domain: "test-workspace",
+				}, nil
+			},
+		}
+
+		slackSvc, err := slack_svc.New(slackMock, "#test-channel")
+		gt.NoError(t, err)
+
+		uc := usecase.New(
+			usecase.WithRepository(repoMock),
+			usecase.WithSlackService(slackSvc),
+		)
+		testAlert := &alert.Alert{
+			ID: types.NewAlertID(),
+			Metadata: alert.Metadata{
+				Title: "Upload Failure Test",
+			},
+			Data:   map[string]interface{}{"key": "value"},
+			Schema: "test.schema",
+		}
+
+		// Error should be propagated, not swallowed
+		err = uc.HandleNotice(ctx, testAlert, "test-channel", &mock.NotifierMock{})
+		gt.Error(t, err)
+	})
+
 	t.Run("uses default channel when no channels specified", func(t *testing.T) {
 		// Create fresh mocks for this test
 		repoMock := &mock.RepositoryMock{
@@ -1326,6 +1441,66 @@ func TestHandleNotice(t *testing.T) {
 		// Verify file upload was called (since testAlert has Data nil, this won't be called)
 		uploadCalls := slackMock.UploadFileContextCalls()
 		gt.Array(t, uploadCalls).Length(0)
+	})
+
+	t.Run("uses resolved channel ID via SlackNotifier path", func(t *testing.T) {
+		// Test the SlackNotifier path (used in the real HandleAlert flow)
+		// where PublishNotice is called instead of the fallback path.
+		repoMock := &mock.RepositoryMock{
+			CreateNoticeFunc: func(ctx context.Context, notice *notice.Notice) error {
+				return nil
+			},
+			UpdateNoticeFunc: func(ctx context.Context, notice *notice.Notice) error {
+				return nil
+			},
+		}
+
+		slackMock := &mock.SlackClientMock{
+			PostMessageContextFunc: func(ctx context.Context, channelID string, options ...slack_sdk.MsgOption) (string, string, error) {
+				// Simulate Slack resolving channel name to channel ID
+				return "C_RESOLVED_VIA_NOTIFIER", "ts-123", nil
+			},
+			UploadFileContextFunc: func(ctx context.Context, params slack_sdk.UploadFileParameters) (*slack_sdk.FileSummary, error) {
+				return &slack_sdk.FileSummary{}, nil
+			},
+			AuthTestFunc: func() (*slack_sdk.AuthTestResponse, error) {
+				return &slack_sdk.AuthTestResponse{
+					UserID: "test-user",
+				}, nil
+			},
+			GetTeamInfoFunc: func() (*slack_sdk.TeamInfo, error) {
+				return &slack_sdk.TeamInfo{
+					Domain: "test-workspace",
+				}, nil
+			},
+		}
+
+		slackSvc, err := slack_svc.New(slackMock, "#alerts")
+		gt.NoError(t, err)
+
+		uc := usecase.New(
+			usecase.WithRepository(repoMock),
+			usecase.WithSlackService(slackSvc),
+		)
+		testAlert := &alert.Alert{
+			ID: types.NewAlertID(),
+			Metadata: alert.Metadata{
+				Title: "SlackNotifier Path Test",
+			},
+			Data:   map[string]any{"raw": "payload"},
+			Schema: "test.schema",
+		}
+
+		// Pass a real SlackNotifier (same as what HandleAlert creates internally)
+		slackNotifier := notifierSvc.NewSlackNotifier()
+		err = uc.HandleNotice(ctx, testAlert, "#alerts", slackNotifier)
+		gt.NoError(t, err)
+
+		// Verify file upload uses resolved channel ID
+		uploadCalls := slackMock.UploadFileContextCalls()
+		gt.Array(t, uploadCalls).Length(1)
+		gt.Equal(t, uploadCalls[0].Params.Channel, "C_RESOLVED_VIA_NOTIFIER")
+		gt.Equal(t, uploadCalls[0].Params.ThreadTimestamp, "ts-123")
 	})
 }
 


### PR DESCRIPTION
## Summary
- `PostNotice` was discarding the resolved channel ID from `PostMessageContext`, causing `UploadFileContext` (which uses `files.completeUploadExternal` internally) to receive an unresolved channel — leading to silent upload failures
- Upload errors were swallowed as warnings at three levels (`PublishNotice`, `sendSimpleNotification`, `handleNotice`), making the failure invisible
- Now returns the resolved channel ID from `PostNotice` and propagates errors properly

## Test plan
- [x] Verify resolved channel ID is passed to `UploadFileContext` (fallback path)
- [x] Verify resolved channel ID is passed to `UploadFileContext` (SlackNotifier path)
- [x] Verify file upload errors are propagated instead of swallowed
- [x] All existing tests pass
- [x] `go vet`, `golangci-lint`, `gosec` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)