### PR TITLE
fix(frontend): default tickets list to Open and make rows real anchor links

### DIFF
--- a/frontend/e2e/pages/TicketListPage.ts
+++ b/frontend/e2e/pages/TicketListPage.ts
@@ -46,7 +46,21 @@ export class TicketListPage extends BasePage {
     return this.page.locator("[data-testid^='ticket-item-']");
   }
 
+  ticketItemById(id: string) {
+    return this.page.getByTestId(`ticket-item-${id}`);
+  }
+
   ticketItemByTitle(title: string) {
     return this.page.getByText(title);
+  }
+
+  // Status filter trigger is the only combobox visible in the Active tab's
+  // filter bar; fall back to the visible label when the dropdown is closed.
+  get statusFilterTrigger() {
+    return this.page.getByRole("combobox").first();
+  }
+
+  statusFilterOption(name: "All Status" | "Open" | "Resolved") {
+    return this.page.getByRole("option", { name });
   }
 }

--- a/frontend/e2e/pages/TicketListPage.ts
+++ b/frontend/e2e/pages/TicketListPage.ts
@@ -54,10 +54,8 @@ export class TicketListPage extends BasePage {
     return this.page.getByText(title);
   }
 
-  // Status filter trigger is the only combobox visible in the Active tab's
-  // filter bar; fall back to the visible label when the dropdown is closed.
   get statusFilterTrigger() {
-    return this.page.getByRole("combobox").first();
+    return this.page.getByTestId("status-filter-trigger");
   }
 
   statusFilterOption(name: "All Status" | "Open" | "Resolved") {

--- a/frontend/e2e/tests/ticket.spec.ts
+++ b/frontend/e2e/tests/ticket.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "../fixtures";
 import { TicketListPage } from "../pages/TicketListPage";
 import {
+  archiveTicketViaAPI,
   createTicketViaAPI,
   resolveTicketViaAPI,
 } from "../helpers/api";
@@ -172,5 +173,97 @@ test.describe("Tickets", () => {
     await expect(page.getByText(`ToArchive-${suffix}`)).not.toBeVisible();
     // Open ticket should still be visible
     await expect(page.getByText(`StayOpen-${suffix}`).first()).toBeVisible();
+  });
+
+  test("should default the Active tab status filter to Open", async ({
+    authenticatedPage: page,
+  }) => {
+    const suffix = Date.now().toString();
+
+    const openTicket = await createTicketViaAPI(
+      page,
+      `DefaultFilterOpen-${suffix}`,
+      "Open ticket should be visible by default"
+    );
+    const resolvedTicket = await createTicketViaAPI(
+      page,
+      `DefaultFilterResolved-${suffix}`,
+      "Resolved ticket should be hidden by default"
+    );
+    await resolveTicketViaAPI(page, resolvedTicket.id);
+
+    const ticketList = new TicketListPage(page);
+    await ticketList.goto();
+
+    // The status trigger reflects the default filter
+    await expect(ticketList.statusFilterTrigger).toHaveText(/Open/);
+
+    // Open ticket is visible, resolved ticket is filtered out
+    await expect(ticketList.ticketItemById(openTicket.id)).toBeVisible();
+    await expect(ticketList.ticketItemById(resolvedTicket.id)).toHaveCount(0);
+
+    // Switching to All Status surfaces the resolved ticket too
+    await ticketList.statusFilterTrigger.click();
+    await ticketList.statusFilterOption("All Status").click();
+    await expect(ticketList.ticketItemById(openTicket.id)).toBeVisible();
+    await expect(ticketList.ticketItemById(resolvedTicket.id)).toBeVisible();
+
+    // Cleanup
+    await archiveTicketViaAPI(page, resolvedTicket.id);
+    await archiveTicketViaAPI(page, openTicket.id);
+  });
+
+  test("should expose ticket rows as anchor links with href", async ({
+    authenticatedPage: page,
+  }) => {
+    const suffix = Date.now().toString();
+    const ticket = await createTicketViaAPI(
+      page,
+      `RowAnchor-${suffix}`,
+      "Row should render as a real <a> with href"
+    );
+
+    const ticketList = new TicketListPage(page);
+    await ticketList.goto();
+
+    const row = ticketList.ticketItemById(ticket.id);
+    await expect(row).toBeVisible();
+    await expect(row).toHaveAttribute("href", `/tickets/${ticket.id}`);
+
+    // Plain click still routes via SPA without a full page reload
+    await row.click();
+    await expect(page).toHaveURL(new RegExp(`/tickets/${ticket.id}$`));
+
+    // Cleanup
+    await archiveTicketViaAPI(page, ticket.id);
+  });
+
+  test("should open ticket detail in a new tab on Cmd/Ctrl+Click", async ({
+    authenticatedPage: page,
+  }) => {
+    const suffix = Date.now().toString();
+    const ticket = await createTicketViaAPI(
+      page,
+      `RowNewTab-${suffix}`,
+      "Cmd/Ctrl+Click should open in a new tab"
+    );
+
+    const ticketList = new TicketListPage(page);
+    await ticketList.goto();
+
+    const row = ticketList.ticketItemById(ticket.id);
+    await expect(row).toBeVisible();
+
+    const context = page.context();
+    const [newPage] = await Promise.all([
+      context.waitForEvent("page"),
+      row.click({ modifiers: ["ControlOrMeta"] }),
+    ]);
+    await newPage.waitForLoadState("domcontentloaded");
+    await expect(newPage).toHaveURL(new RegExp(`/tickets/${ticket.id}$`));
+    await newPage.close();
+
+    // Cleanup
+    await archiveTicketViaAPI(page, ticket.id);
   });
 });

--- a/frontend/e2e/tests/ticket.spec.ts
+++ b/frontend/e2e/tests/ticket.spec.ts
@@ -208,6 +208,14 @@ test.describe("Tickets", () => {
     await expect(ticketList.ticketItemById(openTicket.id)).toBeVisible();
     await expect(ticketList.ticketItemById(resolvedTicket.id)).toBeVisible();
 
+    // Tab round-trip should restore the Open default — switching to Archived
+    // and back to Active must not leave the filter on "All Status".
+    await ticketList.archivedTab.click();
+    await ticketList.activeTab.click();
+    await expect(ticketList.statusFilterTrigger).toHaveText(/Open/);
+    await expect(ticketList.ticketItemById(openTicket.id)).toBeVisible();
+    await expect(ticketList.ticketItemById(resolvedTicket.id)).toHaveCount(0);
+
     // Cleanup
     await archiveTicketViaAPI(page, resolvedTicket.id);
     await archiveTicketViaAPI(page, openTicket.id);

--- a/frontend/e2e/tests/ticket.spec.ts
+++ b/frontend/e2e/tests/ticket.spec.ts
@@ -216,8 +216,9 @@ test.describe("Tickets", () => {
     await expect(ticketList.ticketItemById(openTicket.id)).toBeVisible();
     await expect(ticketList.ticketItemById(resolvedTicket.id)).toHaveCount(0);
 
-    // Cleanup
+    // Cleanup — only the resolved ticket is archivable directly.
     await archiveTicketViaAPI(page, resolvedTicket.id);
+    await resolveTicketViaAPI(page, openTicket.id);
     await archiveTicketViaAPI(page, openTicket.id);
   });
 
@@ -243,6 +244,7 @@ test.describe("Tickets", () => {
     await expect(page).toHaveURL(new RegExp(`/tickets/${ticket.id}$`));
 
     // Cleanup
+    await resolveTicketViaAPI(page, ticket.id);
     await archiveTicketViaAPI(page, ticket.id);
   });
 
@@ -272,6 +274,7 @@ test.describe("Tickets", () => {
     await newPage.close();
 
     // Cleanup
+    await resolveTicketViaAPI(page, ticket.id);
     await archiveTicketViaAPI(page, ticket.id);
   });
 });

--- a/frontend/src/pages/TicketsPage.tsx
+++ b/frontend/src/pages/TicketsPage.tsx
@@ -1,6 +1,6 @@
 import { useQuery, useLazyQuery, useMutation } from "@apollo/client";
 import { useState, useMemo } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { useConfirm } from "@/hooks/use-confirm";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -62,12 +62,10 @@ export default function TicketsPage() {
   const confirm = useConfirm();
 
   // Filter state
-  const [statusFilter, setStatusFilter] = useState<"all" | "open" | "resolved">("all");
+  const [statusFilter, setStatusFilter] = useState<"all" | "open" | "resolved">("open");
   const [assigneeFilter, setAssigneeFilter] = useState<string>("all");
   const [keywordFilter, setKeywordFilter] = useState<string>("");
   const [keywordInput, setKeywordInput] = useState<string>("");
-
-  const navigate = useNavigate();
 
   // Compute the statuses to query based on tab + status filter
   const selectedStatuses = useMemo(() => {
@@ -357,10 +355,11 @@ export default function TicketsPage() {
                 {tickets.map((ticket) => {
                   const conclusion = ticket.conclusion ? CONCLUSION_CONFIG[ticket.conclusion.toLowerCase()] : null;
                   return (
-                    <div
+                    <Link
                       key={ticket.id}
-                      className="flex items-start gap-3 px-4 py-3.5 hover:bg-muted/40 cursor-pointer transition-colors"
-                      onClick={() => navigate(`/tickets/${ticket.id}`)}>
+                      to={`/tickets/${ticket.id}`}
+                      data-testid={`ticket-item-${ticket.id}`}
+                      className="flex items-start gap-3 px-4 py-3.5 hover:bg-muted/40 transition-colors text-inherit no-underline">
                       {/* Status icon */}
                       {getStatusIcon(ticket.status as TicketStatus)}
 
@@ -423,7 +422,7 @@ export default function TicketsPage() {
                           </span>
                         )}
                       </div>
-                    </div>
+                    </Link>
                   );
                 })}
               </div>

--- a/frontend/src/pages/TicketsPage.tsx
+++ b/frontend/src/pages/TicketsPage.tsx
@@ -113,7 +113,7 @@ export default function TicketsPage() {
   const handleTabChange = (tab: string) => {
     setActiveTab(tab as ActiveTab);
     setCurrentPage(1);
-    setStatusFilter("all");
+    setStatusFilter("open");
     setAssigneeFilter("all");
     setKeywordFilter("");
     setKeywordInput("");
@@ -237,11 +237,13 @@ export default function TicketsPage() {
           {/* Status filter — only shown in Active tab */}
           {activeTab === "active" && (
             <Select value={statusFilter} onValueChange={handleStatusFilterChange}>
-              <SelectTrigger className={`h-8 w-36 text-xs transition-colors ${
-                statusFilter !== "all"
-                  ? "border-blue-500 bg-blue-50 text-blue-700 font-medium"
-                  : ""
-              }`}>
+              <SelectTrigger
+                data-testid="status-filter-trigger"
+                className={`h-8 w-36 text-xs transition-colors ${
+                  statusFilter !== "open"
+                    ? "border-blue-500 bg-blue-50 text-blue-700 font-medium"
+                    : ""
+                }`}>
                 {statusFilter === "open" ? (
                   <span className="flex items-center gap-1.5">
                     <CircleDot className="h-3.5 w-3.5 text-blue-500 shrink-0" />
@@ -328,10 +330,10 @@ export default function TicketsPage() {
           </div>
 
           {/* Clear all filters button — shown when any filter is active */}
-          {(statusFilter !== "all" || assigneeFilter !== "all" || keywordFilter) && (
+          {(statusFilter !== "open" || assigneeFilter !== "all" || keywordFilter) && (
             <button
               onClick={() => {
-                setStatusFilter("all");
+                setStatusFilter("open");
                 setAssigneeFilter("all");
                 setKeywordFilter("");
                 setKeywordInput("");

--- a/frontend/src/pages/TicketsPage.tsx
+++ b/frontend/src/pages/TicketsPage.tsx
@@ -96,8 +96,14 @@ export default function TicketsPage() {
   const [archiveAllResolved, { loading: archiving }] = useMutation(ARCHIVE_ALL_RESOLVED_TICKETS);
   const [fetchResolvedCount] = useLazyQuery(GET_TICKETS, { fetchPolicy: "network-only" });
 
+  // Independent of the visible status filter so the "Archive All Resolved"
+  // button still surfaces resolved tickets that are currently filtered out.
+  const { data: resolvedCountData, refetch: refetchResolvedCount } = useQuery(GET_TICKETS, {
+    variables: { statuses: ["resolved"] as TicketStatus[], offset: 0, limit: 1 },
+  });
+  const resolvedTotalCount: number = resolvedCountData?.tickets?.totalCount ?? 0;
+
   const tickets: Ticket[] = ticketsData?.tickets?.tickets || [];
-  const resolvedTickets = tickets.filter(t => t.status === "resolved");
 
   // Collect unique assignees from current result set for the dropdown
   const assigneeOptions = useMemo(() => {
@@ -159,7 +165,7 @@ export default function TicketsPage() {
     });
     if (!ok) return;
     await archiveAllResolved();
-    await refetch();
+    await Promise.all([refetch(), refetchResolvedCount()]);
   };
 
   if (ticketsLoading) {
@@ -218,7 +224,7 @@ export default function TicketsPage() {
             <TabsTrigger value="archived" className="text-sm px-3 h-7">Archived</TabsTrigger>
           </TabsList>
 
-          {activeTab === "active" && resolvedTickets.length > 0 && (
+          {activeTab === "active" && resolvedTotalCount > 0 && (
             <Button
               variant="outline"
               size="sm"


### PR DESCRIPTION
Closes #202

## Summary
- Default the Active tab's status filter on `/tickets` to `Open` so resolved tickets no longer dominate the landing view (still switchable to All Status / Resolved from the dropdown).
- Replace the `<div onClick={navigate(...)}>` ticket row with `react-router-dom`'s `<Link to={...}>` so Cmd/Ctrl+Click, middle-click, and right-click "open in new tab" all work natively. Plain click still goes through SPA routing.
- Add `data-testid="ticket-item-{id}"` to the row (the existing Page Object already expected it).

## Test plan
- [ ] `pnpm run build` passes (tsc + vite)
- [ ] `go vet ./...` clean
- [ ] New Playwright tests in `frontend/e2e/tests/ticket.spec.ts`:
  - [ ] Default Active tab filter shows only Open tickets, switching to All Status surfaces Resolved tickets too
  - [ ] Ticket row exposes `href="/tickets/{id}"` and routes via SPA on plain click
  - [ ] Cmd/Ctrl+Click opens the ticket detail in a new browser page
- [ ] Manual: middle-click / right-click context menu on a row behave like a real link

🤖 Generated with [Claude Code](https://claude.com/claude-code)