### PR TITLE
fix(slack): use multi_static_select for resolve ticket modal tag picker

### DIFF
--- a/pkg/service/slack/blocks.go
+++ b/pkg/service/slack/blocks.go
@@ -470,7 +470,7 @@ func buildResolveTicketModalViewRequest(callbackID model.CallbackID, ticket *tic
 		}
 
 		tagElement := slack.NewOptionsMultiSelectBlockElement(
-			slack.OptTypeStatic,
+			slack.MultiOptTypeStatic,
 			slack.NewTextBlockObject(slack.PlainTextType, "Select tags", false, false),
 			model.BlockActionIDTicketTags.String(),
 			tagOptions...,

--- a/pkg/service/slack/blocks_test.go
+++ b/pkg/service/slack/blocks_test.go
@@ -101,7 +101,7 @@ func TestBuildResolveTicketModalViewRequest_WithTags(t *testing.T) {
 		// Verify it uses multi-select, not checkboxes
 		multiSelect, ok := inputBlock.Element.(*slack_sdk.MultiSelectBlockElement)
 		gt.V(t, ok).Equal(true)
-		gt.V(t, multiSelect.Type).Equal(string(slack_sdk.OptTypeStatic))
+		gt.V(t, multiSelect.Type).Equal(slack_sdk.MultiOptTypeStatic)
 		gt.V(t, len(multiSelect.Options)).Equal(3)
 		gt.V(t, multiSelect.Options[0].Value).Equal("tag-1")
 		gt.V(t, multiSelect.Options[0].Text.Text).Equal("double check")
@@ -147,6 +147,10 @@ func TestBuildResolveTicketModalViewRequest_WithExistingTags(t *testing.T) {
 
 		multiSelect, ok := inputBlock.Element.(*slack_sdk.MultiSelectBlockElement)
 		gt.V(t, ok).Equal(true)
+		// Slack rejects the request with `invalid_arguments` if the type is
+		// `static_select` while `initial_options` (plural) is set. The element
+		// type must be `multi_static_select`.
+		gt.V(t, multiSelect.Type).Equal(slack_sdk.MultiOptTypeStatic)
 
 		// All 3 tags should be available as options
 		gt.V(t, len(multiSelect.Options)).Equal(3)


### PR DESCRIPTION
## Summary
- Resolve Ticket モーダルの tag picker で Slack API が `invalid_arguments` を返してモーダルが開けない問題を修正
- `NewOptionsMultiSelectBlockElement` の optType に `slack.OptTypeStatic`（= `static_select`）を渡していたため、生成される block element の `type` が `static_select` になり、`initial_options`（複数形）と組み合わさったときに Slack API に拒否されていた。`slack.MultiOptTypeStatic`（= `multi_static_select`）に修正
- 副次的に、初期タグなしのチケットでもタグセレクタが単一選択 UI として描画されていた問題も解消し、本来の multi-select UI で表示されるようになる

## Background
- 本番（`argus-warren`）で `failed to show resolve ticket modal: failed to open view: invalid_arguments` が発生（Sentry id: `ef460eb938024bd6a8071632b7f8de39`、`pkg/service/slack/slack.go:1070`）
- 既存テストが誤って `OptTypeStatic` を期待値としてアサートしていたためバグが見逃されていた。テスト側も `MultiOptTypeStatic` を期待するよう修正し、`initial_options` ありのケースにも type アサーションを追加

## Test plan
- [x] `go test ./pkg/service/slack/...` 全 pass
- [x] `go vet ./...` クリーン
- [x] `golangci-lint run ./pkg/service/slack/...` 0 issues
- [x] `gosec -exclude-generated -quiet ./pkg/service/slack/...` 検出なし
- [ ] 本番デプロイ後、初期タグありのチケットで Resolve Ticket モーダルが正常に開けることを確認
- [ ] タグが multi-select UI として描画され、複数タグを選択できることを確認