### PR TITLE
feat(policy): load Rego rules from a GitHub repository

### DIFF
--- a/doc/operation/policy.md
+++ b/doc/operation/policy.md
@@ -332,17 +332,7 @@ Specifying both `--policy` and `--policy-github-repo` is supported. Files from b
 
 ### Multi-instance considerations
 
-Each Warren instance polls GitHub independently with its own `cachedAt`. Within a single TTL window, two instances may briefly serve evaluations against different commit shas (the spread is bounded by the TTL). This is intentional for the read-only Phase 1 scope; future work will close the gap with webhook-driven invalidation.
-
-### Out of scope (today)
-
-The following are deliberately not part of the GitHub source:
-
-- Webhook-driven instant reload (each instance polls)
-- Editing through Warren (Web UI / Slack / PR creation / auto merge)
-- Pre-flight checks on candidate rules
-- Multi-instance commit-sha synchronization
-- Audit logging beyond ordinary process logs
+Each Warren instance polls GitHub independently with its own `cachedAt`. Within a single TTL window, two instances may briefly serve evaluations against different commit shas (the spread is bounded by the TTL).
 
 ## Best Practices
 

--- a/doc/operation/policy.md
+++ b/doc/operation/policy.md
@@ -258,6 +258,92 @@ warren test \
   --test-ignore-data ./test/myservice/ignore
 ```
 
+## Policy Sources
+
+Warren can load Rego policies from two kinds of sources, which may be combined. The Rego `package` mechanism merges contributions across sources naturally — partial rules (e.g. `ignore if ...`, `alerts contains ...`) accumulate, while complete rules conflict if they assign different values for the same input.
+
+### File source (default)
+
+Specify one or more local files or directories with `--policy` (or `WARREN_POLICY`). Directories are scanned recursively for `.rego` files. Files are loaded once at startup and never reloaded; restart Warren to pick up changes.
+
+```bash
+warren serve --policy ./policies
+```
+
+### GitHub source
+
+Set `--policy-github-repo owner/repo` together with GitHub App credentials. Each Warren instance independently fetches the default branch HEAD of the repository and rebuilds its policy client when the commit sha changes. There is no editing UI, push, or PR support yet — this stage only adds a read path.
+
+```bash
+warren serve \
+  --policy-github-repo myorg/warren-policy \
+  --policy-github-path policies \
+  --policy-github-app-id 123456 \
+  --policy-github-app-installation-id 78901234 \
+  --policy-github-app-private-key "$(cat /secrets/warren-policy.pem)"
+```
+
+Equivalent environment variables:
+
+```bash
+export WARREN_POLICY_GITHUB_REPO=myorg/warren-policy
+export WARREN_POLICY_GITHUB_PATH=policies
+export WARREN_POLICY_GITHUB_APP_ID=123456
+export WARREN_POLICY_GITHUB_APP_INSTALLATION_ID=78901234
+export WARREN_POLICY_GITHUB_APP_PRIVATE_KEY="$(cat /secrets/warren-policy.pem)"
+```
+
+#### GitHub App setup
+
+Create a dedicated GitHub App with the **minimum** permissions required for read access:
+
+- **Repository permissions**:
+  - `Contents`: **Read-only**
+  - `Metadata`: **Read-only**
+- **Webhook**: not required (Warren polls)
+- **Install on**: only the policy repository (not org-wide)
+
+After creation, install the App on your policy repository and capture:
+- App ID (Settings → GitHub Apps → your app)
+- Installation ID (the `installations/<id>` path segment after install)
+- Private key (Settings → GitHub Apps → your app → Generate a private key, downloads `.pem`)
+
+#### Recommended: dedicated GitHub App
+
+If your Warren deployment already uses a GitHub App for tool use (e.g. `pkg/tool/github`), **create a separate App for policy loading** rather than reusing the existing one.
+
+- The tool-use App typically needs read access to many repositories. Reusing it for policy loading would leave the policy repository within a wider blast radius if that App's credentials were ever compromised.
+- A dedicated `warren-policy` (or `warren-rule`) App can be installed on **only** the policy repository with `contents: read` + `metadata: read`, and it leaves room to later add a separate write-capable App for editing flows without entangling responsibilities.
+
+### Caching behavior
+
+Each instance caches the GitHub fetch result in memory:
+
+1. Within `--policy-github-cache-ttl` (default `1m`), repeated evaluations reuse the cached compiled policy without contacting GitHub.
+2. After the TTL elapses, the next evaluation fetches the default branch HEAD sha. If unchanged, the in-memory policy is reused and only `cachedAt` is refreshed.
+3. If the sha differs, file contents are fetched and validated. On success the cache is replaced.
+4. If the new fetch or validation fails (network error, invalid Rego, etc.), Warren logs the error and **falls back to the previously cached policy**. The very first fetch has no fallback and will surface as a startup error.
+
+Cache updates are guarded by an in-process mutex so concurrent evaluations in the same instance trigger at most one fetch.
+
+### Combining sources
+
+Specifying both `--policy` and `--policy-github-repo` is supported. Files from both are merged into a single compiled policy. Prefer using distinct Rego file paths between sources to avoid accidental key collisions; the loader reports an error if two sources contribute different content under the same path.
+
+### Multi-instance considerations
+
+Each Warren instance polls GitHub independently with its own `cachedAt`. Within a single TTL window, two instances may briefly serve evaluations against different commit shas (the spread is bounded by the TTL). This is intentional for the read-only Phase 1 scope; future work will close the gap with webhook-driven invalidation.
+
+### Out of scope (today)
+
+The following are deliberately not part of the GitHub source:
+
+- Webhook-driven instant reload (each instance polls)
+- Editing through Warren (Web UI / Slack / PR creation / auto merge)
+- Pre-flight checks on candidate rules
+- Multi-instance commit-sha synchronization
+- Audit logging beyond ordinary process logs
+
 ## Best Practices
 
 - **Filter early** with `ignore` rules to drop noise before AI processing

--- a/doc/reference/configuration.md
+++ b/doc/reference/configuration.md
@@ -80,6 +80,14 @@ Warren uses the following precedence (highest to lowest):
 |---|---|---|---|
 | `WARREN_POLICY` | `--policy` | - | Path to policy files/directories |
 | `WARREN_WATCH` | `--watch` | `false` | Watch policy files for changes |
+| `WARREN_POLICY_GITHUB_REPO` | `--policy-github-repo` | - | GitHub repository hosting Rego policy files (format: `owner/repo`). Loaded from default branch HEAD. |
+| `WARREN_POLICY_GITHUB_PATH` | `--policy-github-path` | repo root | Path within the GitHub repository to scan recursively for `.rego` files. May be specified multiple times. |
+| `WARREN_POLICY_GITHUB_APP_ID` | `--policy-github-app-id` | - | GitHub App ID used for policy repository read access. Required when `--policy-github-repo` is set. |
+| `WARREN_POLICY_GITHUB_APP_INSTALLATION_ID` | `--policy-github-app-installation-id` | - | GitHub App Installation ID. Required when `--policy-github-repo` is set. |
+| `WARREN_POLICY_GITHUB_APP_PRIVATE_KEY` | `--policy-github-app-private-key` | - | GitHub App private key (PEM string). Required when `--policy-github-repo` is set. |
+| `WARREN_POLICY_GITHUB_CACHE_TTL` | `--policy-github-cache-ttl` | `1m` | TTL for cached GitHub policy contents. The HEAD commit sha is checked at most once per TTL; identical sha skips re-fetching file contents. |
+
+GitHub policy loading is described in detail in [`doc/operation/policy.md`](../operation/policy.md#policy-sources).
 
 ### Chat / Agent
 

--- a/pkg/adapter/policy/file_source.go
+++ b/pkg/adapter/policy/file_source.go
@@ -1,0 +1,61 @@
+package policy
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"sort"
+
+	"github.com/m-mizutani/goerr/v2"
+	"github.com/m-mizutani/opaq"
+)
+
+// FileSource loads Rego files from local filesystem paths once at
+// construction time. The contents do not change for the lifetime of the
+// process, matching the existing --policy behavior.
+type FileSource struct {
+	paths    []string
+	snapshot *Snapshot
+}
+
+// NewFileSource reads .rego files from the given paths (files or directories,
+// recursively) using opaq.Files semantics. Returns an error if any path is
+// invalid or files fail to load.
+func NewFileSource(paths []string) (*FileSource, error) {
+	client, err := opaq.New(opaq.Files(paths...))
+	if err != nil {
+		return nil, goerr.Wrap(err, "failed to load policy files",
+			goerr.V("paths", paths))
+	}
+
+	files := client.Sources()
+	return &FileSource{
+		paths: paths,
+		snapshot: &Snapshot{
+			Files:   files,
+			Version: "file:" + hashFiles(files),
+		},
+	}, nil
+}
+
+func (s *FileSource) Snapshot(_ context.Context) (*Snapshot, error) {
+	return s.snapshot, nil
+}
+
+// hashFiles produces a deterministic version identifier for a files map.
+func hashFiles(files map[string]string) string {
+	keys := make([]string, 0, len(files))
+	for k := range files {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	h := sha256.New()
+	for _, k := range keys {
+		h.Write([]byte(k))
+		h.Write([]byte{0})
+		h.Write([]byte(files[k]))
+		h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}

--- a/pkg/adapter/policy/file_source_test.go
+++ b/pkg/adapter/policy/file_source_test.go
@@ -1,0 +1,39 @@
+package policy_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/m-mizutani/gt"
+	"github.com/secmon-lab/warren/pkg/adapter/policy"
+)
+
+func TestFileSource_Snapshot(t *testing.T) {
+	t.Run("loads files from a directory", func(t *testing.T) {
+		src, err := policy.NewFileSource([]string{"testdata"})
+		gt.NoError(t, err)
+
+		snap, err := src.Snapshot(context.Background())
+		gt.NoError(t, err)
+		gt.NotNil(t, snap)
+		gt.M(t, snap.Files).Length(1)
+		gt.True(t, snap.Version != "")
+	})
+
+	t.Run("returns identical snapshot on repeated calls", func(t *testing.T) {
+		src, err := policy.NewFileSource([]string{"testdata"})
+		gt.NoError(t, err)
+
+		first, err := src.Snapshot(context.Background())
+		gt.NoError(t, err)
+		second, err := src.Snapshot(context.Background())
+		gt.NoError(t, err)
+
+		gt.Equal(t, first.Version, second.Version)
+	})
+
+	t.Run("fails on non-existent path", func(t *testing.T) {
+		_, err := policy.NewFileSource([]string{"testdata/does-not-exist"})
+		gt.Error(t, err)
+	})
+}

--- a/pkg/adapter/policy/github_source.go
+++ b/pkg/adapter/policy/github_source.go
@@ -1,0 +1,227 @@
+package policy
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/bradleyfalzon/ghinstallation/v2"
+	"github.com/google/go-github/v74/github"
+	"github.com/m-mizutani/goerr/v2"
+	"github.com/m-mizutani/opaq"
+	"github.com/secmon-lab/warren/pkg/utils/errutil"
+)
+
+// DefaultGitHubCacheTTL is the default time-to-live for GitHubSource cache.
+const DefaultGitHubCacheTTL = time.Minute
+
+// GitHubSourceOpts configures a GitHubSource.
+//
+// Either Client must be provided directly (typically for testing), or all of
+// AppID, InstallationID, and PrivateKey must be provided so that a GitHub App
+// installation token can be obtained.
+type GitHubSourceOpts struct {
+	Owner string
+	Repo  string
+
+	// Paths within the repository to recursively scan for .rego files.
+	// An empty slice scans the repository root.
+	Paths []string
+
+	// TTL for the in-memory cache. Zero means DefaultGitHubCacheTTL.
+	TTL time.Duration
+
+	// Optional pre-built client. When non-nil, App credentials below are ignored.
+	Client *github.Client
+
+	// GitHub App credentials. Required when Client is nil.
+	AppID          int64
+	InstallationID int64
+	PrivateKey     []byte
+}
+
+// GitHubSource fetches Rego policy files from a GitHub repository's default
+// branch HEAD. Results are cached in memory for TTL; sha-based change detection
+// avoids re-fetching content when the branch HEAD has not moved. On any
+// fetch or validation failure, the previously known good snapshot is returned.
+type GitHubSource struct {
+	owner  string
+	repo   string
+	paths  []string
+	ttl    time.Duration
+	client *github.Client
+
+	mu          sync.Mutex
+	cachedFiles map[string]string
+	cachedSha   string
+	cachedAt    time.Time
+}
+
+// NewGitHubSource constructs a GitHubSource. If opts.Client is nil, App
+// credentials are required and a github.Client is built using
+// bradleyfalzon/ghinstallation/v2.
+func NewGitHubSource(opts GitHubSourceOpts) (*GitHubSource, error) {
+	if opts.Owner == "" || opts.Repo == "" {
+		return nil, goerr.New("owner and repo are required")
+	}
+
+	client := opts.Client
+	if client == nil {
+		if opts.AppID == 0 || opts.InstallationID == 0 || len(opts.PrivateKey) == 0 {
+			return nil, goerr.New("GitHub App credentials are required when Client is not provided")
+		}
+		transport, err := ghinstallation.New(http.DefaultTransport, opts.AppID, opts.InstallationID, opts.PrivateKey)
+		if err != nil {
+			return nil, goerr.Wrap(err, "failed to create GitHub App transport")
+		}
+		client = github.NewClient(&http.Client{
+			Transport: transport,
+			Timeout:   30 * time.Second,
+		})
+	}
+
+	paths := opts.Paths
+	if len(paths) == 0 {
+		paths = []string{""}
+	}
+
+	ttl := opts.TTL
+	if ttl <= 0 {
+		ttl = DefaultGitHubCacheTTL
+	}
+
+	return &GitHubSource{
+		owner:  opts.Owner,
+		repo:   opts.Repo,
+		paths:  paths,
+		ttl:    ttl,
+		client: client,
+	}, nil
+}
+
+// Snapshot returns the current snapshot, fetching from GitHub if the cache is
+// stale. Concurrent callers serialise on the internal mutex so only one fetch
+// is in flight at a time.
+func (s *GitHubSource) Snapshot(ctx context.Context) (*Snapshot, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.cachedFiles != nil && time.Since(s.cachedAt) < s.ttl {
+		return s.snapshotLocked(), nil
+	}
+
+	repoInfo, _, err := s.client.Repositories.Get(ctx, s.owner, s.repo)
+	if err != nil {
+		return s.fallbackLocked(ctx, goerr.Wrap(err, "failed to fetch repo info",
+			goerr.V("owner", s.owner), goerr.V("repo", s.repo)))
+	}
+	defaultBranch := repoInfo.GetDefaultBranch()
+	if defaultBranch == "" {
+		return s.fallbackLocked(ctx, goerr.New("repository has no default branch",
+			goerr.V("owner", s.owner), goerr.V("repo", s.repo)))
+	}
+
+	branch, _, err := s.client.Repositories.GetBranch(ctx, s.owner, s.repo, defaultBranch, 0)
+	if err != nil {
+		return s.fallbackLocked(ctx, goerr.Wrap(err, "failed to fetch branch",
+			goerr.V("branch", defaultBranch)))
+	}
+	headSha := branch.GetCommit().GetSHA()
+	if headSha == "" {
+		return s.fallbackLocked(ctx, goerr.New("branch has no HEAD commit",
+			goerr.V("branch", defaultBranch)))
+	}
+
+	if s.cachedFiles != nil && headSha == s.cachedSha {
+		s.cachedAt = time.Now()
+		return s.snapshotLocked(), nil
+	}
+
+	files, err := s.fetchAllPaths(ctx, headSha)
+	if err != nil {
+		return s.fallbackLocked(ctx, goerr.Wrap(err, "failed to fetch policy files",
+			goerr.V("commit_sha", headSha)))
+	}
+
+	if _, err := opaq.New(opaq.DataMap(files)); err != nil {
+		return s.fallbackLocked(ctx, goerr.Wrap(err, "policy validation failed",
+			goerr.V("commit_sha", headSha)))
+	}
+
+	s.cachedFiles = files
+	s.cachedSha = headSha
+	s.cachedAt = time.Now()
+	return s.snapshotLocked(), nil
+}
+
+func (s *GitHubSource) snapshotLocked() *Snapshot {
+	return &Snapshot{
+		Files:   s.cachedFiles,
+		Version: "github://" + s.owner + "/" + s.repo + "@" + s.cachedSha,
+	}
+}
+
+// fallbackLocked decides what to return when a fetch step fails.
+// If a previous snapshot exists, the error is logged via errutil.Handle and
+// the cached snapshot is returned. Otherwise the error is returned.
+func (s *GitHubSource) fallbackLocked(ctx context.Context, err error) (*Snapshot, error) {
+	if s.cachedFiles != nil {
+		errutil.Handle(ctx, err)
+		return s.snapshotLocked(), nil
+	}
+	return nil, err
+}
+
+func (s *GitHubSource) fetchAllPaths(ctx context.Context, sha string) (map[string]string, error) {
+	out := map[string]string{}
+	opts := &github.RepositoryContentGetOptions{Ref: sha}
+	for _, p := range s.paths {
+		if err := s.fetchPath(ctx, p, opts, out); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+func (s *GitHubSource) fetchPath(ctx context.Context, p string, opts *github.RepositoryContentGetOptions, out map[string]string) error {
+	fileContent, dirContents, _, err := s.client.Repositories.GetContents(ctx, s.owner, s.repo, p, opts)
+	if err != nil {
+		return goerr.Wrap(err, "failed to fetch contents", goerr.V("path", p))
+	}
+
+	if fileContent != nil {
+		if !strings.HasSuffix(fileContent.GetName(), ".rego") {
+			return nil
+		}
+		content, err := fileContent.GetContent()
+		if err != nil {
+			return goerr.Wrap(err, "failed to decode file content",
+				goerr.V("path", fileContent.GetPath()))
+		}
+		out[s.fileKey(fileContent.GetPath())] = content
+		return nil
+	}
+
+	for _, entry := range dirContents {
+		switch entry.GetType() {
+		case "file":
+			if !strings.HasSuffix(entry.GetName(), ".rego") {
+				continue
+			}
+			if err := s.fetchPath(ctx, entry.GetPath(), opts, out); err != nil {
+				return err
+			}
+		case "dir":
+			if err := s.fetchPath(ctx, entry.GetPath(), opts, out); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (s *GitHubSource) fileKey(repoPath string) string {
+	return "github://" + s.owner + "/" + s.repo + "/" + repoPath
+}

--- a/pkg/adapter/policy/github_source.go
+++ b/pkg/adapter/policy/github_source.go
@@ -2,6 +2,7 @@ package policy
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strings"
 	"sync"
@@ -145,9 +146,17 @@ func (s *GitHubSource) Snapshot(ctx context.Context) (*Snapshot, error) {
 			goerr.V("commit_sha", headSha)))
 	}
 
-	if _, err := opaq.New(opaq.DataMap(files)); err != nil {
-		return s.fallbackLocked(ctx, goerr.Wrap(err, "policy validation failed",
-			goerr.V("commit_sha", headSha)))
+	if err := validatePolicy(ctx, files); err != nil {
+		// Validation failures indicate a data-level problem (bad Rego, rule
+		// conflict, etc.) that will not self-heal on retry, so notify
+		// regardless of whether a cached snapshot is available.
+		wrapped := goerr.Wrap(err, "policy validation failed",
+			goerr.V("commit_sha", headSha))
+		errutil.Handle(ctx, wrapped)
+		if s.cachedFiles != nil {
+			return s.snapshotLocked(), nil
+		}
+		return nil, wrapped
 	}
 
 	s.cachedFiles = files
@@ -224,4 +233,25 @@ func (s *GitHubSource) fetchPath(ctx context.Context, p string, opts *github.Rep
 
 func (s *GitHubSource) fileKey(repoPath string) string {
 	return "github://" + s.owner + "/" + s.repo + "/" + repoPath
+}
+
+// validatePolicy performs both compile-time and runtime checks against a set
+// of Rego files. The compile step catches syntax and reference errors; the
+// runtime step (evaluating the root data document with an empty input)
+// surfaces problems such as complete-rule conflicts that pass compilation
+// but fail at evaluation time. ErrNoEvalResult is treated as success since
+// it merely indicates that the requested document is not defined.
+func validatePolicy(ctx context.Context, files map[string]string) error {
+	client, err := opaq.New(opaq.DataMap(files))
+	if err != nil {
+		return goerr.Wrap(err, "failed to compile policy")
+	}
+	var out any
+	if err := client.Query(ctx, "data", map[string]any{}, &out); err != nil {
+		if errors.Is(err, opaq.ErrNoEvalResult) {
+			return nil
+		}
+		return goerr.Wrap(err, "policy evaluation failed under empty input")
+	}
+	return nil
 }

--- a/pkg/adapter/policy/github_source_test.go
+++ b/pkg/adapter/policy/github_source_test.go
@@ -269,6 +269,62 @@ func TestGitHubSource_ValidationFailure_FallbackToCached(t *testing.T) {
 	gt.True(t, strings.Contains(snap.Files["github://owner/repo/policies/ignore.rego"], "from-github\""))
 }
 
+func TestGitHubSource_RuntimeConflict_FallbackToCached(t *testing.T) {
+	mock := newMockGitHub(t, "sha-1", map[string]string{
+		"policies/ignore.rego": ghTestRego,
+	})
+
+	src, err := policyadapter.NewGitHubSource(policyadapter.GitHubSourceOpts{
+		Owner:  "owner",
+		Repo:   "repo",
+		Paths:  []string{"policies"},
+		Client: mock.client(),
+		TTL:    time.Nanosecond,
+	})
+	gt.NoError(t, err)
+
+	first, err := src.Snapshot(context.Background())
+	gt.NoError(t, err)
+
+	// Compile succeeds but evaluating data triggers a complete-rule conflict.
+	mock.update("sha-conflict", map[string]string{
+		"policies/conflict.rego": `package conflict
+import rego.v1
+x := 1
+x := 2
+`,
+	})
+
+	time.Sleep(2 * time.Millisecond)
+
+	snap, err := src.Snapshot(context.Background())
+	gt.NoError(t, err)
+	gt.Equal(t, snap.Version, first.Version)
+	gt.True(t, strings.Contains(snap.Files["github://owner/repo/policies/ignore.rego"], "from-github\""))
+}
+
+func TestGitHubSource_RuntimeConflict_NoCache_ReturnsError(t *testing.T) {
+	mock := newMockGitHub(t, "sha-conflict", map[string]string{
+		"policies/conflict.rego": `package conflict
+import rego.v1
+x := 1
+x := 2
+`,
+	})
+
+	src, err := policyadapter.NewGitHubSource(policyadapter.GitHubSourceOpts{
+		Owner:  "owner",
+		Repo:   "repo",
+		Paths:  []string{"policies"},
+		Client: mock.client(),
+		TTL:    time.Minute,
+	})
+	gt.NoError(t, err)
+
+	_, err = src.Snapshot(context.Background())
+	gt.Error(t, err)
+}
+
 func TestGitHubSource_ValidationFailure_NoCache_ReturnsError(t *testing.T) {
 	mock := newMockGitHub(t, "sha-broken", map[string]string{
 		"policies/ignore.rego": "not valid rego at all",

--- a/pkg/adapter/policy/github_source_test.go
+++ b/pkg/adapter/policy/github_source_test.go
@@ -1,0 +1,340 @@
+package policy_test
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/go-github/v74/github"
+	"github.com/m-mizutani/gt"
+	policyadapter "github.com/secmon-lab/warren/pkg/adapter/policy"
+)
+
+type mockGitHub struct {
+	t       *testing.T
+	server  *httptest.Server
+	mu      sync.Mutex
+	headSha string
+	// fileTree maps repo paths (e.g. "policies/x.rego") to rego contents.
+	fileTree     map[string]string
+	repoHits     int
+	branchHits   int
+	contentsHits int
+}
+
+func newMockGitHub(t *testing.T, headSha string, fileTree map[string]string) *mockGitHub {
+	m := &mockGitHub{
+		t:        t,
+		headSha:  headSha,
+		fileTree: fileTree,
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/owner/repo", m.handleRepo)
+	mux.HandleFunc("/repos/owner/repo/branches/main", m.handleBranch)
+	mux.HandleFunc("/repos/owner/repo/contents/", m.handleContents)
+	m.server = httptest.NewServer(mux)
+	t.Cleanup(m.server.Close)
+	return m
+}
+
+func (m *mockGitHub) update(headSha string, fileTree map[string]string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.headSha = headSha
+	m.fileTree = fileTree
+}
+
+func (m *mockGitHub) client() *github.Client {
+	u, err := url.Parse(m.server.URL + "/")
+	gt.NoError(m.t, err)
+	c := github.NewClient(nil)
+	c.BaseURL = u
+	c.UploadURL = u
+	return c
+}
+
+func (m *mockGitHub) handleRepo(w http.ResponseWriter, r *http.Request) {
+	m.mu.Lock()
+	m.repoHits++
+	m.mu.Unlock()
+	_, _ = fmt.Fprintln(w, `{"default_branch": "main"}`)
+}
+
+func (m *mockGitHub) handleBranch(w http.ResponseWriter, r *http.Request) {
+	m.mu.Lock()
+	m.branchHits++
+	sha := m.headSha
+	m.mu.Unlock()
+	_, _ = fmt.Fprintf(w, `{"name": "main", "commit": {"sha": %q}}`+"\n", sha)
+}
+
+func (m *mockGitHub) handleContents(w http.ResponseWriter, r *http.Request) {
+	m.mu.Lock()
+	m.contentsHits++
+	tree := m.fileTree
+	m.mu.Unlock()
+
+	repoPath := strings.TrimPrefix(r.URL.Path, "/repos/owner/repo/contents/")
+	repoPath = strings.TrimSuffix(repoPath, "/")
+
+	if content, ok := tree[repoPath]; ok {
+		encoded := base64.StdEncoding.EncodeToString([]byte(content))
+		_, _ = fmt.Fprintf(w,
+			`{"name": %q, "path": %q, "type": "file", "encoding": "base64", "content": %q}`+"\n",
+			path.Base(repoPath), repoPath, encoded)
+		return
+	}
+
+	prefix := repoPath
+	if prefix != "" {
+		prefix += "/"
+	}
+
+	var entries []string
+	for filePath := range tree {
+		if !strings.HasPrefix(filePath, prefix) {
+			continue
+		}
+		rest := filePath[len(prefix):]
+		if rest == "" || strings.Contains(rest, "/") {
+			continue
+		}
+		entries = append(entries,
+			fmt.Sprintf(`{"name": %q, "path": %q, "type": "file"}`, rest, filePath))
+	}
+	_, _ = fmt.Fprintf(w, "[%s]\n", strings.Join(entries, ","))
+}
+
+const ghTestRego = `package ingest.fromgh
+import rego.v1
+alerts contains a if {
+	input.kind == "test"
+	a := {"title": "from-github"}
+}
+`
+
+const ghTestRegoV2 = `package ingest.fromgh
+import rego.v1
+alerts contains a if {
+	input.kind == "test"
+	a := {"title": "from-github-v2"}
+}
+`
+
+func TestGitHubSource_InitialFetch(t *testing.T) {
+	mock := newMockGitHub(t, "sha-1", map[string]string{
+		"policies/ignore.rego": ghTestRego,
+	})
+
+	src, err := policyadapter.NewGitHubSource(policyadapter.GitHubSourceOpts{
+		Owner:  "owner",
+		Repo:   "repo",
+		Paths:  []string{"policies"},
+		Client: mock.client(),
+		TTL:    time.Minute,
+	})
+	gt.NoError(t, err)
+
+	snap, err := src.Snapshot(context.Background())
+	gt.NoError(t, err)
+	gt.NotNil(t, snap)
+	gt.M(t, snap.Files).Length(1)
+	gt.True(t, strings.Contains(snap.Version, "sha-1"))
+
+	gt.Equal(t, mock.repoHits, 1)
+	gt.Equal(t, mock.branchHits, 1)
+	gt.True(t, mock.contentsHits >= 1)
+}
+
+func TestGitHubSource_CachesWithinTTL(t *testing.T) {
+	mock := newMockGitHub(t, "sha-1", map[string]string{
+		"policies/ignore.rego": ghTestRego,
+	})
+
+	src, err := policyadapter.NewGitHubSource(policyadapter.GitHubSourceOpts{
+		Owner:  "owner",
+		Repo:   "repo",
+		Paths:  []string{"policies"},
+		Client: mock.client(),
+		TTL:    time.Hour,
+	})
+	gt.NoError(t, err)
+
+	_, err = src.Snapshot(context.Background())
+	gt.NoError(t, err)
+	repoBefore := mock.repoHits
+
+	_, err = src.Snapshot(context.Background())
+	gt.NoError(t, err)
+
+	gt.Equal(t, mock.repoHits, repoBefore) // no additional API calls within TTL
+}
+
+func TestGitHubSource_RefreshesAfterTTL_SameSha(t *testing.T) {
+	mock := newMockGitHub(t, "sha-1", map[string]string{
+		"policies/ignore.rego": ghTestRego,
+	})
+
+	src, err := policyadapter.NewGitHubSource(policyadapter.GitHubSourceOpts{
+		Owner:  "owner",
+		Repo:   "repo",
+		Paths:  []string{"policies"},
+		Client: mock.client(),
+		TTL:    time.Nanosecond, // immediately expire
+	})
+	gt.NoError(t, err)
+
+	_, err = src.Snapshot(context.Background())
+	gt.NoError(t, err)
+	contentsBefore := mock.contentsHits
+
+	// Wait a moment to ensure TTL window passes.
+	time.Sleep(2 * time.Millisecond)
+
+	snap, err := src.Snapshot(context.Background())
+	gt.NoError(t, err)
+	gt.True(t, strings.Contains(snap.Version, "sha-1"))
+
+	// repo + branch are re-fetched; contents must NOT be re-fetched (sha unchanged).
+	gt.Equal(t, mock.contentsHits, contentsBefore)
+}
+
+func TestGitHubSource_RefreshesAfterTTL_NewSha(t *testing.T) {
+	mock := newMockGitHub(t, "sha-1", map[string]string{
+		"policies/ignore.rego": ghTestRego,
+	})
+
+	src, err := policyadapter.NewGitHubSource(policyadapter.GitHubSourceOpts{
+		Owner:  "owner",
+		Repo:   "repo",
+		Paths:  []string{"policies"},
+		Client: mock.client(),
+		TTL:    time.Nanosecond,
+	})
+	gt.NoError(t, err)
+
+	first, err := src.Snapshot(context.Background())
+	gt.NoError(t, err)
+
+	mock.update("sha-2", map[string]string{
+		"policies/ignore.rego": ghTestRegoV2,
+	})
+
+	time.Sleep(2 * time.Millisecond)
+
+	second, err := src.Snapshot(context.Background())
+	gt.NoError(t, err)
+	gt.NotEqual(t, first.Version, second.Version)
+	gt.True(t, strings.Contains(second.Version, "sha-2"))
+	gt.True(t, strings.Contains(second.Files["github://owner/repo/policies/ignore.rego"], "from-github-v2"))
+}
+
+func TestGitHubSource_ValidationFailure_FallbackToCached(t *testing.T) {
+	mock := newMockGitHub(t, "sha-1", map[string]string{
+		"policies/ignore.rego": ghTestRego,
+	})
+
+	src, err := policyadapter.NewGitHubSource(policyadapter.GitHubSourceOpts{
+		Owner:  "owner",
+		Repo:   "repo",
+		Paths:  []string{"policies"},
+		Client: mock.client(),
+		TTL:    time.Nanosecond,
+	})
+	gt.NoError(t, err)
+
+	first, err := src.Snapshot(context.Background())
+	gt.NoError(t, err)
+
+	// New sha but bad rego.
+	mock.update("sha-broken", map[string]string{
+		"policies/ignore.rego": "this is not rego",
+	})
+
+	time.Sleep(2 * time.Millisecond)
+
+	snap, err := src.Snapshot(context.Background())
+	gt.NoError(t, err)
+	// Falls back to previous good snapshot.
+	gt.Equal(t, snap.Version, first.Version)
+	gt.True(t, strings.Contains(snap.Files["github://owner/repo/policies/ignore.rego"], "from-github\""))
+}
+
+func TestGitHubSource_ValidationFailure_NoCache_ReturnsError(t *testing.T) {
+	mock := newMockGitHub(t, "sha-broken", map[string]string{
+		"policies/ignore.rego": "not valid rego at all",
+	})
+
+	src, err := policyadapter.NewGitHubSource(policyadapter.GitHubSourceOpts{
+		Owner:  "owner",
+		Repo:   "repo",
+		Paths:  []string{"policies"},
+		Client: mock.client(),
+		TTL:    time.Minute,
+	})
+	gt.NoError(t, err)
+
+	_, err = src.Snapshot(context.Background())
+	gt.Error(t, err)
+}
+
+func TestGitHubSource_ConcurrentSnapshot_SerialisesFetch(t *testing.T) {
+	var inFlight atomic.Int32
+	var maxInFlight atomic.Int32
+
+	mock := newMockGitHub(t, "sha-1", map[string]string{
+		"policies/ignore.rego": ghTestRego,
+	})
+	// Wrap the original handler to detect concurrent fetches.
+	origHandler := mock.server.Config.Handler
+	mock.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		current := inFlight.Add(1)
+		for {
+			oldMax := maxInFlight.Load()
+			if current <= oldMax {
+				break
+			}
+			if maxInFlight.CompareAndSwap(oldMax, current) {
+				break
+			}
+		}
+		// Tiny delay to widen the race window.
+		time.Sleep(5 * time.Millisecond)
+		origHandler.ServeHTTP(w, r)
+		inFlight.Add(-1)
+	})
+
+	src, err := policyadapter.NewGitHubSource(policyadapter.GitHubSourceOpts{
+		Owner:  "owner",
+		Repo:   "repo",
+		Paths:  []string{"policies"},
+		Client: mock.client(),
+		TTL:    time.Minute,
+	})
+	gt.NoError(t, err)
+
+	const N = 10
+	var wg sync.WaitGroup
+	for range N {
+		wg.Go(func() {
+			_, err := src.Snapshot(context.Background())
+			gt.NoError(t, err)
+		})
+	}
+	wg.Wait()
+
+	// Even with concurrent callers, the lock ensures fetch happens once;
+	// after that, cache is hit. So total repo API hits should be 1.
+	gt.Equal(t, mock.repoHits, 1)
+	// And no concurrent fetches inside the lock window.
+	gt.True(t, maxInFlight.Load() <= 1)
+}

--- a/pkg/adapter/policy/loader.go
+++ b/pkg/adapter/policy/loader.go
@@ -1,0 +1,130 @@
+package policy
+
+import (
+	"context"
+	"strings"
+	"sync"
+
+	"github.com/m-mizutani/goerr/v2"
+	"github.com/m-mizutani/opaq"
+	"github.com/secmon-lab/warren/pkg/domain/interfaces"
+)
+
+var _ interfaces.PolicyClient = (*Loader)(nil)
+
+// Loader composes one or more Sources into a single PolicyClient. It rebuilds
+// the underlying *opaq.Client when the combined version of all sources
+// changes, otherwise it returns a cached client.
+//
+// Loader satisfies interfaces.PolicyClient.
+type Loader struct {
+	sources []Source
+
+	mu            sync.Mutex
+	cachedClient  *opaq.Client
+	cachedVersion string
+}
+
+// NewLoader creates a Loader from the given sources. At least one source
+// SHOULD be supplied, otherwise Query will return ErrNoPolicy.
+func NewLoader(sources ...Source) *Loader {
+	return &Loader{sources: sources}
+}
+
+// Query evaluates the given query string against the merged policy of all
+// sources.
+func (l *Loader) Query(ctx context.Context, query string, input, output any, opts ...opaq.QueryOption) error {
+	client, err := l.client(ctx)
+	if err != nil {
+		return err
+	}
+	return client.Query(ctx, query, input, output, opts...)
+}
+
+// Sources returns the merged file map (path -> rego content) backing the
+// current compiled client. Returns an empty map if no client has been built.
+func (l *Loader) Sources() map[string]string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.cachedClient == nil {
+		return map[string]string{}
+	}
+	return l.cachedClient.Sources()
+}
+
+// HasSources reports whether the Loader has any sources configured.
+func (l *Loader) HasSources() bool {
+	return len(l.sources) > 0
+}
+
+// Prime forces an initial build of the underlying opaq client. Calling Prime
+// at configure time ensures that Sources() returns the loaded policy contents
+// before the first Query, and surfaces any source-side errors (e.g. an
+// unreachable GitHub repository) at startup rather than on first evaluation.
+func (l *Loader) Prime(ctx context.Context) error {
+	_, err := l.client(ctx)
+	return err
+}
+
+func (l *Loader) client(ctx context.Context) (*opaq.Client, error) {
+	if len(l.sources) == 0 {
+		return nil, goerr.New("no policy sources configured")
+	}
+
+	snapshots := make([]*Snapshot, 0, len(l.sources))
+	for _, s := range l.sources {
+		snap, err := s.Snapshot(ctx)
+		if err != nil {
+			return nil, goerr.Wrap(err, "failed to obtain policy snapshot")
+		}
+		snapshots = append(snapshots, snap)
+	}
+
+	combined := combineVersions(snapshots)
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.cachedClient != nil && l.cachedVersion == combined {
+		return l.cachedClient, nil
+	}
+
+	merged, err := mergeFiles(snapshots)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := opaq.New(opaq.DataMap(merged))
+	if err != nil {
+		return nil, goerr.Wrap(err, "failed to compile merged policy")
+	}
+
+	l.cachedClient = client
+	l.cachedVersion = combined
+	return client, nil
+}
+
+func combineVersions(snapshots []*Snapshot) string {
+	var b strings.Builder
+	for i, s := range snapshots {
+		if i > 0 {
+			b.WriteByte('|')
+		}
+		b.WriteString(s.Version)
+	}
+	return b.String()
+}
+
+func mergeFiles(snapshots []*Snapshot) (map[string]string, error) {
+	out := map[string]string{}
+	for _, s := range snapshots {
+		for k, v := range s.Files {
+			if existing, ok := out[k]; ok && existing != v {
+				return nil, goerr.New("duplicate policy file key across sources",
+					goerr.V("key", k))
+			}
+			out[k] = v
+		}
+	}
+	return out, nil
+}

--- a/pkg/adapter/policy/loader_test.go
+++ b/pkg/adapter/policy/loader_test.go
@@ -1,0 +1,194 @@
+package policy_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/m-mizutani/gt"
+	"github.com/secmon-lab/warren/pkg/adapter/policy"
+)
+
+type fakeSource struct {
+	files   map[string]string
+	version string
+	calls   int
+	err     error
+}
+
+func (f *fakeSource) Snapshot(_ context.Context) (*policy.Snapshot, error) {
+	f.calls++
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &policy.Snapshot{Files: f.files, Version: f.version}, nil
+}
+
+type loaderTestOutput struct {
+	Alerts []map[string]any `json:"alerts"`
+}
+
+func TestLoader_Query_FromSingleSource(t *testing.T) {
+	src, err := policy.NewFileSource([]string{"testdata"})
+	gt.NoError(t, err)
+
+	loader := policy.NewLoader(src)
+	gt.True(t, loader.HasSources())
+
+	input := map[string]any{
+		"event_type": "test",
+		"title":      "hello",
+	}
+	var out loaderTestOutput
+	err = loader.Query(context.Background(), "data.ingest.test", input, &out)
+	gt.NoError(t, err)
+	gt.A(t, out.Alerts).Length(1)
+	gt.Equal(t, out.Alerts[0]["title"], "hello")
+}
+
+func TestLoader_Query_MergesMultipleSources(t *testing.T) {
+	a := &fakeSource{
+		files: map[string]string{
+			"a://ingest.rego": `package ingest.merged
+import rego.v1
+alerts contains alert if {
+	input.kind == "a"
+	alert := {"title": "from-a"}
+}
+`,
+		},
+		version: "v-a-1",
+	}
+	b := &fakeSource{
+		files: map[string]string{
+			"b://ingest.rego": `package ingest.merged
+import rego.v1
+alerts contains alert if {
+	input.kind == "b"
+	alert := {"title": "from-b"}
+}
+`,
+		},
+		version: "v-b-1",
+	}
+
+	loader := policy.NewLoader(a, b)
+
+	var out loaderTestOutput
+	err := loader.Query(context.Background(), "data.ingest.merged", map[string]any{"kind": "a"}, &out)
+	gt.NoError(t, err)
+	gt.A(t, out.Alerts).Length(1)
+	gt.Equal(t, out.Alerts[0]["title"], "from-a")
+
+	out = loaderTestOutput{}
+	err = loader.Query(context.Background(), "data.ingest.merged", map[string]any{"kind": "b"}, &out)
+	gt.NoError(t, err)
+	gt.A(t, out.Alerts).Length(1)
+	gt.Equal(t, out.Alerts[0]["title"], "from-b")
+}
+
+func TestLoader_CachesClient_WhenVersionUnchanged(t *testing.T) {
+	src := &fakeSource{
+		files: map[string]string{
+			"x://only.rego": `package ingest.cached
+import rego.v1
+alerts contains alert if {
+	input.kind == "x"
+	alert := {"title": "x"}
+}
+`,
+		},
+		version: "v1",
+	}
+	loader := policy.NewLoader(src)
+
+	var out loaderTestOutput
+	err := loader.Query(context.Background(), "data.ingest.cached", map[string]any{"kind": "x"}, &out)
+	gt.NoError(t, err)
+
+	// Capture sources map identity to verify reuse.
+	srcsBefore := loader.Sources()
+	gt.M(t, srcsBefore).Length(1)
+
+	// Second query with same version: snapshot is fetched again (Sources are
+	// pulled per Query) but the compiled client must be reused.
+	err = loader.Query(context.Background(), "data.ingest.cached", map[string]any{"kind": "x"}, &out)
+	gt.NoError(t, err)
+
+	srcsAfter := loader.Sources()
+	gt.Equal(t, srcsBefore["x://only.rego"], srcsAfter["x://only.rego"])
+	gt.Equal(t, src.calls, 2) // Snapshot called once per Query
+}
+
+func TestLoader_RebuildsClient_WhenVersionChanges(t *testing.T) {
+	src := &fakeSource{
+		files: map[string]string{
+			"x://only.rego": `package ingest.dynamic
+import rego.v1
+alerts contains alert if {
+	input.kind == "x"
+	alert := {"title": "v1-result"}
+}
+`,
+		},
+		version: "v1",
+	}
+	loader := policy.NewLoader(src)
+
+	var out loaderTestOutput
+	err := loader.Query(context.Background(), "data.ingest.dynamic", map[string]any{"kind": "x"}, &out)
+	gt.NoError(t, err)
+	gt.Equal(t, out.Alerts[0]["title"], "v1-result")
+
+	// Mutate the source: new content + new version.
+	src.files = map[string]string{
+		"x://only.rego": `package ingest.dynamic
+import rego.v1
+alerts contains alert if {
+	input.kind == "x"
+	alert := {"title": "v2-result"}
+}
+`,
+	}
+	src.version = "v2"
+
+	out = loaderTestOutput{}
+	err = loader.Query(context.Background(), "data.ingest.dynamic", map[string]any{"kind": "x"}, &out)
+	gt.NoError(t, err)
+	gt.Equal(t, out.Alerts[0]["title"], "v2-result")
+}
+
+func TestLoader_NoSources_ReturnsError(t *testing.T) {
+	loader := policy.NewLoader()
+	gt.False(t, loader.HasSources())
+
+	var out loaderTestOutput
+	err := loader.Query(context.Background(), "data.x", map[string]any{}, &out)
+	gt.Error(t, err)
+}
+
+func TestLoader_DuplicateKey_AcrossSources_ReturnsError(t *testing.T) {
+	a := &fakeSource{
+		files:   map[string]string{"shared.rego": "package a\nimport rego.v1\nx := 1\n"},
+		version: "a",
+	}
+	b := &fakeSource{
+		files:   map[string]string{"shared.rego": "package b\nimport rego.v1\ny := 2\n"},
+		version: "b",
+	}
+	loader := policy.NewLoader(a, b)
+
+	var out map[string]any
+	err := loader.Query(context.Background(), "data.a", map[string]any{}, &out)
+	gt.Error(t, err)
+}
+
+func TestLoader_Sources_EmptyBeforeFirstQuery(t *testing.T) {
+	src := &fakeSource{
+		files:   map[string]string{"x.rego": "package x\n"},
+		version: "v1",
+	}
+	loader := policy.NewLoader(src)
+
+	srcs := loader.Sources()
+	gt.M(t, srcs).Length(0)
+}

--- a/pkg/adapter/policy/source.go
+++ b/pkg/adapter/policy/source.go
@@ -1,0 +1,23 @@
+package policy
+
+import "context"
+
+// Snapshot is the content of a policy source at a specific point in time.
+// Version is an opaque identifier that changes when Files content changes,
+// so callers can decide whether downstream artifacts (compiled clients) need
+// to be rebuilt.
+type Snapshot struct {
+	// Files maps a unique key (e.g. file path or "github://...") to the Rego
+	// source. Keys MUST be unique across all sources composed in a single
+	// Loader.
+	Files map[string]string
+
+	// Version changes whenever Files changes.
+	Version string
+}
+
+// Source represents an origin of Rego policy contents.
+// Implementations are expected to be safe for concurrent use.
+type Source interface {
+	Snapshot(ctx context.Context) (*Snapshot, error)
+}

--- a/pkg/adapter/policy/testdata/sample.rego
+++ b/pkg/adapter/policy/testdata/sample.rego
@@ -1,0 +1,11 @@
+package ingest.test
+
+import rego.v1
+
+alerts contains alert if {
+	input.event_type == "test"
+	alert := {
+		"title":       input.title,
+		"description": "sample policy",
+	}
+}

--- a/pkg/cli/alert.go
+++ b/pkg/cli/alert.go
@@ -68,7 +68,7 @@ func runAlertPipeline(ctx context.Context, policyCfg *config.Policy, genaiCfg *c
 	schema := types.AlertSchema(schemaStr)
 
 	// Setup policy client
-	policyClient, err := policyCfg.Configure()
+	policyClient, err := policyCfg.Configure(ctx)
 	if err != nil {
 		return goerr.Wrap(err, "failed to create policy client")
 	}

--- a/pkg/cli/chat.go
+++ b/pkg/cli/chat.go
@@ -92,7 +92,7 @@ func cmdChat() *cli.Command {
 			}
 
 			// Configure policy client
-			policyClient, err := policyCfg.Configure()
+			policyClient, err := policyCfg.Configure(ctx)
 			if err != nil {
 				return goerr.Wrap(err, "failed to configure policy")
 			}

--- a/pkg/cli/config/policy.go
+++ b/pkg/cli/config/policy.go
@@ -94,7 +94,11 @@ func (x Policy) LogValue() slog.Value {
 // Configure builds a PolicyClient that aggregates configured policy sources.
 // File and GitHub sources may be combined; if neither is configured the
 // returned client behaves as a no-op (HasPolicies reports false beforehand).
-func (x *Policy) Configure() (interfaces.PolicyClient, error) {
+//
+// The context is used for the initial GitHub fetch (when a GitHub source is
+// configured), so callers should pass the CLI command's context to honour
+// cancellation and timeouts.
+func (x *Policy) Configure(ctx context.Context) (interfaces.PolicyClient, error) {
 	var sources []policyadapter.Source
 
 	if len(x.filePaths) > 0 {
@@ -134,7 +138,7 @@ func (x *Policy) Configure() (interfaces.PolicyClient, error) {
 	loader := policyadapter.NewLoader(sources...)
 
 	if loader.HasSources() {
-		if err := loader.Prime(context.Background()); err != nil {
+		if err := loader.Prime(ctx); err != nil {
 			return nil, goerr.Wrap(err, "failed to load initial policy")
 		}
 	}

--- a/pkg/cli/config/policy.go
+++ b/pkg/cli/config/policy.go
@@ -1,15 +1,26 @@
 package config
 
 import (
+	"context"
 	"log/slog"
+	"strings"
+	"time"
 
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/opaq"
+	policyadapter "github.com/secmon-lab/warren/pkg/adapter/policy"
+	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	"github.com/urfave/cli/v3"
 )
 
 type Policy struct {
 	filePaths []string
+
+	githubRepo           string
+	githubPaths          []string
+	githubAppID          int64
+	githubInstallationID int64
+	githubPrivateKey     string
+	githubCacheTTL       time.Duration
 }
 
 func (x *Policy) Flags() []cli.Flag {
@@ -22,24 +33,129 @@ func (x *Policy) Flags() []cli.Flag {
 			Category:    "Policy",
 			Sources:     cli.EnvVars("WARREN_POLICY"),
 		},
+		&cli.StringFlag{
+			Name:        "policy-github-repo",
+			Usage:       "GitHub repository hosting Rego policy files (format: owner/repo). Loaded from default branch HEAD.",
+			Destination: &x.githubRepo,
+			Category:    "Policy",
+			Sources:     cli.EnvVars("WARREN_POLICY_GITHUB_REPO"),
+		},
+		&cli.StringSliceFlag{
+			Name:        "policy-github-path",
+			Usage:       "Path within the GitHub repository to scan recursively for .rego files. May be specified multiple times. Defaults to repository root.",
+			Destination: &x.githubPaths,
+			Category:    "Policy",
+			Sources:     cli.EnvVars("WARREN_POLICY_GITHUB_PATH"),
+		},
+		&cli.Int64Flag{
+			Name:        "policy-github-app-id",
+			Usage:       "GitHub App ID for policy repository access (separate App recommended; see doc/operation/policy.md).",
+			Destination: &x.githubAppID,
+			Category:    "Policy",
+			Sources:     cli.EnvVars("WARREN_POLICY_GITHUB_APP_ID"),
+		},
+		&cli.Int64Flag{
+			Name:        "policy-github-app-installation-id",
+			Usage:       "GitHub App Installation ID for policy repository access.",
+			Destination: &x.githubInstallationID,
+			Category:    "Policy",
+			Sources:     cli.EnvVars("WARREN_POLICY_GITHUB_APP_INSTALLATION_ID"),
+		},
+		&cli.StringFlag{
+			Name:        "policy-github-app-private-key",
+			Usage:       "GitHub App private key (PEM format) for policy repository access.",
+			Destination: &x.githubPrivateKey,
+			Category:    "Policy",
+			Sources:     cli.EnvVars("WARREN_POLICY_GITHUB_APP_PRIVATE_KEY"),
+		},
+		&cli.DurationFlag{
+			Name:        "policy-github-cache-ttl",
+			Usage:       "TTL for cached GitHub policy contents. The HEAD commit sha is checked at most once per TTL; identical sha skips re-fetching.",
+			Value:       policyadapter.DefaultGitHubCacheTTL,
+			Destination: &x.githubCacheTTL,
+			Category:    "Policy",
+			Sources:     cli.EnvVars("WARREN_POLICY_GITHUB_CACHE_TTL"),
+		},
 	}
 }
 
 func (x Policy) LogValue() slog.Value {
 	return slog.GroupValue(
 		slog.Any("file_paths", x.filePaths),
+		slog.String("github_repo", x.githubRepo),
+		slog.Any("github_paths", x.githubPaths),
+		slog.Int64("github_app_id", x.githubAppID),
+		slog.Int64("github_app_installation_id", x.githubInstallationID),
+		slog.Bool("github_private_key_set", x.githubPrivateKey != ""),
+		slog.Duration("github_cache_ttl", x.githubCacheTTL),
 	)
 }
 
-func (x *Policy) Configure() (*opaq.Client, error) {
-	client, err := opaq.New(opaq.Files(x.filePaths...))
-	if err != nil {
-		return nil, goerr.Wrap(err, "failed to create opaq client", goerr.V("file_paths", x.filePaths))
+// Configure builds a PolicyClient that aggregates configured policy sources.
+// File and GitHub sources may be combined; if neither is configured the
+// returned client behaves as a no-op (HasPolicies reports false beforehand).
+func (x *Policy) Configure() (interfaces.PolicyClient, error) {
+	var sources []policyadapter.Source
+
+	if len(x.filePaths) > 0 {
+		fs, err := policyadapter.NewFileSource(x.filePaths)
+		if err != nil {
+			return nil, goerr.Wrap(err, "failed to create file policy source",
+				goerr.V("file_paths", x.filePaths))
+		}
+		sources = append(sources, fs)
 	}
 
-	return client, nil
+	if x.githubRepo != "" {
+		owner, repo, ok := splitGitHubRepo(x.githubRepo)
+		if !ok {
+			return nil, goerr.New("invalid policy-github-repo, expected owner/repo",
+				goerr.V("value", x.githubRepo))
+		}
+		if x.githubAppID == 0 || x.githubInstallationID == 0 || x.githubPrivateKey == "" {
+			return nil, goerr.New("policy-github-app-id, policy-github-app-installation-id, and policy-github-app-private-key are all required when policy-github-repo is set")
+		}
+		gs, err := policyadapter.NewGitHubSource(policyadapter.GitHubSourceOpts{
+			Owner:          owner,
+			Repo:           repo,
+			Paths:          x.githubPaths,
+			AppID:          x.githubAppID,
+			InstallationID: x.githubInstallationID,
+			PrivateKey:     []byte(x.githubPrivateKey),
+			TTL:            x.githubCacheTTL,
+		})
+		if err != nil {
+			return nil, goerr.Wrap(err, "failed to create GitHub policy source",
+				goerr.V("repo", x.githubRepo))
+		}
+		sources = append(sources, gs)
+	}
+
+	loader := policyadapter.NewLoader(sources...)
+
+	if loader.HasSources() {
+		if err := loader.Prime(context.Background()); err != nil {
+			return nil, goerr.Wrap(err, "failed to load initial policy")
+		}
+	}
+
+	return loader, nil
 }
 
+// HasPolicies reports whether at least one policy source is configured.
 func (x *Policy) HasPolicies() bool {
-	return len(x.filePaths) > 0
+	return len(x.filePaths) > 0 || x.githubRepo != ""
+}
+
+func splitGitHubRepo(s string) (owner, repo string, ok bool) {
+	idx := strings.Index(s, "/")
+	if idx <= 0 || idx == len(s)-1 {
+		return "", "", false
+	}
+	owner = s[:idx]
+	repo = s[idx+1:]
+	if strings.Contains(repo, "/") {
+		return "", "", false
+	}
+	return owner, repo, true
 }

--- a/pkg/cli/config/policy_test.go
+++ b/pkg/cli/config/policy_test.go
@@ -1,0 +1,171 @@
+package config_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/m-mizutani/gt"
+	"github.com/secmon-lab/warren/pkg/cli/config"
+	"github.com/urfave/cli/v3"
+)
+
+type policyTestOutput struct {
+	Alerts []map[string]any `json:"alerts"`
+}
+
+func TestPolicy_HasPolicies(t *testing.T) {
+	t.Run("empty when nothing configured", func(t *testing.T) {
+		cfg := &config.Policy{}
+		gt.False(t, cfg.HasPolicies())
+	})
+
+	t.Run("true when file path is configured", func(t *testing.T) {
+		cfg := &config.Policy{}
+		app := &cli.Command{
+			Flags: cfg.Flags(),
+			Action: func(_ context.Context, _ *cli.Command) error {
+				return nil
+			},
+		}
+		err := app.Run(context.Background(), []string{"test", "--policy", "testdata/policy"})
+		gt.NoError(t, err)
+		gt.True(t, cfg.HasPolicies())
+	})
+}
+
+func TestPolicy_Configure_FileSource(t *testing.T) {
+	t.Run("loads .rego file from directory and evaluates", func(t *testing.T) {
+		cfg := &config.Policy{}
+		app := &cli.Command{
+			Flags: cfg.Flags(),
+			Action: func(_ context.Context, _ *cli.Command) error {
+				return nil
+			},
+		}
+		err := app.Run(context.Background(), []string{"test", "--policy", "testdata/policy"})
+		gt.NoError(t, err)
+
+		client, err := cfg.Configure()
+		gt.NoError(t, err)
+		gt.NotNil(t, client)
+
+		input := map[string]any{
+			"event_type": "test",
+			"title":      "hello",
+		}
+		var out policyTestOutput
+		err = client.Query(context.Background(), "data.ingest.test", input, &out)
+		gt.NoError(t, err)
+		gt.A(t, out.Alerts).Length(1)
+		gt.Equal(t, out.Alerts[0]["title"], "hello")
+	})
+
+	t.Run("loads .rego file from single file path", func(t *testing.T) {
+		cfg := &config.Policy{}
+		app := &cli.Command{
+			Flags: cfg.Flags(),
+			Action: func(_ context.Context, _ *cli.Command) error {
+				return nil
+			},
+		}
+		err := app.Run(context.Background(), []string{"test", "--policy", "testdata/policy/sample.rego"})
+		gt.NoError(t, err)
+
+		client, err := cfg.Configure()
+		gt.NoError(t, err)
+		gt.NotNil(t, client)
+
+		input := map[string]any{
+			"event_type": "test",
+			"title":      "world",
+		}
+		var out policyTestOutput
+		err = client.Query(context.Background(), "data.ingest.test", input, &out)
+		gt.NoError(t, err)
+		gt.A(t, out.Alerts).Length(1)
+		gt.Equal(t, out.Alerts[0]["title"], "world")
+	})
+
+	t.Run("returns error for non-existent path", func(t *testing.T) {
+		cfg := &config.Policy{}
+		app := &cli.Command{
+			Flags: cfg.Flags(),
+			Action: func(_ context.Context, _ *cli.Command) error {
+				return nil
+			},
+		}
+		err := app.Run(context.Background(), []string{"test", "--policy", "testdata/does-not-exist"})
+		gt.NoError(t, err)
+
+		_, err = cfg.Configure()
+		gt.Error(t, err)
+	})
+}
+
+func TestPolicy_Configure_NoSources_ReturnsEmptyClient(t *testing.T) {
+	cfg := &config.Policy{}
+	gt.False(t, cfg.HasPolicies())
+
+	client, err := cfg.Configure()
+	gt.NoError(t, err)
+	gt.NotNil(t, client)
+	gt.M(t, client.Sources()).Length(0)
+}
+
+func TestPolicy_Configure_GitHubFlagValidation(t *testing.T) {
+	t.Run("invalid repo format rejected", func(t *testing.T) {
+		cfg := &config.Policy{}
+		app := &cli.Command{
+			Flags: cfg.Flags(),
+			Action: func(_ context.Context, _ *cli.Command) error {
+				return nil
+			},
+		}
+		err := app.Run(context.Background(), []string{
+			"test",
+			"--policy-github-repo", "no-slash",
+			"--policy-github-app-id", "1",
+			"--policy-github-app-installation-id", "2",
+			"--policy-github-app-private-key", "dummy",
+		})
+		gt.NoError(t, err)
+
+		_, err = cfg.Configure()
+		gt.Error(t, err)
+	})
+
+	t.Run("missing app credentials rejected", func(t *testing.T) {
+		cfg := &config.Policy{}
+		app := &cli.Command{
+			Flags: cfg.Flags(),
+			Action: func(_ context.Context, _ *cli.Command) error {
+				return nil
+			},
+		}
+		err := app.Run(context.Background(), []string{
+			"test",
+			"--policy-github-repo", "owner/repo",
+			// app credentials intentionally omitted
+		})
+		gt.NoError(t, err)
+
+		_, err = cfg.Configure()
+		gt.Error(t, err)
+	})
+
+	t.Run("HasPolicies true when github repo set", func(t *testing.T) {
+		cfg := &config.Policy{}
+		app := &cli.Command{
+			Flags: cfg.Flags(),
+			Action: func(_ context.Context, _ *cli.Command) error {
+				return nil
+			},
+		}
+		err := app.Run(context.Background(), []string{
+			"test",
+			"--policy-github-repo", "owner/repo",
+		})
+		gt.NoError(t, err)
+		gt.True(t, cfg.HasPolicies())
+	})
+}

--- a/pkg/cli/config/policy_test.go
+++ b/pkg/cli/config/policy_test.go
@@ -45,7 +45,7 @@ func TestPolicy_Configure_FileSource(t *testing.T) {
 		err := app.Run(context.Background(), []string{"test", "--policy", "testdata/policy"})
 		gt.NoError(t, err)
 
-		client, err := cfg.Configure()
+		client, err := cfg.Configure(context.Background())
 		gt.NoError(t, err)
 		gt.NotNil(t, client)
 
@@ -71,7 +71,7 @@ func TestPolicy_Configure_FileSource(t *testing.T) {
 		err := app.Run(context.Background(), []string{"test", "--policy", "testdata/policy/sample.rego"})
 		gt.NoError(t, err)
 
-		client, err := cfg.Configure()
+		client, err := cfg.Configure(context.Background())
 		gt.NoError(t, err)
 		gt.NotNil(t, client)
 
@@ -97,7 +97,7 @@ func TestPolicy_Configure_FileSource(t *testing.T) {
 		err := app.Run(context.Background(), []string{"test", "--policy", "testdata/does-not-exist"})
 		gt.NoError(t, err)
 
-		_, err = cfg.Configure()
+		_, err = cfg.Configure(context.Background())
 		gt.Error(t, err)
 	})
 }
@@ -106,7 +106,7 @@ func TestPolicy_Configure_NoSources_ReturnsEmptyClient(t *testing.T) {
 	cfg := &config.Policy{}
 	gt.False(t, cfg.HasPolicies())
 
-	client, err := cfg.Configure()
+	client, err := cfg.Configure(context.Background())
 	gt.NoError(t, err)
 	gt.NotNil(t, client)
 	gt.M(t, client.Sources()).Length(0)
@@ -130,7 +130,7 @@ func TestPolicy_Configure_GitHubFlagValidation(t *testing.T) {
 		})
 		gt.NoError(t, err)
 
-		_, err = cfg.Configure()
+		_, err = cfg.Configure(context.Background())
 		gt.Error(t, err)
 	})
 
@@ -149,7 +149,7 @@ func TestPolicy_Configure_GitHubFlagValidation(t *testing.T) {
 		})
 		gt.NoError(t, err)
 
-		_, err = cfg.Configure()
+		_, err = cfg.Configure(context.Background())
 		gt.Error(t, err)
 	})
 

--- a/pkg/cli/config/testdata/policy/sample.rego
+++ b/pkg/cli/config/testdata/policy/sample.rego
@@ -1,0 +1,11 @@
+package ingest.test
+
+import rego.v1
+
+alerts contains alert if {
+	input.event_type == "test"
+	alert := {
+		"title": input.title,
+		"description": "sample policy",
+	}
+}

--- a/pkg/cli/serve.go
+++ b/pkg/cli/serve.go
@@ -219,7 +219,7 @@ func cmdServe() *cli.Command {
 				"async", asyncCfg,
 			)
 
-			policyClient, err := policyCfg.Configure()
+			policyClient, err := policyCfg.Configure(ctx)
 			if err != nil {
 				return err
 			}

--- a/pkg/cli/test.go
+++ b/pkg/cli/test.go
@@ -31,7 +31,7 @@ func cmdTest() *cli.Command {
 			logger := logging.From(ctx)
 			logger.Info("Starting test", "testDataCfg", testDataCfg, "policyCfg", policyCfg)
 
-			policyClient, err := policyCfg.Configure()
+			policyClient, err := policyCfg.Configure(ctx)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Summary
- Adds `pkg/adapter/policy/` with a `Source` interface, `FileSource`, `GitHubSource`, and a `Loader` that satisfies `interfaces.PolicyClient`. The Loader composes multiple sources, rebuilds the underlying `*opaq.Client` only when the combined version changes, and serialises GitHub fetches with an in-process mutex.
- `GitHubSource` reads `.rego` files from a repository's default-branch HEAD via a dedicated GitHub App (App ID + Installation ID + private key). Results are cached for a TTL (default 1m); HEAD-sha equality skips re-fetching contents, and validation/fetch failures fall back to the previously cached snapshot.
- Wires the new source into `pkg/cli/config/policy.go` behind new flags (`--policy-github-repo`, `--policy-github-path`, `--policy-github-app-id`, `--policy-github-app-installation-id`, `--policy-github-app-private-key`, `--policy-github-cache-ttl`). The existing `--policy` file path flag is fully backwards compatible; `Configure()` now returns `interfaces.PolicyClient` (callsites adopt automatically via `:=`).
- Updates `doc/reference/configuration.md` and `doc/operation/policy.md` (new "Policy Sources" section, GitHub App setup, recommendation to use a dedicated App separate from the existing tool-use App).

This is the read-only Phase 1 from `tmp/rule-rearch.md` — no editing UI, webhook, PR creation, or pre-flight in this PR.

## Test plan
- [ ] `go test ./pkg/adapter/policy/...` passes (file source, GitHub source cache/sha/validation/concurrency, Loader merging and rebuild semantics)
- [ ] `go test ./pkg/cli/config/...` passes (existing behaviour preserved, new flag validation covered)
- [ ] `go test ./pkg/cli/... ./pkg/adapter/... ./pkg/usecase/...` passes — no regressions
- [ ] `go vet ./...` and `golangci-lint run ./pkg/adapter/policy/... ./pkg/cli/config/...` clean
- [ ] `gosec` clean for the new code (existing `pkg/cli/config/testdata.go` warning is unrelated)
- [ ] Manual smoke (optional): point a Warren instance at a private policy repo with a dedicated App and confirm the policy is loaded; bump a commit and confirm the next evaluation after TTL picks it up

🤖 Generated with [Claude Code](https://claude.com/claude-code)