### PR TITLE
fix(firestore): avoid composite index requirement in session/turn queries

### DIFF
--- a/pkg/repository/firestore/diagnosis.go
+++ b/pkg/repository/firestore/diagnosis.go
@@ -2,6 +2,7 @@ package firestore
 
 import (
 	"context"
+	"sort"
 
 	"cloud.google.com/go/firestore"
 	"github.com/m-mizutani/goerr/v2"
@@ -122,13 +123,10 @@ func (r *Firestore) ListDiagnosisIssues(ctx context.Context, diagnosisID types.D
 		return nil, 0, r.eb.Wrap(err, "failed to extract issue count", goerr.V("diagnosis_id", diagnosisID))
 	}
 
-	// Fetch paginated
-	iter := q.OrderBy("CreatedAt", firestore.Asc).
-		Offset(offset).
-		Limit(limit).
-		Documents(ctx)
+	// In-memory sort/paginate to avoid composite index on (Status, RuleID, CreatedAt).
+	iter := q.Documents(ctx)
 
-	var result []*diagnosis.Issue
+	var all []*diagnosis.Issue
 	for {
 		doc, err := iter.Next()
 		if err == iterator.Done {
@@ -141,10 +139,23 @@ func (r *Firestore) ListDiagnosisIssues(ctx context.Context, diagnosisID types.D
 		if err := doc.DataTo(&iss); err != nil {
 			return nil, 0, r.eb.Wrap(err, "failed to unmarshal diagnosis issue", goerr.V("id", doc.Ref.ID))
 		}
-		result = append(result, &iss)
+		all = append(all, &iss)
 	}
 
-	return result, total, nil
+	sort.Slice(all, func(i, j int) bool { return all[i].CreatedAt.Before(all[j].CreatedAt) })
+
+	if offset < 0 {
+		offset = 0
+	}
+	if offset >= len(all) {
+		return []*diagnosis.Issue{}, total, nil
+	}
+	all = all[offset:]
+	if limit > 0 && limit < len(all) {
+		all = all[:limit]
+	}
+
+	return all, total, nil
 }
 
 // GetDiagnosisIssue retrieves a specific issue by diagnosisID and issueID.

--- a/pkg/repository/firestore/diagnosis.go
+++ b/pkg/repository/firestore/diagnosis.go
@@ -113,18 +113,11 @@ func (r *Firestore) ListDiagnosisIssues(ctx context.Context, diagnosisID types.D
 		q = q.Where("RuleID", "==", string(*ruleID))
 	}
 
-	// Count matching total
-	aggResult, err := q.NewAggregationQuery().WithCount("total").Get(ctx)
-	if err != nil {
-		return nil, 0, r.eb.Wrap(err, "failed to count diagnosis issues", goerr.V("diagnosis_id", diagnosisID))
-	}
-	total, err := extractCountFromAggregationResult(aggResult, "total")
-	if err != nil {
-		return nil, 0, r.eb.Wrap(err, "failed to extract issue count", goerr.V("diagnosis_id", diagnosisID))
-	}
-
 	// In-memory sort/paginate to avoid composite index on (Status, RuleID, CreatedAt).
+	// Total count is derived from the same fetch — saves a round-trip vs. a separate
+	// aggregation query.
 	iter := q.Documents(ctx)
+	defer iter.Stop()
 
 	var all []*diagnosis.Issue
 	for {
@@ -142,6 +135,7 @@ func (r *Firestore) ListDiagnosisIssues(ctx context.Context, diagnosisID types.D
 		all = append(all, &iss)
 	}
 
+	total := len(all)
 	sort.Slice(all, func(i, j int) bool { return all[i].CreatedAt.Before(all[j].CreatedAt) })
 
 	if offset < 0 {

--- a/pkg/repository/firestore/session_v2.go
+++ b/pkg/repository/firestore/session_v2.go
@@ -169,9 +169,10 @@ func (r *Firestore) GetTurn(ctx context.Context, turnID types.TurnID) (*session.
 }
 
 func (r *Firestore) GetTurnsBySession(ctx context.Context, sessionID types.SessionID) ([]*session.Turn, error) {
+	// Single-field Where + in-memory sort to avoid requiring a composite
+	// index on (session_id, started_at).
 	query := r.db.Collection(collectionTurns).
-		Where("session_id", "==", sessionID.String()).
-		OrderBy("started_at", firestore.Asc)
+		Where("session_id", "==", sessionID.String())
 
 	iter := query.Documents(ctx)
 	defer iter.Stop()
@@ -194,6 +195,7 @@ func (r *Firestore) GetTurnsBySession(ctx context.Context, sessionID types.Sessi
 		}
 		turns = append(turns, &t)
 	}
+	sort.Slice(turns, func(i, j int) bool { return turns[i].StartedAt.Before(turns[j].StartedAt) })
 	return turns, nil
 }
 
@@ -232,11 +234,17 @@ func (r *Firestore) UpdateTurnIntent(ctx context.Context, turnID types.TurnID, i
 // sessions/{sessionID}/messages/{messageID}; looking up by turn_id therefore
 // requires a collection group query.
 func (r *Firestore) GetMessagesByTurn(ctx context.Context, turnID types.TurnID) ([]*session.Message, error) {
+	// Single-field Where + in-memory sort to avoid requiring a composite
+	// index on (turn_id, created_at) for the messages collection group.
 	query := r.db.CollectionGroup("messages").
-		Where("turn_id", "==", turnID.String()).
-		OrderBy("created_at", firestore.Asc)
+		Where("turn_id", "==", turnID.String())
 
-	return queryMessages(ctx, r, query)
+	msgs, err := queryMessages(ctx, r, query)
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(msgs, func(i, j int) bool { return msgs[i].CreatedAt.Before(msgs[j].CreatedAt) })
+	return msgs, nil
 }
 
 func (r *Firestore) SearchSessionMessages(ctx context.Context, ticketID types.TicketID, query string, limit int) ([]*session.Message, error) {

--- a/pkg/repository/firestore/ticket.go
+++ b/pkg/repository/firestore/ticket.go
@@ -2,6 +2,7 @@ package firestore
 
 import (
 	"context"
+	"sort"
 	"strings"
 	"time"
 
@@ -207,9 +208,10 @@ func filterTicketsByKeyword(tickets []*ticket.Ticket, keyword string) []*ticket.
 	return result
 }
 
-// fetchAllByQuery retrieves all documents for the given query without offset/limit.
+// fetchAllByQuery retrieves all documents for the given query without offset/limit,
+// sorted by CreatedAt DESC in-memory. Sorting is done in Go to avoid requiring a
+// composite index on (Status, Assignee.ID, CreatedAt).
 func (r *Firestore) fetchAllByQuery(ctx context.Context, q firestore.Query) ([]*ticket.Ticket, error) {
-	q = q.OrderBy("CreatedAt", firestore.Desc)
 	var tickets []*ticket.Ticket
 	iter := q.Documents(ctx)
 	for {
@@ -227,6 +229,7 @@ func (r *Firestore) fetchAllByQuery(ctx context.Context, q firestore.Query) ([]*
 		t.NormalizeLegacyStatus()
 		tickets = append(tickets, &t)
 	}
+	sort.Slice(tickets, func(i, j int) bool { return tickets[i].CreatedAt.After(tickets[j].CreatedAt) })
 	return tickets, nil
 }
 
@@ -252,33 +255,21 @@ func (r *Firestore) GetTicketsByStatus(ctx context.Context, statuses []types.Tic
 		return filtered, nil
 	}
 
-	// Fast path: push ordering and pagination entirely to Firestore.
-	q = q.OrderBy("CreatedAt", firestore.Desc)
+	// In-memory sort/paginate to avoid composite index on (Status, Assignee.ID, CreatedAt).
+	all, err := r.fetchAllByQuery(ctx, q)
+	if err != nil {
+		return nil, err
+	}
 	if offset > 0 {
-		q = q.Offset(offset)
-	}
-	if limit > 0 {
-		q = q.Limit(limit)
-	}
-
-	var tickets []*ticket.Ticket
-	iter := q.Documents(ctx)
-	for {
-		doc, err := iter.Next()
-		if err != nil {
-			if err == iterator.Done {
-				break
-			}
-			return nil, goerr.Wrap(err, "failed to get offset documents")
+		if offset >= len(all) {
+			return []*ticket.Ticket{}, nil
 		}
-		var t ticket.Ticket
-		if err := doc.DataTo(&t); err != nil {
-			return nil, goerr.Wrap(err, "failed to convert data to ticket")
-		}
-		t.NormalizeLegacyStatus()
-		tickets = append(tickets, &t)
+		all = all[offset:]
 	}
-	return tickets, nil
+	if limit > 0 && limit < len(all) {
+		all = all[:limit]
+	}
+	return all, nil
 }
 
 func (r *Firestore) CountTicketsByStatus(ctx context.Context, statuses []types.TicketStatus, keyword, assigneeID string) (int, error) {

--- a/pkg/repository/firestore/ticket.go
+++ b/pkg/repository/firestore/ticket.go
@@ -214,6 +214,7 @@ func filterTicketsByKeyword(tickets []*ticket.Ticket, keyword string) []*ticket.
 func (r *Firestore) fetchAllByQuery(ctx context.Context, q firestore.Query) ([]*ticket.Ticket, error) {
 	var tickets []*ticket.Ticket
 	iter := q.Documents(ctx)
+	defer iter.Stop()
 	for {
 		doc, err := iter.Next()
 		if err != nil {
@@ -236,29 +237,13 @@ func (r *Firestore) fetchAllByQuery(ctx context.Context, q firestore.Query) ([]*
 func (r *Firestore) GetTicketsByStatus(ctx context.Context, statuses []types.TicketStatus, keyword, assigneeID string, offset, limit int) ([]*ticket.Ticket, error) {
 	q := r.buildTicketBaseQuery(statuses, assigneeID)
 
-	// keyword requires Go-side filtering: fetch all DB-filtered docs first.
-	if keyword != "" {
-		all, err := r.fetchAllByQuery(ctx, q)
-		if err != nil {
-			return nil, err
-		}
-		filtered := filterTicketsByKeyword(all, keyword)
-		if offset > 0 {
-			if offset >= len(filtered) {
-				return []*ticket.Ticket{}, nil
-			}
-			filtered = filtered[offset:]
-		}
-		if limit > 0 && limit < len(filtered) {
-			filtered = filtered[:limit]
-		}
-		return filtered, nil
-	}
-
 	// In-memory sort/paginate to avoid composite index on (Status, Assignee.ID, CreatedAt).
 	all, err := r.fetchAllByQuery(ctx, q)
 	if err != nil {
 		return nil, err
+	}
+	if keyword != "" {
+		all = filterTicketsByKeyword(all, keyword)
 	}
 	if offset > 0 {
 		if offset >= len(all) {


### PR DESCRIPTION
## Summary

`warren migrate --job turn-synthesis` was failing 1528/1528 due to missing Firestore composite indexes. New composite indexes are not allowed in this environment, so this PR rewrites the affected queries to use single-field `Where` + Go-side `sort.Slice`, which removes the composite-index dependency entirely.

## Modified functions

| File | Function | Change |
|---|---|---|
| `pkg/repository/firestore/session_v2.go` | `GetTurnsBySession` | Drop `OrderBy(started_at)` → in-memory sort by `StartedAt ASC` |
| `pkg/repository/firestore/session_v2.go` | `GetMessagesByTurn` | Drop `OrderBy(created_at)` → in-memory sort by `CreatedAt ASC` |
| `pkg/repository/firestore/ticket.go` | `fetchAllByQuery` | Drop `OrderBy(CreatedAt DESC)` → in-memory sort by `CreatedAt DESC` |
| `pkg/repository/firestore/ticket.go` | `GetTicketsByStatus` (fast path) | Stop pushing `OrderBy/Offset/Limit` to Firestore; route through `fetchAllByQuery` and paginate in-memory |
| `pkg/repository/firestore/diagnosis.go` | `ListDiagnosisIssues` | Drop `OrderBy(CreatedAt ASC)/Offset/Limit` → in-memory sort + manual offset/limit |

`Where(CreatedAt range) + OrderBy(CreatedAt)` cases (`GetTicketsBySpan`, `GetTicketsByStatusAndSpan`, `FindNearestTicketsWithSpan`) and Where-less `OrderBy` cases were left untouched per the spec.

## Spec

`.spec/firestore-avoid-composite-index/spec.md` (in-repo).

## Test plan

- [x] `go vet ./...`
- [x] `golangci-lint run ./pkg/repository/firestore/...`
- [x] `go test ./...`
- [ ] qa: `warren migrate --dry-run --job turn-synthesis` then `warren migrate --job turn-synthesis` → `errors=0`
- [ ] qa: re-run → `migrated=0, skipped=N` (idempotency)
- [ ] prd applied after qa green

🤖 Generated with [Claude Code](https://claude.com/claude-code)