### PR TITLE
feat: auto-infer alert tags during metadata generation

### DIFF
--- a/pkg/domain/model/alert/alert.go
+++ b/pkg/domain/model/alert/alert.go
@@ -265,14 +265,51 @@ func (x *Alert) CosineSimilarity(other []float32) float64 {
 //go:embed prompt/alert_meta.md
 var alertMetaPrompt string
 
-func (x *Alert) FillMetadata(ctx context.Context, llmClient gollem.LLMClient) error {
+// mergeInferredTags merges LLM-inferred tag names into the existing tag name
+// list. Only names present in the allowed set are added, duplicates are
+// removed, and the original order of existing names is preserved.
+func mergeInferredTags(existing, inferred []string, allowed map[string]bool) []string {
+	if len(inferred) == 0 || len(allowed) == 0 {
+		return existing
+	}
+	seen := make(map[string]bool, len(existing)+len(inferred))
+	for _, name := range existing {
+		seen[name] = true
+	}
+	result := existing
+	for _, name := range inferred {
+		if name == "" || seen[name] || !allowed[name] {
+			continue
+		}
+		result = append(result, name)
+		seen[name] = true
+	}
+	return result
+}
+
+func (x *Alert) FillMetadata(ctx context.Context, llmClient gollem.LLMClient, availableTags []*tag.Tag) error {
 	if x.Title == DefaultAlertTitle || x.Title == "" {
 		logger := logging.From(ctx)
 		logger.Info("fill metadata", "alert", x.Data)
+
+		availableTagNameSet := make(map[string]bool, len(availableTags))
+		tagCandidates := make([]map[string]string, 0, len(availableTags))
+		for _, t := range availableTags {
+			if t == nil || t.Name == "" {
+				continue
+			}
+			availableTagNameSet[t.Name] = true
+			tagCandidates = append(tagCandidates, map[string]string{
+				"name":        t.Name,
+				"description": t.Description,
+			})
+		}
+
 		prompt, err := prompt.Generate(ctx, alertMetaPrompt, map[string]any{
-			"alert":  x.Data,
-			"schema": prompt.ToSchema(Metadata{}),
-			"lang":   lang.From(ctx).Name(),
+			"alert":          x.Data,
+			"schema":         prompt.ToSchema(Metadata{}),
+			"lang":           lang.From(ctx).Name(),
+			"available_tags": tagCandidates,
 		})
 		if err != nil {
 			return err
@@ -314,6 +351,8 @@ func (x *Alert) FillMetadata(ctx context.Context, llmClient gollem.LLMClient) er
 				x.Attributes = append(x.Attributes, resAttr)
 			}
 		}
+
+		x.Tags = mergeInferredTags(x.Tags, resp.Tags, availableTagNameSet)
 	}
 
 	embedding, err := embedding.Generate(ctx, llmClient, x.Data)

--- a/pkg/domain/model/alert/alert.go
+++ b/pkg/domain/model/alert/alert.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"strings"
 	"time"
 
 	"cloud.google.com/go/firestore"
@@ -265,6 +266,35 @@ func (x *Alert) CosineSimilarity(other []float32) float64 {
 //go:embed prompt/alert_meta.md
 var alertMetaPrompt string
 
+// formatAvailableTags renders the available tags as a markdown bullet list
+// ready for injection into the metadata prompt. When there are no tags it
+// returns a short notice that instructs the LLM to leave the tags field
+// empty, so the prompt is unambiguous regardless of system state.
+func formatAvailableTags(tags []*tag.Tag) string {
+	var b strings.Builder
+	any := false
+	for _, t := range tags {
+		if t == nil || t.Name == "" {
+			continue
+		}
+		if !any {
+			any = true
+		}
+		b.WriteString("- `")
+		b.WriteString(t.Name)
+		b.WriteString("`")
+		if t.Description != "" {
+			b.WriteString(": ")
+			b.WriteString(t.Description)
+		}
+		b.WriteString("\n")
+	}
+	if !any {
+		return "_No tags are registered in the system. Return an empty array for `tags`._"
+	}
+	return b.String()
+}
+
 // mergeInferredTags merges LLM-inferred tag names into the existing tag name
 // list. Only names present in the allowed set are added, duplicates are
 // removed, and the original order of existing names is preserved.
@@ -293,23 +323,18 @@ func (x *Alert) FillMetadata(ctx context.Context, llmClient gollem.LLMClient, av
 		logger.Info("fill metadata", "alert", x.Data)
 
 		availableTagNameSet := make(map[string]bool, len(availableTags))
-		tagCandidates := make([]map[string]string, 0, len(availableTags))
 		for _, t := range availableTags {
 			if t == nil || t.Name == "" {
 				continue
 			}
 			availableTagNameSet[t.Name] = true
-			tagCandidates = append(tagCandidates, map[string]string{
-				"name":        t.Name,
-				"description": t.Description,
-			})
 		}
 
 		prompt, err := prompt.Generate(ctx, alertMetaPrompt, map[string]any{
 			"alert":          x.Data,
 			"schema":         prompt.ToSchema(Metadata{}),
 			"lang":           lang.From(ctx).Name(),
-			"available_tags": tagCandidates,
+			"available_tags": formatAvailableTags(availableTags),
 		})
 		if err != nil {
 			return err

--- a/pkg/domain/model/alert/alert.go
+++ b/pkg/domain/model/alert/alert.go
@@ -1,13 +1,14 @@
 package alert
 
 import (
+	"bytes"
 	"context"
 	_ "embed"
 	"encoding/json"
 	"fmt"
 	"io"
 	"math"
-	"strings"
+	"text/template"
 	"time"
 
 	"cloud.google.com/go/firestore"
@@ -266,33 +267,49 @@ func (x *Alert) CosineSimilarity(other []float32) float64 {
 //go:embed prompt/alert_meta.md
 var alertMetaPrompt string
 
-// formatAvailableTags renders the available tags as a markdown bullet list
-// ready for injection into the metadata prompt. When there are no tags it
-// returns a short notice that instructs the LLM to leave the tags field
-// empty, so the prompt is unambiguous regardless of system state.
-func formatAvailableTags(tags []*tag.Tag) string {
-	var b strings.Builder
-	any := false
-	for _, t := range tags {
+// alertMetaTmpl is compiled once. It expects a struct carrying pre-rendered
+// Alert / Schema JSON strings, the Lang code, and a filtered slice of Tag.
+var alertMetaTmpl = template.Must(template.New("alert_meta").Parse(alertMetaPrompt))
+
+type alertMetaPromptData struct {
+	Alert         string
+	Schema        string
+	Lang          string
+	AvailableTags []*tag.Tag
+}
+
+// renderAlertMetaPrompt builds the metadata prompt. It pre-filters nil /
+// empty-name tags so the template can range safely and use `{{ if
+// .AvailableTags }}` to omit the Available Tags section entirely when none
+// are registered (avoiding an awkward empty list that would confuse the LLM).
+func renderAlertMetaPrompt(alertData any, langName string, availableTags []*tag.Tag) (string, error) {
+	alertJSON, err := json.MarshalIndent(alertData, "", "  ")
+	if err != nil {
+		return "", goerr.Wrap(err, "failed to marshal alert data")
+	}
+	schemaJSON, err := json.MarshalIndent(prompt.ToSchema(Metadata{}), "", "  ")
+	if err != nil {
+		return "", goerr.Wrap(err, "failed to marshal metadata schema")
+	}
+
+	tags := make([]*tag.Tag, 0, len(availableTags))
+	for _, t := range availableTags {
 		if t == nil || t.Name == "" {
 			continue
 		}
-		if !any {
-			any = true
-		}
-		b.WriteString("- `")
-		b.WriteString(t.Name)
-		b.WriteString("`")
-		if t.Description != "" {
-			b.WriteString(": ")
-			b.WriteString(t.Description)
-		}
-		b.WriteString("\n")
+		tags = append(tags, t)
 	}
-	if !any {
-		return "_No tags are registered in the system. Return an empty array for `tags`._"
+
+	var buf bytes.Buffer
+	if err := alertMetaTmpl.Execute(&buf, alertMetaPromptData{
+		Alert:         string(alertJSON),
+		Schema:        string(schemaJSON),
+		Lang:          langName,
+		AvailableTags: tags,
+	}); err != nil {
+		return "", goerr.Wrap(err, "failed to execute alert metadata template")
 	}
-	return b.String()
+	return buf.String(), nil
 }
 
 // mergeInferredTags merges LLM-inferred tag names into the existing tag name
@@ -330,12 +347,7 @@ func (x *Alert) FillMetadata(ctx context.Context, llmClient gollem.LLMClient, av
 			availableTagNameSet[t.Name] = true
 		}
 
-		prompt, err := prompt.Generate(ctx, alertMetaPrompt, map[string]any{
-			"alert":          x.Data,
-			"schema":         prompt.ToSchema(Metadata{}),
-			"lang":           lang.From(ctx).Name(),
-			"available_tags": formatAvailableTags(availableTags),
-		})
+		prompt, err := renderAlertMetaPrompt(x.Data, lang.From(ctx).Name(), availableTags)
 		if err != nil {
 			return err
 		}

--- a/pkg/domain/model/alert/alert_test.go
+++ b/pkg/domain/model/alert/alert_test.go
@@ -1,11 +1,16 @@
 package alert_test
 
 import (
+	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
+	"github.com/m-mizutani/gollem"
+	gollem_mock "github.com/m-mizutani/gollem/mock"
 	"github.com/m-mizutani/gt"
 	"github.com/secmon-lab/warren/pkg/domain/model/alert"
+	"github.com/secmon-lab/warren/pkg/domain/model/tag"
 	"github.com/secmon-lab/warren/pkg/utils/embedding"
 	"github.com/secmon-lab/warren/pkg/utils/test"
 )
@@ -18,11 +23,110 @@ func TestAlert_FillMetadata(t *testing.T) {
 		"baz": 123,
 	}, alert.Metadata{})
 
-	gt.NoError(t, a.FillMetadata(t.Context(), client))
+	gt.NoError(t, a.FillMetadata(t.Context(), client, nil))
 	gt.NotEqual(t, a.Title, "")
 	gt.NotEqual(t, a.Description, "")
 	gt.Equal(t, len(a.Embedding), embedding.EmbeddingDimension)
 	t.Logf("metadata: %+v", a.Metadata)
+}
+
+func TestAlert_FillMetadata_TagInference(t *testing.T) {
+	// Mock LLM that records the prompt it receives and returns a fixed
+	// metadata JSON including both known and unknown tag names.
+	var receivedPrompt string
+	mockLLM := &gollem_mock.LLMClientMock{
+		NewSessionFunc: func(ctx context.Context, options ...gollem.SessionOption) (gollem.Session, error) {
+			return &gollem_mock.SessionMock{
+				GenerateFunc: func(ctx context.Context, input []gollem.Input, _ ...gollem.GenerateOption) (*gollem.Response, error) {
+					if txt, ok := input[0].(gollem.Text); ok {
+						receivedPrompt = string(txt)
+					}
+					return &gollem.Response{
+						Texts: []string{`{
+							"title": "Generated title",
+							"description": "Generated description",
+							"attributes": [],
+							"tags": ["malware", "unknown-tag", "network"]
+						}`},
+					}, nil
+				},
+			}, nil
+		},
+		GenerateEmbeddingFunc: func(ctx context.Context, dimension int, input []string) ([][]float64, error) {
+			result := make([][]float64, len(input))
+			for i := range input {
+				result[i] = []float64{0.1, 0.2, 0.3}
+			}
+			return result, nil
+		},
+	}
+
+	available := []*tag.Tag{
+		{ID: "tag_1", Name: "malware", Description: "Malware-related events"},
+		{ID: "tag_2", Name: "network", Description: "Network-related events"},
+		{ID: "tag_3", Name: "phishing", Description: "Phishing-related events"},
+	}
+
+	a := alert.New(t.Context(), "test.alert.v1", map[string]any{
+		"event": "suspicious_binary_download",
+	}, alert.Metadata{
+		Tags: []string{"policy-origin"}, // pre-existing policy-provided tag
+	})
+
+	gt.NoError(t, a.FillMetadata(t.Context(), mockLLM, available))
+
+	// Title / description from LLM response
+	gt.Equal(t, a.Title, "Generated title")
+	gt.Equal(t, a.Description, "Generated description")
+
+	// Tags: policy-origin preserved, malware+network added, unknown-tag filtered out
+	gt.A(t, a.Tags).Length(3).Equal([]string{"policy-origin", "malware", "network"})
+
+	// Prompt must include the available tags so the LLM can choose from them
+	gt.True(t, strings.Contains(receivedPrompt, "malware"))
+	gt.True(t, strings.Contains(receivedPrompt, "phishing"))
+	gt.True(t, strings.Contains(receivedPrompt, "Network-related events"))
+}
+
+func TestMergeInferredTags(t *testing.T) {
+	t.Run("no inferred tags returns existing unchanged", func(t *testing.T) {
+		existing := []string{"a", "b"}
+		got := alert.MergeInferredTags(existing, nil, map[string]bool{"a": true, "c": true})
+		gt.A(t, got).Length(2).Equal([]string{"a", "b"})
+	})
+
+	t.Run("no allowed set returns existing unchanged", func(t *testing.T) {
+		existing := []string{"a"}
+		got := alert.MergeInferredTags(existing, []string{"c", "d"}, map[string]bool{})
+		gt.A(t, got).Length(1).Equal([]string{"a"})
+	})
+
+	t.Run("appends only allowed inferred tags", func(t *testing.T) {
+		allowed := map[string]bool{"security": true, "malware": true, "network": true}
+		got := alert.MergeInferredTags(
+			[]string{"policy"},
+			[]string{"malware", "unknown", "network"},
+			allowed,
+		)
+		// policy is preserved even though not in allowed (it was already set by upstream)
+		gt.A(t, got).Length(3).Equal([]string{"policy", "malware", "network"})
+	})
+
+	t.Run("deduplicates against existing", func(t *testing.T) {
+		allowed := map[string]bool{"security": true, "malware": true}
+		got := alert.MergeInferredTags(
+			[]string{"security"},
+			[]string{"security", "malware"},
+			allowed,
+		)
+		gt.A(t, got).Length(2).Equal([]string{"security", "malware"})
+	})
+
+	t.Run("ignores empty tag names", func(t *testing.T) {
+		allowed := map[string]bool{"malware": true}
+		got := alert.MergeInferredTags(nil, []string{"", "malware", ""}, allowed)
+		gt.A(t, got).Length(1).Equal([]string{"malware"})
+	})
 }
 
 func TestAttribute_UnmarshalJSON(t *testing.T) {

--- a/pkg/domain/model/alert/alert_test.go
+++ b/pkg/domain/model/alert/alert_test.go
@@ -62,9 +62,9 @@ func TestAlert_FillMetadata_TagInference(t *testing.T) {
 	}
 
 	available := []*tag.Tag{
-		{ID: "tag_1", Name: "malware", Description: "Malware-related events"},
-		{ID: "tag_2", Name: "network", Description: "Network-related events"},
-		{ID: "tag_3", Name: "phishing", Description: "Phishing-related events"},
+		{ID: tag.NewID(), Name: "malware", Description: "Malware-related events"},
+		{ID: tag.NewID(), Name: "network", Description: "Network-related events"},
+		{ID: tag.NewID(), Name: "phishing", Description: "Phishing-related events"},
 	}
 
 	a := alert.New(t.Context(), "test.alert.v1", map[string]any{

--- a/pkg/domain/model/alert/alert_test.go
+++ b/pkg/domain/model/alert/alert_test.go
@@ -88,21 +88,34 @@ func TestAlert_FillMetadata_TagInference(t *testing.T) {
 	gt.True(t, strings.Contains(receivedPrompt, "Network-related events"))
 }
 
-func TestFormatAvailableTags(t *testing.T) {
-	t.Run("empty input yields an explicit no-tags notice", func(t *testing.T) {
-		got := alert.FormatAvailableTags(nil)
-		gt.True(t, strings.Contains(got, "No tags are registered"))
-		gt.True(t, strings.Contains(got, "empty array"))
+func TestRenderAlertMetaPrompt(t *testing.T) {
+	t.Run("omits Available Tags section entirely when no tags are registered", func(t *testing.T) {
+		got, err := alert.RenderAlertMetaPrompt(map[string]any{"k": "v"}, "English", nil)
+		gt.NoError(t, err)
+		gt.False(t, strings.Contains(got, "Available Tags"))
+		gt.False(t, strings.Contains(got, "Select zero or more tag names"))
+		// Fallback rule for the schema's tags field is still present so the
+		// LLM knows what to put there (empty array) without being shown an
+		// irrelevant/empty list.
+		gt.True(t, strings.Contains(got, "Output an empty array for this field"))
 	})
 
-	t.Run("nil and empty-name entries are skipped, the rest become a bullet list", func(t *testing.T) {
-		got := alert.FormatAvailableTags([]*tag.Tag{
-			nil,
-			{ID: "x", Name: ""},
+	t.Run("renders Available Tags as a bullet list with name and description", func(t *testing.T) {
+		tags := []*tag.Tag{
+			nil,                 // filtered
+			{ID: "x", Name: ""}, // filtered
 			{ID: tag.NewID(), Name: "malware", Description: "Malware-related events"},
-			{ID: tag.NewID(), Name: "network"}, // description empty -> name only
-		})
-		gt.Equal(t, got, "- `malware`: Malware-related events\n- `network`\n")
+			{ID: tag.NewID(), Name: "network"}, // description empty
+		}
+		got, err := alert.RenderAlertMetaPrompt(map[string]any{"k": "v"}, "English", tags)
+		gt.NoError(t, err)
+
+		gt.True(t, strings.Contains(got, "## Available Tags"))
+		gt.True(t, strings.Contains(got, "- `malware`: Malware-related events"))
+		gt.True(t, strings.Contains(got, "- `network`\n"))
+		gt.False(t, strings.Contains(got, "- `network`: "))
+		gt.True(t, strings.Contains(got, "Select zero or more tag names"))
+		gt.False(t, strings.Contains(got, "Output an empty array for this field"))
 	})
 }
 

--- a/pkg/domain/model/alert/alert_test.go
+++ b/pkg/domain/model/alert/alert_test.go
@@ -88,6 +88,24 @@ func TestAlert_FillMetadata_TagInference(t *testing.T) {
 	gt.True(t, strings.Contains(receivedPrompt, "Network-related events"))
 }
 
+func TestFormatAvailableTags(t *testing.T) {
+	t.Run("empty input yields an explicit no-tags notice", func(t *testing.T) {
+		got := alert.FormatAvailableTags(nil)
+		gt.True(t, strings.Contains(got, "No tags are registered"))
+		gt.True(t, strings.Contains(got, "empty array"))
+	})
+
+	t.Run("nil and empty-name entries are skipped, the rest become a bullet list", func(t *testing.T) {
+		got := alert.FormatAvailableTags([]*tag.Tag{
+			nil,
+			{ID: "x", Name: ""},
+			{ID: tag.NewID(), Name: "malware", Description: "Malware-related events"},
+			{ID: tag.NewID(), Name: "network"}, // description empty -> name only
+		})
+		gt.Equal(t, got, "- `malware`: Malware-related events\n- `network`\n")
+	})
+}
+
 func TestMergeInferredTags(t *testing.T) {
 	t.Run("no inferred tags returns existing unchanged", func(t *testing.T) {
 		existing := []string{"a", "b"}

--- a/pkg/domain/model/alert/export_test.go
+++ b/pkg/domain/model/alert/export_test.go
@@ -1,0 +1,4 @@
+package alert
+
+// MergeInferredTags is exported for testing only.
+var MergeInferredTags = mergeInferredTags

--- a/pkg/domain/model/alert/export_test.go
+++ b/pkg/domain/model/alert/export_test.go
@@ -3,5 +3,5 @@ package alert
 // MergeInferredTags is exported for testing only.
 var MergeInferredTags = mergeInferredTags
 
-// FormatAvailableTags is exported for testing only.
-var FormatAvailableTags = formatAvailableTags
+// RenderAlertMetaPrompt is exported for testing only.
+var RenderAlertMetaPrompt = renderAlertMetaPrompt

--- a/pkg/domain/model/alert/export_test.go
+++ b/pkg/domain/model/alert/export_test.go
@@ -2,3 +2,6 @@ package alert
 
 // MergeInferredTags is exported for testing only.
 var MergeInferredTags = mergeInferredTags
+
+// FormatAvailableTags is exported for testing only.
+var FormatAvailableTags = formatAvailableTags

--- a/pkg/domain/model/alert/prompt/alert_meta.md
+++ b/pkg/domain/model/alert/prompt/alert_meta.md
@@ -8,11 +8,9 @@ Analyze the structured data of the given security alert and generate the corresp
 
 ## Available Tags
 
-The following tags are registered in the system. Use them to classify this alert by selecting the most relevant ones by name. Do NOT invent new tag names — only pick from this list. If no tag is a good fit, leave `tags` empty.
+The following tags are registered in the system. Use them to classify this alert by selecting the most relevant ones by name. Do NOT invent new tag names — only pick from the list below. If no tag is a good fit, leave `tags` empty.
 
-```json
 {{ .available_tags }}
-```
 
 ## Output
 

--- a/pkg/domain/model/alert/prompt/alert_meta.md
+++ b/pkg/domain/model/alert/prompt/alert_meta.md
@@ -3,26 +3,28 @@ Analyze the structured data of the given security alert and generate the corresp
 ## Input
 
 ```json
-{{ .alert }}
+{{ .Alert }}
 ```
-
+{{ if .AvailableTags }}
 ## Available Tags
 
 The following tags are registered in the system. Use them to classify this alert by selecting the most relevant ones by name. Do NOT invent new tag names — only pick from the list below. If no tag is a good fit, leave `tags` empty.
 
-{{ .available_tags }}
-
+{{ range .AvailableTags }}- `{{ .Name }}`{{ if .Description }}: {{ .Description }}{{ end }}
+{{ end }}{{ end }}
 ## Output
 
 Output the result in JSON format. Schema is described below as a JSON schema.
 
 ```json
-{{ .schema }}
+{{ .Schema }}
 ```
 
-Fields rules are as follows. Language of `title` and `description` must be {{ .lang }}.
+Fields rules are as follows. Language of `title` and `description` must be {{ .Lang }}.
 
 - `title`: Provide a one-line title that summarizes the entire alert in natural language, clearly indicating what actor/subject performed what action against which resource/target and what potential impact occurred. The title should be written as a natural sentence or phrase that describes the security event, incorporating the key elements (actor, action, target, impact) in a readable format. Use the field values from the original alert data as much as possible; however, transform technical identifiers into more readable forms when appropriate. Title must be less than 140 characters.
 - `description`: Give a concise summary of the alert.
 - `attrs`: Extract the field values that highlight the key characteristics of the alert. Focus particularly on unique identifiers that can be used for investigation such as IP addresses, host names, domain names, usernames, resource IDs, etc. Avoid redundancy and aim for 3-9 attributes that provide comprehensive context for investigation.
-- `tags`: Select zero or more tag names from the "Available Tags" list above that best classify this alert. Each entry MUST exactly match a `name` from that list (case-sensitive). Do not output tag names that are not in the list. If no tag applies, output an empty array.
+{{ if .AvailableTags }}- `tags`: Select zero or more tag names from the "Available Tags" list above that best classify this alert. Each entry MUST exactly match a `name` from that list (case-sensitive). Do not output tag names that are not in the list. If no tag applies, output an empty array.
+{{ else }}- `tags`: Output an empty array for this field.
+{{ end }}

--- a/pkg/domain/model/alert/prompt/alert_meta.md
+++ b/pkg/domain/model/alert/prompt/alert_meta.md
@@ -6,6 +6,14 @@ Analyze the structured data of the given security alert and generate the corresp
 {{ .alert }}
 ```
 
+## Available Tags
+
+The following tags are registered in the system. Use them to classify this alert by selecting the most relevant ones by name. Do NOT invent new tag names — only pick from this list. If no tag is a good fit, leave `tags` empty.
+
+```json
+{{ .available_tags }}
+```
+
 ## Output
 
 Output the result in JSON format. Schema is described below as a JSON schema.
@@ -19,3 +27,4 @@ Fields rules are as follows. Language of `title` and `description` must be {{ .l
 - `title`: Provide a one-line title that summarizes the entire alert in natural language, clearly indicating what actor/subject performed what action against which resource/target and what potential impact occurred. The title should be written as a natural sentence or phrase that describes the security event, incorporating the key elements (actor, action, target, impact) in a readable format. Use the field values from the original alert data as much as possible; however, transform technical identifiers into more readable forms when appropriate. Title must be less than 140 characters.
 - `description`: Give a concise summary of the alert.
 - `attrs`: Extract the field values that highlight the key characteristics of the alert. Focus particularly on unique identifiers that can be used for investigation such as IP addresses, host names, domain names, usernames, resource IDs, etc. Avoid redundancy and aim for 3-9 attributes that provide comprehensive context for investigation.
+- `tags`: Select zero or more tag names from the "Available Tags" list above that best classify this alert. Each entry MUST exactly match a `name` from that list (case-sensitive). Do not output tag names that are not in the list. If no tag applies, output an empty array.

--- a/pkg/usecase/alert_pipeline.go
+++ b/pkg/usecase/alert_pipeline.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/secmon-lab/warren/pkg/domain/model/policy"
 	"github.com/secmon-lab/warren/pkg/domain/model/prompt"
+	"github.com/secmon-lab/warren/pkg/domain/model/tag"
 	"github.com/secmon-lab/warren/pkg/domain/types"
 	policySvc "github.com/secmon-lab/warren/pkg/service/policy"
 	knowledgeTool "github.com/secmon-lab/warren/pkg/tool/knowledge"
@@ -35,11 +36,12 @@ type AlertPipelineResult struct {
 // This is a pure function without side effects (no DB save, no Slack notification).
 //
 // Pipeline stages:
-// 1. Ingest Policy Evaluation - transforms raw data into Alert objects
-// 2. Tag Conversion - converts tag names to tag IDs
-// 3. Metadata Generation - fills missing titles/descriptions using LLM
-// 4. Enrich Policy Evaluation - executes enrichment tasks (query/agent)
-// 5. Triage Policy Evaluation - applies final metadata and determines publish type
+//  1. Ingest Policy Evaluation - transforms raw data into Alert objects
+//  2. Metadata Generation - fills missing titles/descriptions using LLM and
+//     infers tags from the set of existing tags
+//  3. Tag Conversion - converts tag names (from policy + LLM inference) to tag IDs
+//  4. Enrich Policy Evaluation - executes enrichment tasks (query/agent)
+//  5. Triage Policy Evaluation - applies final metadata and determines publish type
 //
 // All pipeline events are emitted through the notifier for real-time monitoring.
 // The notifier receives type-safe events for each stage of processing.
@@ -72,6 +74,19 @@ func (uc *UseCases) ProcessAlertPipeline(
 		return []*AlertPipelineResult{}, nil
 	}
 
+	// Fetch available tags once for LLM-based tag inference in metadata generation.
+	// Failures here do not abort the pipeline; tag inference is simply skipped.
+	var availableTags []*tag.Tag
+	if uc.tagService != nil {
+		tags, tagErr := uc.tagService.ListAllTags(ctx)
+		if tagErr != nil {
+			logging.From(ctx).Warn("failed to list tags for metadata generation; tag inference skipped",
+				"error", tagErr)
+		} else {
+			availableTags = tags
+		}
+	}
+
 	// Process each alert through enrich and commit policies
 	var results []*AlertPipelineResult
 	for _, processedAlert := range alerts {
@@ -80,7 +95,20 @@ func (uc *UseCases) ProcessAlertPipeline(
 			processedAlert.Topic = types.KnowledgeTopic(schema)
 		}
 
-		// Step 1.5: Convert metadata tags (names) to tag IDs
+		// Step 1.5: Fill metadata (generate title/description if missing) and
+		// infer tags from the available tag set. LLM may append new tag names
+		// to processedAlert.Tags; these are converted to IDs in the next step.
+		if uc.llmClient != nil {
+			if err := processedAlert.FillMetadata(ctx, uc.llmClient, availableTags); err != nil {
+				notifier.NotifyError(ctx, &event.ErrorEvent{
+					Error:   err,
+					Message: "Failed to generate alert metadata",
+				})
+				return nil, goerr.Wrap(err, "failed to fill alert metadata")
+			}
+		}
+
+		// Step 1.6: Convert metadata tag names (policy-provided + LLM-inferred) to tag IDs
 		if len(processedAlert.Tags) > 0 && uc.tagService != nil {
 			tags, err := uc.tagService.ConvertNamesToTags(ctx, processedAlert.Tags)
 			if err != nil {
@@ -95,17 +123,6 @@ func (uc *UseCases) ProcessAlertPipeline(
 			}
 			for _, tagID := range tags {
 				processedAlert.TagIDs[tagID] = true
-			}
-		}
-
-		// Step 1.6: Fill metadata (generate title/description if missing)
-		if uc.llmClient != nil {
-			if err := processedAlert.FillMetadata(ctx, uc.llmClient); err != nil {
-				notifier.NotifyError(ctx, &event.ErrorEvent{
-					Error:   err,
-					Message: "Failed to generate alert metadata",
-				})
-				return nil, goerr.Wrap(err, "failed to fill alert metadata")
 			}
 		}
 

--- a/pkg/usecase/alert_pipeline_test.go
+++ b/pkg/usecase/alert_pipeline_test.go
@@ -11,7 +11,9 @@ import (
 	"github.com/secmon-lab/warren/pkg/domain/mock"
 	"github.com/secmon-lab/warren/pkg/domain/model/alert"
 	"github.com/secmon-lab/warren/pkg/domain/model/notice"
+	"github.com/secmon-lab/warren/pkg/repository"
 	slackService "github.com/secmon-lab/warren/pkg/service/slack"
+	tagService "github.com/secmon-lab/warren/pkg/service/tag"
 	"github.com/secmon-lab/warren/pkg/usecase"
 	"github.com/slack-go/slack"
 )
@@ -351,6 +353,83 @@ func TestProcessAlertPipeline_Basic(t *testing.T) {
 
 		// Should return error when LLM client is not configured
 		gt.Error(t, err)
+	})
+}
+
+func TestProcessAlertPipeline_AutoTagInference(t *testing.T) {
+	t.Run("LLM-inferred tag names are persisted as TagIDs on the alert", func(t *testing.T) {
+		ctx := context.Background()
+
+		// Seed memory repository with existing tags that the LLM may choose from.
+		repo := repository.NewMemory()
+		tagSvc := tagService.New(repo)
+		malwareTag, err := tagSvc.CreateTagWithCustomColor(ctx, "malware", "Malware-related", "", "")
+		gt.NoError(t, err)
+		networkTag, err := tagSvc.CreateTagWithCustomColor(ctx, "network", "Network-related", "", "")
+		gt.NoError(t, err)
+		_, err = tagSvc.CreateTagWithCustomColor(ctx, "phishing", "Phishing-related", "", "")
+		gt.NoError(t, err)
+
+		// Mock LLM: metadata response includes known (malware, network) and
+		// unknown (bogus-tag) tag names. Known ones must survive through
+		// Tag Conversion and land in Alert.TagIDs.
+		mockLLM := &gollem_mock.LLMClientMock{
+			NewSessionFunc: func(ctx context.Context, options ...gollem.SessionOption) (gollem.Session, error) {
+				return &gollem_mock.SessionMock{
+					GenerateFunc: func(ctx context.Context, input []gollem.Input, _ ...gollem.GenerateOption) (*gollem.Response, error) {
+						return &gollem.Response{
+							Texts: []string{`{
+								"title": "Suspicious binary download",
+								"description": "Host downloaded a known malware sample over the network.",
+								"attributes": [],
+								"tags": ["malware", "network", "bogus-tag"]
+							}`},
+						}, nil
+					},
+				}, nil
+			},
+			GenerateEmbeddingFunc: func(ctx context.Context, dimension int, input []string) ([][]float64, error) {
+				result := make([][]float64, len(input))
+				for i := range input {
+					result[i] = []float64{0.1, 0.2, 0.3}
+				}
+				return result, nil
+			},
+		}
+
+		policyClient, err := opaq.New(
+			opaq.Files(
+				"testdata/ingest_no_title.rego",
+				"testdata/enrich_no_tasks.rego",
+				"testdata/triage_simple.rego",
+			),
+		)
+		gt.NoError(t, err)
+
+		uc := usecase.New(
+			usecase.WithRepository(repo),
+			usecase.WithTagService(tagSvc),
+			usecase.WithLLMClient(mockLLM),
+			usecase.WithPolicyClient(policyClient),
+		)
+
+		results, err := uc.ProcessAlertPipeline(ctx, "test_schema", map[string]any{"test": "data"}, &mock.NotifierMock{})
+		gt.NoError(t, err)
+		gt.A(t, results).Length(1)
+
+		a := results[0].Alert
+		// LLM's title/description applied
+		gt.Equal(t, a.Title, "Suspicious binary download")
+
+		// TagIDs must contain the two known tag IDs and nothing else.
+		gt.N(t, len(a.TagIDs)).Equal(2)
+		gt.True(t, a.TagIDs[malwareTag.ID])
+		gt.True(t, a.TagIDs[networkTag.ID])
+
+		// Bogus tag must not have been auto-created or attached.
+		existing, err := repo.GetTagByName(ctx, "bogus-tag")
+		gt.NoError(t, err)
+		gt.Nil(t, existing)
 	})
 }
 

--- a/pkg/usecase/diagnosis/missing_alert_metadata.go
+++ b/pkg/usecase/diagnosis/missing_alert_metadata.go
@@ -66,7 +66,12 @@ func (r *MissingAlertMetadataRule) Fix(ctx context.Context, repo interfaces.Repo
 		return goerr.Wrap(err, "failed to get alert", goerr.V("alert_id", alertID))
 	}
 
-	if err := a.FillMetadata(ctx, r.llmClient); err != nil {
+	availableTags, err := repo.ListAllTags(ctx)
+	if err != nil {
+		return goerr.Wrap(err, "failed to list tags", goerr.V("alert_id", alertID))
+	}
+
+	if err := a.FillMetadata(ctx, r.llmClient, availableTags); err != nil {
 		return goerr.Wrap(err, "failed to fill alert metadata", goerr.V("alert_id", alertID))
 	}
 

--- a/pkg/usecase/diagnosis/missing_embedding.go
+++ b/pkg/usecase/diagnosis/missing_embedding.go
@@ -64,7 +64,12 @@ func (r *MissingAlertEmbeddingRule) Fix(ctx context.Context, repo interfaces.Rep
 		return goerr.Wrap(err, "failed to get alert", goerr.V("alert_id", alertID))
 	}
 
-	if err := a.FillMetadata(ctx, r.llmClient); err != nil {
+	availableTags, err := repo.ListAllTags(ctx)
+	if err != nil {
+		return goerr.Wrap(err, "failed to list tags", goerr.V("alert_id", alertID))
+	}
+
+	if err := a.FillMetadata(ctx, r.llmClient, availableTags); err != nil {
 		return goerr.Wrap(err, "failed to fill alert metadata/embedding", goerr.V("alert_id", alertID))
 	}
 

--- a/pkg/usecase/testdata/ingest_no_title.rego
+++ b/pkg/usecase/testdata/ingest_no_title.rego
@@ -1,0 +1,9 @@
+package ingest.test_schema
+
+# Test ingest policy that emits an alert without a title so that
+# FillMetadata runs during the pipeline. Used for tag-inference tests.
+import rego.v1
+
+alerts contains {} if {
+    input.test
+}


### PR DESCRIPTION
## Summary
- Extend `Alert.FillMetadata` to ask the LLM to classify the alert against the existing tag set in the same call that generates title/description/attrs (no additional round-trip).
- Swap alert pipeline stage order to **Metadata Generation → Tag Conversion** so both policy-provided and LLM-inferred tag names flow through the same `ConvertNamesToTags` step.
- Inferred tag names that are not in the available tag set are filtered out; no new tags are auto-created. Ticket creation automatically inherits the resulting `TagIDs` from linked alerts — no ticket-side changes needed.

## Test plan
- [x] `go test ./pkg/...` — all green
- [x] `go vet ./... && go fmt ./...` — clean
- [x] `golangci-lint run ./...` — 0 issues on affected packages
- [x] New unit tests:
  - `TestAlert_FillMetadata_TagInference` — mock LLM end-to-end: prompt carries available tag list, response's tags merged into Alert.Tags, unknown tag names filtered
  - `TestMergeInferredTags` — helper covers empty / disallowed / dedupe / empty-name cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)