### PR TITLE
fix: update dompurify to 3.4.0 (GHSA-39q2-94rc-95cp)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,7 +38,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
-    "dompurify": "^3.3.3",
+    "dompurify": "^3.4.0",
     "graphql": "^16.13.2",
     "lucide-react": "^0.511.0",
     "react": "^19.2.4",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -72,8 +72,8 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       dompurify:
-        specifier: ^3.3.3
-        version: 3.3.3
+        specifier: ^3.4.0
+        version: 3.4.0
       graphql:
         specifier: ^16.13.2
         version: 16.13.2
@@ -2076,8 +2076,8 @@ packages:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
 
-  dompurify@3.3.3:
-    resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
+  dompurify@3.4.0:
+    resolution: {integrity: sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==}
 
   dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
@@ -6067,7 +6067,7 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
-  dompurify@3.3.3:
+  dompurify@3.4.0:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 


### PR DESCRIPTION
## Summary
- Bumps `dompurify` from 3.3.3 to 3.4.0 to resolve GHSA-39q2-94rc-95cp (FORBID_TAGS bypass via ADD_TAGS short-circuit evaluation, MEDIUM).
- Fixes trivy CI scheduled scan failure on `main`.

## Test plan
- [x] `trivy fs --ignore-unfixed --scanners vuln .` reports 0 vulnerabilities locally.
- [ ] CI trivy job passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)