### PR TITLE
feat(webfetch): per-tool LLM flags with HITL fallback when disabled

### DIFF
--- a/doc/reference/configuration.md
+++ b/doc/reference/configuration.md
@@ -171,6 +171,73 @@ Tools are automatically enabled when their API key is configured. Missing keys a
 |---|---|---|---|
 | `WARREN_SLACK_TOOL_USER_TOKEN` | `--slack-tool-user-token` | - | Slack User token (`xoxp-...`) with `search:read` scope |
 
+### WebFetch (Tool)
+
+`web_fetch` performs an HTTP/HTTPS GET, extracts the body, and optionally screens it through an LLM for Markdown reformatting + indirect-prompt-injection detection. Its LLM is configured independently from the warren-wide Gemini/Claude setup so the screening provider can differ from the main one (or be disabled).
+
+| Environment Variable | CLI Flag | Default | Description |
+|---|---|---|---|
+| `WARREN_WEBFETCH_LLM_PROVIDER` | `--webfetch-llm-provider` | _(empty)_ | LLM provider for analyze step: `gemini`, `claude`, or `openai`. Empty disables LLM analysis and forces HITL approval per call. |
+| `WARREN_WEBFETCH_LLM_MODEL` | `--webfetch-llm-model` | _(empty)_ | LLM model name. Required when `--webfetch-llm-provider` is set. Examples: `gemini-2.5-flash`, `claude-sonnet-4@20250514`, `gpt-4o`. |
+| `WARREN_WEBFETCH_LLM_ARGS` | `--webfetch-llm-args` | _(empty)_ | Provider-specific options as `key=value,key=value`. Recognized keys: `project_id`, `location` (Vertex routes), `temperature` (all providers). |
+| `WARREN_WEBFETCH_LLM_API_KEY` | `--webfetch-llm-api-key` | _(empty)_ | API key. Required for `openai` and for the `claude` Anthropic-direct route. Ignored for `gemini` and for the `claude` Vertex route. |
+
+**HITL behavior**: When `--webfetch-llm-provider` is empty, indirect-prompt-injection screening is not performed, so every `web_fetch` call is gated by a human-in-the-loop (HITL) approval dialog. When the provider is set, the LLM performs the screening and the dialog is suppressed to reduce friction.
+
+**Startup ping**: With a provider configured, warren issues a minimal `max_tokens=1` generation request at start-up so misconfigurations (bad API key, wrong model name, wrong project/location) fail fast instead of at first use.
+
+**Claude routing**: The `claude` provider auto-selects between the Vertex AI route and the direct Anthropic API route based on the supplied args/api-key:
+
+- Set `project_id` and `location` in `--webfetch-llm-args`, no api-key → Vertex AI route
+- Set `--webfetch-llm-api-key`, no `project_id`/`location` → Anthropic direct route
+- Set both → start-up error (ambiguous)
+- Set neither → start-up error (route unspecified)
+
+#### Examples
+
+Gemini on Vertex AI:
+
+```bash
+warren chat \
+  --webfetch-llm-provider gemini \
+  --webfetch-llm-model    gemini-2.5-flash \
+  --webfetch-llm-args     "project_id=my-proj,location=us-central1"
+```
+
+Claude on Vertex AI (project/location present → Vertex route):
+
+```bash
+warren chat \
+  --webfetch-llm-provider claude \
+  --webfetch-llm-model    "claude-sonnet-4@20250514" \
+  --webfetch-llm-args     "project_id=my-proj,location=us-east5"
+```
+
+Claude via Anthropic direct API (api-key present → direct route):
+
+```bash
+warren chat \
+  --webfetch-llm-provider claude \
+  --webfetch-llm-model    claude-sonnet-4-5-20250929 \
+  --webfetch-llm-api-key  "$ANTHROPIC_API_KEY"
+```
+
+OpenAI:
+
+```bash
+warren chat \
+  --webfetch-llm-provider openai \
+  --webfetch-llm-model    gpt-4o \
+  --webfetch-llm-args     "temperature=0.2" \
+  --webfetch-llm-api-key  "$OPENAI_API_KEY"
+```
+
+LLM analysis disabled (HITL approval gates every call):
+
+```bash
+warren chat   # no --webfetch-llm-* flags
+```
+
 ## Sub-Agent Configuration
 
 ### BigQuery Agent

--- a/go.mod
+++ b/go.mod
@@ -126,6 +126,7 @@ require (
 	github.com/open-policy-agent/opa v1.15.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.26 // indirect
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
+	github.com/pkoukk/tiktoken-go v0.1.8 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
@@ -133,6 +134,7 @@ require (
 	github.com/radovskyb/watcher v1.0.7 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9 // indirect
 	github.com/sajari/fuzzy v1.0.0 // indirect
+	github.com/sashabaranov/go-openai v1.41.2 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect
 	github.com/sergi/go-diff v1.4.0 // indirect

--- a/pkg/cli/export_test.go
+++ b/pkg/cli/export_test.go
@@ -1,11 +1,19 @@
 package cli
 
 import (
+	"context"
 	"io"
 
 	"github.com/m-mizutani/fireconf"
+	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	"github.com/secmon-lab/warren/pkg/usecase"
 )
+
+// HITLToolNamesForTest exposes toolList.HITLToolNames for testing.
+func HITLToolNamesForTest(ctx context.Context, tools ...interfaces.Tool) ([]string, error) {
+	tl := toolList(tools)
+	return tl.HITLToolNames(ctx)
+}
 
 // ReadAlertDataForTest exposes readAlertData for testing
 func ReadAlertDataForTest(inputFile string) (any, error) {

--- a/pkg/cli/serve.go
+++ b/pkg/cli/serve.go
@@ -440,8 +440,18 @@ func cmdServe() *cli.Command {
 					return goerr.New("unknown budget strategy", goerr.V("strategy", budgetStrategy))
 				}
 
-				// Configure HITL tools that require human approval
-				asterOpts = append(asterOpts, aster.WithHITLTools([]string{"web_fetch"}))
+				// Configure HITL tools that require human approval. The list is
+				// built dynamically from each tool's RequiresHITL() state so that
+				// e.g. webfetch only requires HITL when its own LLM screening is
+				// disabled (see pkg/tool/webfetch/action.go RequiresHITL).
+				hitlNames, err := tools.HITLToolNames(ctx)
+				if err != nil {
+					return goerr.Wrap(err, "failed to compute HITL tool list")
+				}
+				if len(hitlNames) > 0 {
+					asterOpts = append(asterOpts, aster.WithHITLTools(hitlNames))
+				}
+				logging.From(ctx).Info("HITL tools configured", "names", hitlNames)
 
 				asterStrategy := aster.New(repo, llmClient, asterOpts...)
 				commonOpts := buildChatUseCaseOpts(repo, policyClient, slackSvc, noAuthorization, webUICfg.GetFrontendURL())
@@ -492,7 +502,14 @@ func cmdServe() *cli.Command {
 					return goerr.New("unknown budget strategy", goerr.V("strategy", budgetStrategy))
 				}
 
-				bluebellOpts = append(bluebellOpts, bluebell.WithHITLTools([]string{"web_fetch"}))
+				hitlNames, err := tools.HITLToolNames(ctx)
+				if err != nil {
+					return goerr.Wrap(err, "failed to compute HITL tool list")
+				}
+				if len(hitlNames) > 0 {
+					bluebellOpts = append(bluebellOpts, bluebell.WithHITLTools(hitlNames))
+				}
+				logging.From(ctx).Info("HITL tools configured", "names", hitlNames)
 
 				bluebellStrategy, err := bluebell.New(repo, llmClient, bluebellOpts...)
 				if err != nil {

--- a/pkg/cli/utils.go
+++ b/pkg/cli/utils.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 
+	"github.com/m-mizutani/goerr/v2"
 	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	"github.com/secmon-lab/warren/pkg/tool/abusech"
@@ -77,14 +78,42 @@ func (x toolList) InjectSlackClient(slackClient interfaces.SlackClient) {
 	}
 }
 
-// InjectLLMClient injects the LLM client into tools that support it (e.g. webfetch
-// uses the LLM both for body cleanup and indirect-prompt-injection detection).
+// InjectLLMClient injects the warren-wide LLM client into tools that support
+// it. Tools that own their own LLM lifecycle (e.g. webfetch, which builds and
+// pings its client from its own --webfetch-llm-* flags) do not implement the
+// SetLLMClient setter and are skipped by the duck-typed loop below.
 func (x toolList) InjectLLMClient(llmClient gollem.LLMClient) {
 	for _, tool := range x {
 		if setter, ok := tool.(interface{ SetLLMClient(gollem.LLMClient) }); ok {
 			setter.SetLLMClient(llmClient)
 		}
 	}
+}
+
+// HITLToolNames returns the names of tool functions (Specs entries) that
+// require human-in-the-loop approval, based on each tool's RequiresHITL()
+// state. Tools that do not implement the HITL-aware interface are excluded.
+//
+// Configure() MUST have been called on the tool list before this — for
+// flag-driven gating like webfetch's --webfetch-llm-provider, the dynamic
+// state needs to be resolved first.
+func (x toolList) HITLToolNames(ctx context.Context) ([]string, error) {
+	var names []string
+	for _, tool := range x {
+		aware, ok := tool.(interface{ RequiresHITL() bool })
+		if !ok || !aware.RequiresHITL() {
+			continue
+		}
+		specs, err := tool.Specs(ctx)
+		if err != nil {
+			return nil, goerr.Wrap(err, "failed to read tool specs for HITL list",
+				goerr.V("tool", tool.ID()))
+		}
+		for _, s := range specs {
+			names = append(names, s.Name)
+		}
+	}
+	return names, nil
 }
 
 func (x toolList) Flags() []cli.Flag {

--- a/pkg/cli/utils_test.go
+++ b/pkg/cli/utils_test.go
@@ -1,0 +1,116 @@
+package cli_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/m-mizutani/gollem"
+	"github.com/m-mizutani/gt"
+	"github.com/secmon-lab/warren/pkg/cli"
+	"github.com/secmon-lab/warren/pkg/domain/interfaces"
+	cliv3 "github.com/urfave/cli/v3"
+)
+
+// fakeHITLTool is a minimal interfaces.Tool that also implements the
+// RequiresHITL() interface used by the HITLToolNames helper.
+type fakeHITLTool struct {
+	id    string
+	specs []gollem.ToolSpec
+	hitl  bool
+}
+
+func (f *fakeHITLTool) ID() string          { return f.id }
+func (f *fakeHITLTool) Description() string { return f.id }
+func (f *fakeHITLTool) Specs(_ context.Context) ([]gollem.ToolSpec, error) {
+	return f.specs, nil
+}
+func (f *fakeHITLTool) Run(_ context.Context, _ string, _ map[string]any) (map[string]any, error) {
+	return nil, nil
+}
+func (f *fakeHITLTool) Prompt(_ context.Context) (string, error) { return "", nil }
+func (f *fakeHITLTool) Flags() []cliv3.Flag                      { return nil }
+func (f *fakeHITLTool) Configure(_ context.Context) error        { return nil }
+func (f *fakeHITLTool) LogValue() slog.Value                     { return slog.GroupValue() }
+func (f *fakeHITLTool) Helper() *cliv3.Command                   { return nil }
+func (f *fakeHITLTool) RequiresHITL() bool                       { return f.hitl }
+
+var _ interfaces.Tool = &fakeHITLTool{}
+
+// fakeNoHITLTool is a minimal interfaces.Tool that does NOT implement
+// RequiresHITL(). The HITLToolNames helper must silently skip such tools.
+type fakeNoHITLTool struct {
+	id    string
+	specs []gollem.ToolSpec
+}
+
+func (f *fakeNoHITLTool) ID() string          { return f.id }
+func (f *fakeNoHITLTool) Description() string { return f.id }
+func (f *fakeNoHITLTool) Specs(_ context.Context) ([]gollem.ToolSpec, error) {
+	return f.specs, nil
+}
+func (f *fakeNoHITLTool) Run(_ context.Context, _ string, _ map[string]any) (map[string]any, error) {
+	return nil, nil
+}
+func (f *fakeNoHITLTool) Prompt(_ context.Context) (string, error) { return "", nil }
+func (f *fakeNoHITLTool) Flags() []cliv3.Flag                      { return nil }
+func (f *fakeNoHITLTool) Configure(_ context.Context) error        { return nil }
+func (f *fakeNoHITLTool) LogValue() slog.Value                     { return slog.GroupValue() }
+func (f *fakeNoHITLTool) Helper() *cliv3.Command                   { return nil }
+
+var _ interfaces.Tool = &fakeNoHITLTool{}
+
+func TestHITLToolNames_IncludesToolWhenRequiresHITLTrue(t *testing.T) {
+	hitlTool := &fakeHITLTool{
+		id:    "fetcher",
+		specs: []gollem.ToolSpec{{Name: "web_fetch"}},
+		hitl:  true,
+	}
+	plainTool := &fakeHITLTool{
+		id:    "lookup",
+		specs: []gollem.ToolSpec{{Name: "lookup_thing"}},
+		hitl:  false,
+	}
+
+	names, err := cli.HITLToolNamesForTest(t.Context(), hitlTool, plainTool)
+	gt.NoError(t, err).Required()
+	gt.Array(t, names).Length(1)
+	gt.Value(t, names[0]).Equal("web_fetch")
+}
+
+func TestHITLToolNames_ExcludesToolWhenRequiresHITLFalse(t *testing.T) {
+	tool := &fakeHITLTool{
+		id:    "fetcher",
+		specs: []gollem.ToolSpec{{Name: "web_fetch"}},
+		hitl:  false,
+	}
+	names, err := cli.HITLToolNamesForTest(t.Context(), tool)
+	gt.NoError(t, err).Required()
+	gt.Array(t, names).Length(0)
+}
+
+func TestHITLToolNames_ToolWithoutInterfaceIsSkipped(t *testing.T) {
+	tool := &fakeNoHITLTool{
+		id:    "lookup",
+		specs: []gollem.ToolSpec{{Name: "lookup_thing"}},
+	}
+	names, err := cli.HITLToolNamesForTest(t.Context(), tool)
+	gt.NoError(t, err).Required()
+	gt.Array(t, names).Length(0)
+}
+
+func TestHITLToolNames_AggregatesMultipleSpecs(t *testing.T) {
+	tool := &fakeHITLTool{
+		id: "multi",
+		specs: []gollem.ToolSpec{
+			{Name: "fn_one"},
+			{Name: "fn_two"},
+		},
+		hitl: true,
+	}
+	names, err := cli.HITLToolNamesForTest(t.Context(), tool)
+	gt.NoError(t, err).Required()
+	gt.Array(t, names).Length(2)
+	gt.Value(t, names[0]).Equal("fn_one")
+	gt.Value(t, names[1]).Equal("fn_two")
+}

--- a/pkg/tool/webfetch/README.md
+++ b/pkg/tool/webfetch/README.md
@@ -1,6 +1,6 @@
 # WebFetch
 
-Fetch a web page and return its body as Markdown after extracting the main content and screening for indirect prompt injection.
+Fetch a web page and return its body. When an LLM is configured, the body is reformatted as Markdown and screened for indirect prompt injection; otherwise the extracted text is returned verbatim and every call is gated by a HITL approval dialog.
 
 ## Overview
 
@@ -8,29 +8,102 @@ Fetch a web page and return its body as Markdown after extracting the main conte
 
 1. **Fetch** the URL over HTTP/HTTPS (30 s timeout, fixed User-Agent). No response-size cap is applied; the request timeout and the context deadline bound the operation.
 2. **Extract** the textual body. HTML pages are parsed with `golang.org/x/net/html`, stripped of `<script>` / `<style>` / `<svg>` / hidden nodes / comments, and rendered as semi-structured plain text that preserves headings, lists, code blocks, and tables. Text-based responses (`text/plain`, `application/json`, etc.) pass through verbatim. Binary content types are rejected.
-3. **Analyze** the body through an LLM call that (a) reformats the content into clean Markdown and (b) checks for indirect prompt injection (role-change attempts, system-prompt overrides, control-token-style strings, etc.). The body is delivered as a `user`-role message; all instructions live in the `system` prompt, which declares the user message untrusted.
+3. **Analyze** (optional). When an LLM is configured via `--webfetch-llm-*` flags, the body goes through an LLM call that (a) reformats the content into clean Markdown and (b) checks for indirect prompt injection (role-change attempts, system-prompt overrides, control-token-style strings, etc.). The body is delivered as a `user`-role message; all instructions live in the `system` prompt, which declares the user message untrusted. When no LLM is configured, this stage is skipped — the extracted text is returned verbatim with `"llm_analysis": "disabled"` in the response.
 
-If the LLM judges the body malicious, the tool returns an error tagged `validation` with the LLM-supplied reason. Otherwise, it returns the formatted Markdown.
+If the LLM judges the body malicious, the tool returns an error tagged `validation` with the LLM-supplied reason. Otherwise, it returns the formatted Markdown (or the raw extracted text in LLM-disabled mode).
 
 ## Configuration
 
-No environment variables or CLI flags. The tool is always available when the LLM client is configured.
+The webfetch tool owns its LLM configuration independently from warren's main `--gemini-*` / `--claude-*` flags, so the screening provider can differ from (or be absent compared to) the main warren LLM.
+
+| Environment Variable | CLI Flag | Default | Description |
+|---|---|---|---|
+| `WARREN_WEBFETCH_LLM_PROVIDER` | `--webfetch-llm-provider` | _(empty)_ | LLM provider for analyze step: `gemini`, `claude`, or `openai`. Empty disables LLM analysis. |
+| `WARREN_WEBFETCH_LLM_MODEL` | `--webfetch-llm-model` | _(empty)_ | LLM model name. Required when provider is set. |
+| `WARREN_WEBFETCH_LLM_ARGS` | `--webfetch-llm-args` | _(empty)_ | Provider-specific options as `key=value,key=value`. Recognized: `project_id`, `location`, `temperature`. |
+| `WARREN_WEBFETCH_LLM_API_KEY` | `--webfetch-llm-api-key` | _(empty)_ | API key. Required for `openai` and `claude` Anthropic-direct. Ignored for `gemini` and `claude` Vertex. |
+
+### Claude routing
+
+The `claude` provider auto-selects between Vertex AI and the direct Anthropic API based on the supplied inputs:
+
+| Inputs | Route |
+|---|---|
+| `project_id` + `location` in `--webfetch-llm-args`, no api-key | Vertex AI |
+| `--webfetch-llm-api-key` set, no `project_id` / `location` | Anthropic direct |
+| Both Vertex args and api-key | _Start-up error (ambiguous)_ |
+| Neither | _Start-up error (route unspecified)_ |
+
+### Examples
+
+Gemini on Vertex AI:
+
+```bash
+--webfetch-llm-provider gemini
+--webfetch-llm-model    gemini-2.5-flash
+--webfetch-llm-args     "project_id=my-proj,location=us-central1"
+```
+
+Claude on Vertex AI:
+
+```bash
+--webfetch-llm-provider claude
+--webfetch-llm-model    "claude-sonnet-4@20250514"
+--webfetch-llm-args     "project_id=my-proj,location=us-east5"
+```
+
+Claude via Anthropic direct API:
+
+```bash
+--webfetch-llm-provider claude
+--webfetch-llm-model    claude-sonnet-4-5-20250929
+--webfetch-llm-api-key  "$ANTHROPIC_API_KEY"
+```
+
+OpenAI:
+
+```bash
+--webfetch-llm-provider openai
+--webfetch-llm-model    gpt-4o
+--webfetch-llm-args     "temperature=0.2"
+--webfetch-llm-api-key  "$OPENAI_API_KEY"
+```
+
+LLM disabled (no flags): every call is HITL-gated, response includes `"llm_analysis": "disabled"`.
+
+### Start-up ping
+
+Whenever `--webfetch-llm-provider` is set, warren issues a minimal `max_tokens=1` generation request at start-up so misconfigurations surface immediately instead of at first use. The ping cost is negligible (single-digit tokens) but it catches:
+
+- API key typos or expired keys
+- Model name typos
+- Vertex AI `project_id` / `location` mistakes or permission gaps
+- Network reachability issues
+
+The ping covers the analyze provider only; the warren-wide LLM (Gemini/Claude) is independent.
 
 ## Available Functions
 
 | Function | Description |
 |---|---|
-| `web_fetch` | Fetch the given URL and return Markdown extracted from its body. Argument: `url` (http/https only). |
+| `web_fetch` | Fetch the given URL and return Markdown (when LLM is configured) or raw extracted text (when not). Argument: `url` (http/https only). |
+
+## HITL (Human-in-the-Loop)
+
+`web_fetch` is conditionally registered as a HITL-gated tool. The decision is driven by `--webfetch-llm-provider`:
+
+- **`--webfetch-llm-provider` empty (LLM disabled)** → HITL approval dialog is shown for every `web_fetch` call. The human is the only safety net since indirect-prompt-injection screening does not run in this mode.
+- **`--webfetch-llm-provider` set (LLM enabled)** → HITL approval is suppressed. The LLM screening handles IPI detection.
+
+The wiring lives in `pkg/cli/serve.go`: it consults each tool's `RequiresHITL()` method (implemented by webfetch) and passes the resulting names to `aster.WithHITLTools` / `bluebell.WithHITLTools`.
 
 ## Setup
 
-No external API keys. The tool relies on the warren-wide LLM client (Gemini via `gollem`) which is injected at start-up.
-
-`web_fetch` is registered as a HITL (Human-in-the-Loop) tool: every invocation requires user approval before the request is made. This is configured in `pkg/cli/serve.go` via `aster.WithHITLTools` / `bluebell.WithHITLTools`.
+No external API keys are required when running in LLM-disabled mode (every call goes through HITL approval). When LLM analysis is enabled, the API key requirement depends on the provider — see the routing table above.
 
 ## Limitations
 
-- **No URL allow/deny filtering.** Access control is delegated to HITL approval. Any reachable HTTP/HTTPS URL is fetchable once approved.
+- **No URL allow/deny filtering.** Access control is delegated to the HITL approval dialog (LLM-disabled mode) and / or the LLM IPI screen (LLM-enabled mode).
 - **No SSRF protection** beyond scheme restriction. Internal IPs and metadata endpoints are not blocked at this layer.
 - **UTF-8 assumed.** The `Content-Type` charset is not honored; non-UTF-8 pages may produce garbled output.
 - **No summarization.** The LLM only reformats — it does not condense the body. Large pages (after extraction) are passed to the upstream agent as-is.
@@ -40,6 +113,7 @@ No external API keys. The tool relies on the warren-wide LLM client (Gemini via 
 
 The package tests cover both pure logic and external integrations:
 
+- **Unit tests for the LLM-flag parser / builder / ping helper** (`llmflag_test.go`) — always run; uses gollem mocks for the ping path.
 - **Unit / extract / analyze mock tests** — always run as part of `go test ./pkg/tool/webfetch/...`.
 - **`TestExtract_Live_RealWebsites`** — always runs. Fetches a small set of real security-info sites (NVD, MITRE ATT&CK, Wikipedia, GitHub Security Advisory, OWASP) and asserts that extraction produces non-empty text containing expected keywords and no surviving `<script>` / `<style>` markup. Per-case transient failures (network errors, anti-bot 4xx/5xx) are converted into per-case skips rather than hard failures.
 - **`TestAnalyze_Live_*`** — runs when both `TEST_GEMINI_PROJECT_ID` and `TEST_GEMINI_LOCATION` are set. Verifies indirect-prompt-injection detection against a real Gemini endpoint.

--- a/pkg/tool/webfetch/action.go
+++ b/pkg/tool/webfetch/action.go
@@ -12,6 +12,7 @@ import (
 	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	"github.com/secmon-lab/warren/pkg/utils/errutil"
+	"github.com/secmon-lab/warren/pkg/utils/logging"
 	"github.com/secmon-lab/warren/pkg/utils/safe"
 	"github.com/urfave/cli/v3"
 )
@@ -19,26 +20,32 @@ import (
 const (
 	defaultTimeout = 30 * time.Second
 	userAgent      = "warren-webfetch/1.0 (+https://github.com/secmon-lab/warren)"
+
+	flagCategory = "WebFetch"
 )
 
 // Action implements the interfaces.Tool interface for fetching web content
 // and sanitizing it through an LLM-based pipeline.
+//
+// LLM analysis is configured via the --webfetch-llm-* flags. If
+// --webfetch-llm-provider is empty, the analyze step is disabled and the
+// extracted text is returned verbatim. In that mode, HITL approval is
+// required for every web_fetch invocation (RequiresHITL returns true) so a
+// human gates each request.
 type Action struct {
-	client    *http.Client
+	client *http.Client
+
+	// Flag-bound fields populated via cli.StringFlag Destination.
+	llmProvider string
+	llmModel    string
+	llmArgs     string
+	llmAPIKey   string
+
+	// Resolved at Configure(). Nil when LLM analysis is disabled.
 	llmClient gollem.LLMClient
 }
 
 var _ interfaces.Tool = &Action{}
-
-// SetLLMClient injects the LLM client used by the analyze step.
-// It is invoked from pkg/cli during start-up so that all entrypoints that
-// own an LLM client share the same instance with the webfetch tool.
-//
-// Mutable injection is intentionally retained for now; migrating the whole
-// tool family to an immutable construction model is tracked in #214.
-func (x *Action) SetLLMClient(client gollem.LLMClient) {
-	x.llmClient = client
-}
 
 func (x *Action) Helper() *cli.Command {
 	return nil
@@ -49,18 +56,47 @@ func (x *Action) ID() string {
 }
 
 func (x *Action) Description() string {
-	return "Web page content fetching with LLM-based Markdown extraction and indirect prompt injection detection"
+	return "Web page content fetching with optional LLM-based Markdown extraction and indirect prompt injection detection"
 }
 
 func (x *Action) Flags() []cli.Flag {
-	return []cli.Flag{}
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:        "webfetch-llm-provider",
+			Usage:       "LLM provider for webfetch analyze step (gemini, claude, openai). Empty disables LLM analysis and forces HITL approval per call.",
+			Sources:     cli.EnvVars("WARREN_WEBFETCH_LLM_PROVIDER"),
+			Destination: &x.llmProvider,
+			Category:    flagCategory,
+		},
+		&cli.StringFlag{
+			Name:        "webfetch-llm-model",
+			Usage:       "LLM model name (e.g. gemini-2.5-flash, claude-sonnet-4@20250514, gpt-4o). Required when --webfetch-llm-provider is set.",
+			Sources:     cli.EnvVars("WARREN_WEBFETCH_LLM_MODEL"),
+			Destination: &x.llmModel,
+			Category:    flagCategory,
+		},
+		&cli.StringFlag{
+			Name:        "webfetch-llm-args",
+			Usage:       "Provider-specific options as comma-separated key=value (e.g. 'project_id=my-proj,location=us-central1,temperature=0.2').",
+			Sources:     cli.EnvVars("WARREN_WEBFETCH_LLM_ARGS"),
+			Destination: &x.llmArgs,
+			Category:    flagCategory,
+		},
+		&cli.StringFlag{
+			Name:        "webfetch-llm-api-key",
+			Usage:       "API key for the LLM provider. Required for openai and for claude direct (Anthropic) route. Ignored for gemini and for claude Vertex route.",
+			Sources:     cli.EnvVars("WARREN_WEBFETCH_LLM_API_KEY"),
+			Destination: &x.llmAPIKey,
+			Category:    flagCategory,
+		},
+	}
 }
 
 func (x *Action) Specs(_ context.Context) ([]gollem.ToolSpec, error) {
 	return []gollem.ToolSpec{
 		{
 			Name:        "web_fetch",
-			Description: "Fetch a web page and return its body as Markdown after extracting the main content and running an indirect-prompt-injection check.",
+			Description: "Fetch a web page and return its body. When LLM analysis is enabled, the body is reformatted as Markdown and screened for indirect prompt injection; otherwise the extracted text is returned verbatim (HITL approval gates each call in that mode).",
 			Parameters: map[string]*gollem.Parameter{
 				"url": {
 					Type:        gollem.TypeString,
@@ -105,11 +141,6 @@ func (x *Action) Run(ctx context.Context, name string, args map[string]any) (map
 			goerr.V("url", rawURL))
 	}
 
-	if x.llmClient == nil {
-		return nil, goerr.New("LLM client is not injected for webfetch",
-			goerr.T(errutil.TagInternal))
-	}
-
 	status, contentType, body, err := x.fetch(ctx, rawURL)
 	if err != nil {
 		return nil, err
@@ -119,6 +150,18 @@ func (x *Action) Run(ctx context.Context, name string, args map[string]any) (map
 	if err != nil {
 		return nil, goerr.Wrap(err, "failed to extract body",
 			goerr.V("url", rawURL))
+	}
+
+	if x.llmClient == nil {
+		// LLM analysis disabled: return the extracted text verbatim. HITL
+		// approval (wired in pkg/cli/serve.go) is the safety net in this mode.
+		return map[string]any{
+			"result":       text,
+			"url":          rawURL,
+			"status":       status,
+			"content_type": contentType,
+			"llm_analysis": "disabled",
+		}, nil
 	}
 
 	result, err := analyze(ctx, x.llmClient, text)
@@ -173,15 +216,63 @@ func (x *Action) fetch(ctx context.Context, rawURL string) (int, string, []byte,
 	return resp.StatusCode, resp.Header.Get("Content-Type"), body, nil
 }
 
-func (x *Action) Configure(_ context.Context) error {
+func (x *Action) Configure(ctx context.Context) error {
 	if x.client == nil {
 		x.client = &http.Client{Timeout: defaultTimeout}
 	}
+
+	if x.llmProvider == "" {
+		logging.From(ctx).Info("webfetch LLM analysis disabled; HITL approval is required for every web_fetch call")
+		return nil
+	}
+
+	parsedArgs, err := parseLLMArgs(x.llmArgs)
+	if err != nil {
+		return goerr.Wrap(err, "failed to parse --webfetch-llm-args",
+			goerr.V("provider", x.llmProvider))
+	}
+
+	client, err := buildLLMClient(ctx, x.llmProvider, x.llmModel, parsedArgs, x.llmAPIKey)
+	if err != nil {
+		return goerr.Wrap(err, "failed to build webfetch LLM client",
+			goerr.V("provider", x.llmProvider),
+			goerr.V("model", x.llmModel))
+	}
+
+	if err := pingLLMClient(ctx, client); err != nil {
+		return goerr.Wrap(err, "webfetch LLM ping failed",
+			goerr.V("provider", x.llmProvider),
+			goerr.V("model", x.llmModel))
+	}
+
+	x.llmClient = client
+	logging.From(ctx).Info("webfetch LLM analysis enabled",
+		"provider", x.llmProvider,
+		"model", x.llmModel)
 	return nil
 }
 
+// RequiresHITL reports whether the web_fetch tool should be gated by a HITL
+// (Human-in-the-Loop) approval dialog. When LLM analysis is enabled, the LLM
+// performs indirect-prompt-injection screening so the dialog is unnecessary
+// and is skipped; when LLM is disabled, the dialog is the only remaining
+// safety layer and is always required.
+func (x *Action) RequiresHITL() bool {
+	return x.llmProvider == ""
+}
+
 func (x *Action) LogValue() slog.Value {
-	return slog.GroupValue()
+	attrs := []slog.Attr{
+		slog.Bool("hitl_required", x.RequiresHITL()),
+	}
+	if x.llmProvider != "" {
+		attrs = append(attrs,
+			slog.String("llm_provider", x.llmProvider),
+			slog.String("llm_model", x.llmModel),
+			slog.String("llm_args", x.llmArgs),
+		)
+	}
+	return slog.GroupValue(attrs...)
 }
 
 func (x *Action) Prompt(_ context.Context) (string, error) {

--- a/pkg/tool/webfetch/action_test.go
+++ b/pkg/tool/webfetch/action_test.go
@@ -53,11 +53,53 @@ func TestAction_Run_MissingHost(t *testing.T) {
 	gt.True(t, goerr.HasTag(err, errutil.TagValidation))
 }
 
-func TestAction_Run_LLMClientNotInjected(t *testing.T) {
+func TestAction_RequiresHITL_DefaultsTrue(t *testing.T) {
 	action := &webfetch.Action{}
-	_, err := action.Run(t.Context(), "web_fetch", map[string]any{"url": "https://example.com"})
+	gt.True(t, action.RequiresHITL())
+}
+
+func TestAction_RequiresHITL_FalseWhenLLMProviderSet(t *testing.T) {
+	action := &webfetch.Action{}
+	action.SetLLMFlags("openai", "gpt-4o", "", "fake-key")
+	gt.False(t, action.RequiresHITL())
+}
+
+func TestAction_Run_NoLLM_SkipsAnalyzeAndReturnsDisabled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte("hello body"))
+	}))
+	defer srv.Close()
+
+	action := &webfetch.Action{}
+	action.SetHTTPClient(srv.Client())
+	// llmClient stays nil; analyze must NOT be invoked.
+
+	out, err := action.Run(t.Context(), "web_fetch", map[string]any{"url": srv.URL})
+	gt.NoError(t, err).Required()
+	gt.Value(t, out["result"]).Equal("hello body")
+	gt.Value(t, out["llm_analysis"]).Equal("disabled")
+	gt.Value(t, out["url"]).Equal(srv.URL)
+	gt.Value(t, out["status"]).Equal(http.StatusOK)
+}
+
+func TestAction_Configure_NoFlags_DisablesLLM(t *testing.T) {
+	action := &webfetch.Action{}
+	gt.NoError(t, action.Configure(t.Context()))
+	gt.Nil(t, action.LLMClient())
+	gt.True(t, action.RequiresHITL())
+}
+
+func TestAction_Configure_PingFailurePropagates(t *testing.T) {
+	// We can't easily configure the flag-driven build path against a mock
+	// LLM (Configure constructs the client itself), but the ping helper is
+	// tested directly in llmflag_test.go. Here we verify that a malformed
+	// --webfetch-llm-args bubbles out of Configure as a validation error.
+	action := &webfetch.Action{}
+	action.SetLLMFlags("openai", "gpt-4o", "no-equals-token", "fake-key")
+	err := action.Configure(t.Context())
 	gt.Error(t, err).Required()
-	gt.True(t, goerr.HasTag(err, errutil.TagInternal))
+	gt.True(t, goerr.HasTag(err, errutil.TagValidation))
 }
 
 func TestAction_Name(t *testing.T) {

--- a/pkg/tool/webfetch/export_test.go
+++ b/pkg/tool/webfetch/export_test.go
@@ -1,6 +1,10 @@
 package webfetch
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/m-mizutani/gollem"
+)
 
 // Extract is the test-only export of the package-private extract function.
 var Extract = extract
@@ -8,7 +12,41 @@ var Extract = extract
 // Analyze is the test-only export of the package-private analyze function.
 var Analyze = analyze
 
+// ParseLLMArgs is the test-only export of parseLLMArgs.
+var ParseLLMArgs = parseLLMArgs
+
+// BuildLLMClient is the test-only export of buildLLMClient.
+var BuildLLMClient = buildLLMClient
+
+// PingLLMClient is the test-only export of pingLLMClient.
+var PingLLMClient = pingLLMClient
+
 // SetHTTPClient injects a custom http.Client for tests (e.g. with httptest server).
 func (x *Action) SetHTTPClient(c *http.Client) {
 	x.client = c
+}
+
+// SetLLMClient injects an LLM client for tests, bypassing the flag-driven
+// build+ping path used in production.
+func (x *Action) SetLLMClient(c gollem.LLMClient) {
+	x.llmClient = c
+}
+
+// LLMClient returns the currently configured LLM client (test-only accessor).
+func (x *Action) LLMClient() gollem.LLMClient {
+	return x.llmClient
+}
+
+// LLMProvider returns the configured provider name (test-only accessor).
+func (x *Action) LLMProvider() string {
+	return x.llmProvider
+}
+
+// SetLLMFlags overrides the flag-bound fields for tests so we don't need a
+// full CLI flag-parse round trip.
+func (x *Action) SetLLMFlags(provider, model, args, apiKey string) {
+	x.llmProvider = provider
+	x.llmModel = model
+	x.llmArgs = args
+	x.llmAPIKey = apiKey
 }

--- a/pkg/tool/webfetch/llmflag.go
+++ b/pkg/tool/webfetch/llmflag.go
@@ -1,0 +1,275 @@
+package webfetch
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/m-mizutani/goerr/v2"
+	"github.com/m-mizutani/gollem"
+	"github.com/m-mizutani/gollem/llm/claude"
+	"github.com/m-mizutani/gollem/llm/gemini"
+	"github.com/m-mizutani/gollem/llm/openai"
+	"github.com/secmon-lab/warren/pkg/utils/errutil"
+)
+
+const (
+	providerGemini = "gemini"
+	providerClaude = "claude"
+	providerOpenAI = "openai"
+
+	argProjectID   = "project_id"
+	argLocation    = "location"
+	argTemperature = "temperature"
+)
+
+// parseLLMArgs parses a "key=value,key=value" string into a map.
+// Empty input yields an empty (non-nil) map.
+func parseLLMArgs(raw string) (map[string]string, error) {
+	result := map[string]string{}
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return result, nil
+	}
+
+	for _, token := range strings.Split(trimmed, ",") {
+		token = strings.TrimSpace(token)
+		if token == "" {
+			return nil, goerr.New("empty args token",
+				goerr.T(errutil.TagValidation),
+				goerr.V("raw", raw))
+		}
+		idx := strings.Index(token, "=")
+		if idx < 0 {
+			return nil, goerr.New("args token missing '='",
+				goerr.T(errutil.TagValidation),
+				goerr.V("token", token))
+		}
+		key := strings.TrimSpace(token[:idx])
+		value := strings.TrimSpace(token[idx+1:])
+		if key == "" {
+			return nil, goerr.New("empty args key",
+				goerr.T(errutil.TagValidation),
+				goerr.V("token", token))
+		}
+		if _, exists := result[key]; exists {
+			return nil, goerr.New("duplicate args key",
+				goerr.T(errutil.TagValidation),
+				goerr.V("key", key))
+		}
+		result[key] = value
+	}
+	return result, nil
+}
+
+// buildLLMClient constructs a gollem.LLMClient from the parsed flags.
+//
+// Provider dispatch:
+//   - "gemini" : Vertex AI Gemini. Requires project_id and location in args.
+//   - "claude" : Vertex AI Claude (project_id+location in args) OR direct
+//     Anthropic API (apiKey present). The route is auto-detected from the
+//     presence of these inputs. Mixing both is an error (ambiguous).
+//   - "openai" : OpenAI direct. Requires apiKey.
+//
+// Recognized args keys are enforced per provider; unknown keys produce an
+// errutil.TagValidation error so misconfigurations surface at start-up.
+func buildLLMClient(ctx context.Context, provider, model string, args map[string]string, apiKey string) (gollem.LLMClient, error) {
+	if model == "" {
+		return nil, goerr.New("model is required",
+			goerr.T(errutil.TagValidation),
+			goerr.V("provider", provider))
+	}
+
+	switch provider {
+	case providerGemini:
+		return buildGeminiClient(ctx, model, args, apiKey)
+	case providerClaude:
+		return buildClaudeClient(ctx, model, args, apiKey)
+	case providerOpenAI:
+		return buildOpenAIClient(ctx, model, args, apiKey)
+	default:
+		return nil, goerr.New("unknown llm provider",
+			goerr.T(errutil.TagValidation),
+			goerr.V("provider", provider))
+	}
+}
+
+func buildGeminiClient(ctx context.Context, model string, args map[string]string, apiKey string) (gollem.LLMClient, error) {
+	if apiKey != "" {
+		return nil, goerr.New("api-key is not used for gemini (Vertex AI)",
+			goerr.T(errutil.TagValidation),
+			goerr.V("provider", providerGemini))
+	}
+	if err := checkKnownArgs(providerGemini, args, argProjectID, argLocation, argTemperature); err != nil {
+		return nil, err
+	}
+
+	projectID := args[argProjectID]
+	location := args[argLocation]
+	if projectID == "" || location == "" {
+		return nil, goerr.New("gemini requires project_id and location args",
+			goerr.T(errutil.TagValidation),
+			goerr.V("project_id", projectID),
+			goerr.V("location", location))
+	}
+
+	opts := []gemini.Option{gemini.WithModel(model)}
+	if raw, ok := args[argTemperature]; ok {
+		temp, err := parseTemperature(raw)
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, gemini.WithTemperature(float32(temp)))
+	}
+
+	client, err := gemini.New(ctx, projectID, location, opts...)
+	if err != nil {
+		return nil, goerr.Wrap(err, "failed to construct gemini client",
+			goerr.V("provider", providerGemini),
+			goerr.V("model", model))
+	}
+	return client, nil
+}
+
+func buildClaudeClient(ctx context.Context, model string, args map[string]string, apiKey string) (gollem.LLMClient, error) {
+	if err := checkKnownArgs(providerClaude, args, argProjectID, argLocation, argTemperature); err != nil {
+		return nil, err
+	}
+
+	projectID := args[argProjectID]
+	location := args[argLocation]
+	hasVertexArg := projectID != "" || location != ""
+	hasAPIKey := apiKey != ""
+
+	if hasVertexArg && hasAPIKey {
+		return nil, goerr.New("claude route is ambiguous: both Vertex args (project_id/location) and api-key are set",
+			goerr.T(errutil.TagValidation),
+			goerr.V("provider", providerClaude))
+	}
+	if !hasVertexArg && !hasAPIKey {
+		return nil, goerr.New("claude route unspecified: set api-key for Anthropic direct API, or project_id+location for Vertex AI",
+			goerr.T(errutil.TagValidation),
+			goerr.V("provider", providerClaude))
+	}
+
+	if hasVertexArg {
+		if projectID == "" || location == "" {
+			return nil, goerr.New("claude Vertex route requires both project_id and location",
+				goerr.T(errutil.TagValidation),
+				goerr.V("project_id", projectID),
+				goerr.V("location", location))
+		}
+		opts := []claude.VertexOption{claude.WithVertexModel(model)}
+		if raw, ok := args[argTemperature]; ok {
+			temp, err := parseTemperature(raw)
+			if err != nil {
+				return nil, err
+			}
+			opts = append(opts, claude.WithVertexTemperature(temp))
+		}
+		client, err := claude.NewWithVertex(ctx, location, projectID, opts...)
+		if err != nil {
+			return nil, goerr.Wrap(err, "failed to construct claude Vertex client",
+				goerr.V("provider", providerClaude),
+				goerr.V("route", "vertex"),
+				goerr.V("model", model))
+		}
+		return client, nil
+	}
+
+	// Anthropic direct route.
+	opts := []claude.Option{claude.WithModel(model)}
+	if raw, ok := args[argTemperature]; ok {
+		temp, err := parseTemperature(raw)
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, claude.WithTemperature(temp))
+	}
+	client, err := claude.New(ctx, apiKey, opts...)
+	if err != nil {
+		return nil, goerr.Wrap(err, "failed to construct claude direct client",
+			goerr.V("provider", providerClaude),
+			goerr.V("route", "anthropic"),
+			goerr.V("model", model))
+	}
+	return client, nil
+}
+
+func buildOpenAIClient(ctx context.Context, model string, args map[string]string, apiKey string) (gollem.LLMClient, error) {
+	if err := checkKnownArgs(providerOpenAI, args, argTemperature); err != nil {
+		return nil, err
+	}
+	if apiKey == "" {
+		return nil, goerr.New("openai requires api-key",
+			goerr.T(errutil.TagValidation),
+			goerr.V("provider", providerOpenAI))
+	}
+
+	opts := []openai.Option{openai.WithModel(model)}
+	if raw, ok := args[argTemperature]; ok {
+		temp, err := parseTemperature(raw)
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, openai.WithTemperature(float32(temp)))
+	}
+
+	client, err := openai.New(ctx, apiKey, opts...)
+	if err != nil {
+		return nil, goerr.Wrap(err, "failed to construct openai client",
+			goerr.V("provider", providerOpenAI),
+			goerr.V("model", model))
+	}
+	return client, nil
+}
+
+func checkKnownArgs(provider string, args map[string]string, allowed ...string) error {
+	allowedSet := make(map[string]struct{}, len(allowed))
+	for _, k := range allowed {
+		allowedSet[k] = struct{}{}
+	}
+	for k := range args {
+		if _, ok := allowedSet[k]; !ok {
+			return goerr.New("unknown args key for provider",
+				goerr.T(errutil.TagValidation),
+				goerr.V("provider", provider),
+				goerr.V("key", k))
+		}
+	}
+	return nil
+}
+
+func parseTemperature(raw string) (float64, error) {
+	v, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
+		return 0, goerr.Wrap(err, "failed to parse temperature as float",
+			goerr.T(errutil.TagValidation),
+			goerr.V("raw", raw))
+	}
+	return v, nil
+}
+
+// pingLLMClient performs a minimal generate request (max_tokens=1) so that
+// misconfigurations such as a bad API key, wrong project_id/location, or a
+// typo in the model name surface at start-up rather than at first use.
+func pingLLMClient(ctx context.Context, client gollem.LLMClient) error {
+	if client == nil {
+		return goerr.New("llm client is nil", goerr.T(errutil.TagInternal))
+	}
+
+	session, err := client.NewSession(ctx)
+	if err != nil {
+		return goerr.Wrap(err, "failed to start llm session for ping",
+			goerr.T(errutil.TagLLMError))
+	}
+
+	if _, err := session.Generate(ctx,
+		[]gollem.Input{gollem.Text("ping")},
+		gollem.WithMaxTokens(1),
+	); err != nil {
+		return goerr.Wrap(err, "llm ping request failed",
+			goerr.T(errutil.TagLLMError))
+	}
+	return nil
+}

--- a/pkg/tool/webfetch/llmflag.go
+++ b/pkg/tool/webfetch/llmflag.go
@@ -240,12 +240,22 @@ func checkKnownArgs(provider string, args map[string]string, allowed ...string) 
 	return nil
 }
 
+// parseTemperature parses the temperature arg and validates the range. The
+// accepted range [0.0, 2.0] covers all currently supported providers (OpenAI
+// and Gemini allow up to 2.0; Anthropic up to 1.0 — values that satisfy this
+// check but exceed a provider's own cap will still fail at the start-up ping,
+// just with a less explicit error).
 func parseTemperature(raw string) (float64, error) {
 	v, err := strconv.ParseFloat(raw, 64)
 	if err != nil {
 		return 0, goerr.Wrap(err, "failed to parse temperature as float",
 			goerr.T(errutil.TagValidation),
 			goerr.V("raw", raw))
+	}
+	if v < 0 || v > 2 {
+		return 0, goerr.New("temperature must be between 0.0 and 2.0",
+			goerr.T(errutil.TagValidation),
+			goerr.V("value", v))
 	}
 	return v, nil
 }

--- a/pkg/tool/webfetch/llmflag_test.go
+++ b/pkg/tool/webfetch/llmflag_test.go
@@ -1,0 +1,249 @@
+package webfetch_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/m-mizutani/goerr/v2"
+	"github.com/m-mizutani/gollem"
+	"github.com/m-mizutani/gollem/mock"
+	"github.com/m-mizutani/gt"
+	"github.com/secmon-lab/warren/pkg/tool/webfetch"
+	"github.com/secmon-lab/warren/pkg/utils/errutil"
+)
+
+func TestParseLLMArgs_Empty(t *testing.T) {
+	m, err := webfetch.ParseLLMArgs("")
+	gt.NoError(t, err).Required()
+	gt.Map(t, m).Length(0)
+}
+
+func TestParseLLMArgs_SinglePair(t *testing.T) {
+	m, err := webfetch.ParseLLMArgs("project_id=my-proj")
+	gt.NoError(t, err).Required()
+	gt.Map(t, m).HasKeyValue("project_id", "my-proj")
+}
+
+func TestParseLLMArgs_MultiplePairs(t *testing.T) {
+	m, err := webfetch.ParseLLMArgs("project_id=p,location=us-central1,temperature=0.2")
+	gt.NoError(t, err).Required()
+	gt.Map(t, m).Length(3)
+	gt.Value(t, m["project_id"]).Equal("p")
+	gt.Value(t, m["location"]).Equal("us-central1")
+	gt.Value(t, m["temperature"]).Equal("0.2")
+}
+
+func TestParseLLMArgs_WhitespaceTolerated(t *testing.T) {
+	m, err := webfetch.ParseLLMArgs(" project_id = p , location = us-central1 ")
+	gt.NoError(t, err).Required()
+	gt.Value(t, m["project_id"]).Equal("p")
+	gt.Value(t, m["location"]).Equal("us-central1")
+}
+
+func TestParseLLMArgs_TokenWithoutEquals(t *testing.T) {
+	_, err := webfetch.ParseLLMArgs("project_id")
+	gt.Error(t, err).Required()
+	gt.True(t, goerr.HasTag(err, errutil.TagValidation))
+}
+
+func TestParseLLMArgs_EmptyKey(t *testing.T) {
+	_, err := webfetch.ParseLLMArgs("=value")
+	gt.Error(t, err).Required()
+	gt.True(t, goerr.HasTag(err, errutil.TagValidation))
+}
+
+func TestParseLLMArgs_DuplicateKey(t *testing.T) {
+	_, err := webfetch.ParseLLMArgs("project_id=a,project_id=b")
+	gt.Error(t, err).Required()
+	gt.True(t, goerr.HasTag(err, errutil.TagValidation))
+}
+
+func TestParseLLMArgs_EmptyToken(t *testing.T) {
+	_, err := webfetch.ParseLLMArgs("project_id=a,,location=b")
+	gt.Error(t, err).Required()
+	gt.True(t, goerr.HasTag(err, errutil.TagValidation))
+}
+
+func TestBuildLLMClient_ModelMissing(t *testing.T) {
+	_, err := webfetch.BuildLLMClient(t.Context(), "openai", "", map[string]string{}, "key")
+	gt.Error(t, err).Required()
+	gt.True(t, goerr.HasTag(err, errutil.TagValidation))
+}
+
+func TestBuildLLMClient_UnknownProvider(t *testing.T) {
+	_, err := webfetch.BuildLLMClient(t.Context(), "mistral", "model", map[string]string{}, "")
+	gt.Error(t, err).Required()
+	gt.True(t, goerr.HasTag(err, errutil.TagValidation))
+}
+
+func TestBuildLLMClient_GeminiMissingArgs(t *testing.T) {
+	_, err := webfetch.BuildLLMClient(t.Context(), "gemini", "gemini-2.5-flash", map[string]string{}, "")
+	gt.Error(t, err).Required()
+	gt.True(t, goerr.HasTag(err, errutil.TagValidation))
+}
+
+func TestBuildLLMClient_GeminiUnknownKey(t *testing.T) {
+	args := map[string]string{
+		"project_id": "p",
+		"location":   "us-central1",
+		"foo":        "bar",
+	}
+	_, err := webfetch.BuildLLMClient(t.Context(), "gemini", "gemini-2.5-flash", args, "")
+	gt.Error(t, err).Required()
+	gt.True(t, goerr.HasTag(err, errutil.TagValidation))
+}
+
+func TestBuildLLMClient_GeminiRejectsAPIKey(t *testing.T) {
+	args := map[string]string{"project_id": "p", "location": "us-central1"}
+	_, err := webfetch.BuildLLMClient(t.Context(), "gemini", "gemini-2.5-flash", args, "should-not-be-set")
+	gt.Error(t, err).Required()
+	gt.True(t, goerr.HasTag(err, errutil.TagValidation))
+}
+
+func TestBuildLLMClient_OpenAIMissingAPIKey(t *testing.T) {
+	_, err := webfetch.BuildLLMClient(t.Context(), "openai", "gpt-4o", map[string]string{}, "")
+	gt.Error(t, err).Required()
+	gt.True(t, goerr.HasTag(err, errutil.TagValidation))
+}
+
+func TestBuildLLMClient_OpenAIUnknownKey(t *testing.T) {
+	args := map[string]string{"project_id": "p"}
+	_, err := webfetch.BuildLLMClient(t.Context(), "openai", "gpt-4o", args, "key")
+	gt.Error(t, err).Required()
+	gt.True(t, goerr.HasTag(err, errutil.TagValidation))
+}
+
+func TestBuildLLMClient_OpenAIInvalidTemperature(t *testing.T) {
+	args := map[string]string{"temperature": "not-a-float"}
+	_, err := webfetch.BuildLLMClient(t.Context(), "openai", "gpt-4o", args, "key")
+	gt.Error(t, err).Required()
+	gt.True(t, goerr.HasTag(err, errutil.TagValidation))
+}
+
+// TestBuildLLMClient_OpenAIHappy verifies the dispatch reaches the OpenAI
+// constructor when given valid inputs. The OpenAI gollem constructor does not
+// require network access at construction time, so this happy-path test is
+// safe to run unconditionally.
+func TestBuildLLMClient_OpenAIHappy(t *testing.T) {
+	args := map[string]string{"temperature": "0.2"}
+	client, err := webfetch.BuildLLMClient(t.Context(), "openai", "gpt-4o", args, "fake-key")
+	gt.NoError(t, err).Required()
+	gt.NotNil(t, client)
+}
+
+func TestBuildLLMClient_ClaudeRoute_VertexHappy_RequiresGCP(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Claude Vertex constructor requires GCP authentication; skipped in -short mode")
+	}
+	// We don't run real construction in unit tests since it requires GCP creds.
+	// Validation-path coverage below verifies all error branches.
+}
+
+func TestBuildLLMClient_ClaudeRoute_Unspecified(t *testing.T) {
+	_, err := webfetch.BuildLLMClient(t.Context(), "claude", "claude-sonnet-4-5-20250929", map[string]string{}, "")
+	gt.Error(t, err).Required()
+	gt.True(t, goerr.HasTag(err, errutil.TagValidation))
+}
+
+func TestBuildLLMClient_ClaudeRoute_Ambiguous(t *testing.T) {
+	args := map[string]string{"project_id": "p", "location": "us-east5"}
+	_, err := webfetch.BuildLLMClient(t.Context(), "claude", "claude-sonnet-4@20250514", args, "also-api-key")
+	gt.Error(t, err).Required()
+	gt.True(t, goerr.HasTag(err, errutil.TagValidation))
+}
+
+func TestBuildLLMClient_ClaudeRoute_PartialVertexProjectOnly(t *testing.T) {
+	args := map[string]string{"project_id": "p"}
+	_, err := webfetch.BuildLLMClient(t.Context(), "claude", "claude-sonnet-4@20250514", args, "")
+	gt.Error(t, err).Required()
+	gt.True(t, goerr.HasTag(err, errutil.TagValidation))
+}
+
+func TestBuildLLMClient_ClaudeRoute_PartialVertexLocationOnly(t *testing.T) {
+	args := map[string]string{"location": "us-east5"}
+	_, err := webfetch.BuildLLMClient(t.Context(), "claude", "claude-sonnet-4@20250514", args, "")
+	gt.Error(t, err).Required()
+	gt.True(t, goerr.HasTag(err, errutil.TagValidation))
+}
+
+func TestBuildLLMClient_ClaudeRoute_UnknownKey(t *testing.T) {
+	args := map[string]string{"foo": "bar"}
+	_, err := webfetch.BuildLLMClient(t.Context(), "claude", "claude-sonnet-4-5-20250929", args, "key")
+	gt.Error(t, err).Required()
+	gt.True(t, goerr.HasTag(err, errutil.TagValidation))
+}
+
+// TestBuildLLMClient_ClaudeRoute_DirectHappy verifies the Anthropic-direct
+// dispatch path. The claude direct constructor does not perform network calls
+// at construction time, so this works without real credentials.
+func TestBuildLLMClient_ClaudeRoute_DirectHappy(t *testing.T) {
+	client, err := webfetch.BuildLLMClient(t.Context(), "claude", "claude-sonnet-4-5-20250929", map[string]string{}, "fake-key")
+	gt.NoError(t, err).Required()
+	gt.NotNil(t, client)
+}
+
+func TestPingLLMClient_NilClient(t *testing.T) {
+	err := webfetch.PingLLMClient(t.Context(), nil)
+	gt.Error(t, err).Required()
+	gt.True(t, goerr.HasTag(err, errutil.TagInternal))
+}
+
+func TestPingLLMClient_Success(t *testing.T) {
+	var sessionCalls int
+	var generateCalls int
+	var capturedOpts []gollem.GenerateOption
+
+	client := &mock.LLMClientMock{
+		NewSessionFunc: func(ctx context.Context, options ...gollem.SessionOption) (gollem.Session, error) {
+			sessionCalls++
+			return &mock.SessionMock{
+				GenerateFunc: func(ctx context.Context, input []gollem.Input, opts ...gollem.GenerateOption) (*gollem.Response, error) {
+					generateCalls++
+					capturedOpts = opts
+					return &gollem.Response{Texts: []string{"ok"}}, nil
+				},
+			}, nil
+		},
+	}
+
+	gt.NoError(t, webfetch.PingLLMClient(t.Context(), client))
+	gt.Value(t, sessionCalls).Equal(1)
+	gt.Value(t, generateCalls).Equal(1)
+	// Verify the ping uses a max-tokens cap to keep the call cheap.
+	cfg := gollem.NewGenerateConfig(capturedOpts...)
+	maxTokens := cfg.MaxTokens()
+	gt.NotNil(t, maxTokens)
+	gt.Value(t, *maxTokens).Equal(1)
+}
+
+func TestPingLLMClient_GenerateError(t *testing.T) {
+	upstream := errors.New("upstream failure")
+	client := &mock.LLMClientMock{
+		NewSessionFunc: func(ctx context.Context, options ...gollem.SessionOption) (gollem.Session, error) {
+			return &mock.SessionMock{
+				GenerateFunc: func(ctx context.Context, input []gollem.Input, opts ...gollem.GenerateOption) (*gollem.Response, error) {
+					return nil, upstream
+				},
+			}, nil
+		},
+	}
+
+	err := webfetch.PingLLMClient(t.Context(), client)
+	gt.Error(t, err).Required()
+	gt.True(t, errors.Is(err, upstream))
+	gt.True(t, goerr.HasTag(err, errutil.TagLLMError))
+}
+
+func TestPingLLMClient_SessionError(t *testing.T) {
+	upstream := errors.New("session init failure")
+	client := &mock.LLMClientMock{
+		NewSessionFunc: func(ctx context.Context, options ...gollem.SessionOption) (gollem.Session, error) {
+			return nil, upstream
+		},
+	}
+	err := webfetch.PingLLMClient(t.Context(), client)
+	gt.Error(t, err).Required()
+	gt.True(t, errors.Is(err, upstream))
+	gt.True(t, goerr.HasTag(err, errutil.TagLLMError))
+}

--- a/pkg/tool/webfetch/llmflag_test.go
+++ b/pkg/tool/webfetch/llmflag_test.go
@@ -121,6 +121,30 @@ func TestBuildLLMClient_OpenAIInvalidTemperature(t *testing.T) {
 	gt.True(t, goerr.HasTag(err, errutil.TagValidation))
 }
 
+func TestBuildLLMClient_OpenAITemperatureTooHigh(t *testing.T) {
+	args := map[string]string{"temperature": "2.5"}
+	_, err := webfetch.BuildLLMClient(t.Context(), "openai", "gpt-4o", args, "key")
+	gt.Error(t, err).Required()
+	gt.True(t, goerr.HasTag(err, errutil.TagValidation))
+}
+
+func TestBuildLLMClient_OpenAITemperatureNegative(t *testing.T) {
+	args := map[string]string{"temperature": "-0.1"}
+	_, err := webfetch.BuildLLMClient(t.Context(), "openai", "gpt-4o", args, "key")
+	gt.Error(t, err).Required()
+	gt.True(t, goerr.HasTag(err, errutil.TagValidation))
+}
+
+func TestBuildLLMClient_OpenAITemperatureBoundaryAccepted(t *testing.T) {
+	// 0.0 and 2.0 are both accepted (inclusive bounds).
+	for _, raw := range []string{"0", "0.0", "2", "2.0"} {
+		args := map[string]string{"temperature": raw}
+		client, err := webfetch.BuildLLMClient(t.Context(), "openai", "gpt-4o", args, "fake-key")
+		gt.NoError(t, err).Required()
+		gt.NotNil(t, client)
+	}
+}
+
 // TestBuildLLMClient_OpenAIHappy verifies the dispatch reaches the OpenAI
 // constructor when given valid inputs. The OpenAI gollem constructor does not
 // require network access at construction time, so this happy-path test is


### PR DESCRIPTION
## Summary

- Add `--webfetch-llm-{provider,model,args,api-key}` so the webfetch analyze step can use an LLM provider independent of warren's main `--gemini-*` / `--claude-*` configuration (or none at all).
- `claude` auto-routes between Vertex AI and the direct Anthropic API based on which inputs are supplied (`project_id`+`location` → Vertex, `api-key` → direct; mixing both is a start-up error).
- When `--webfetch-llm-provider` is empty, LLM analysis (Markdown reformatting + indirect-prompt-injection screening) is skipped and every `web_fetch` invocation is gated by the existing HITL approval dialog. When the provider is set, HITL is suppressed since the LLM handles IPI detection.
- Start-up issues a `max_tokens=1` ping per configured provider so misconfigurations (bad key, wrong model, wrong project/location) fail fast.
- `pkg/cli/serve.go` now builds the HITL tool list dynamically from each tool's `RequiresHITL()` state, replacing the hardcoded `[]string{"web_fetch"}` in both the aster and bluebell branches.
- Remove the unused `webfetch.Action.SetLLMClient` setter; `pkg/cli/utils.go::InjectLLMClient` becomes a no-op for webfetch and is kept as the entry point for future tools.

## Flags

| Flag | Env | Description |
|---|---|---|
| `--webfetch-llm-provider` | `WARREN_WEBFETCH_LLM_PROVIDER` | `gemini` / `claude` / `openai`. Empty disables LLM analysis (HITL gates every call). |
| `--webfetch-llm-model` | `WARREN_WEBFETCH_LLM_MODEL` | Required when provider is set. |
| `--webfetch-llm-args` | `WARREN_WEBFETCH_LLM_ARGS` | `key=value,key=value`. Recognized: `project_id`, `location`, `temperature`. |
| `--webfetch-llm-api-key` | `WARREN_WEBFETCH_LLM_API_KEY` | Required for `openai` and `claude` Anthropic-direct. Ignored for `gemini` and `claude` Vertex. |

## Claude routing examples

Vertex AI:

```bash
--webfetch-llm-provider claude \
--webfetch-llm-model    "claude-sonnet-4@20250514" \
--webfetch-llm-args     "project_id=my-proj,location=us-east5"

Anthropic direct API:

--webfetch-llm-provider claude \
--webfetch-llm-model    claude-sonnet-4-5-20250929 \
--webfetch-llm-api-key  "$ANTHROPIC_API_KEY"

Docs

- Rewrite pkg/tool/webfetch/README.md (flag table, Claude routing, HITL behavior, examples).
- Add a ### WebFetch (Tool) section to doc/reference/configuration.md with Bash examples for Gemini, Claude (Vertex), Claude (Anthropic direct), OpenAI, and the LLM-disabled HITL-only mode.

Test plan

- go vet ./...
- go fmt ./...
- golangci-lint run ./... (0 issues)
- gosec -exclude-generated -quiet ./... (no new issues from this change; pre-existing project issues unchanged)
- go test ./... full suite green. New unit tests cover:
  - parseLLMArgs happy + 4 validation cases
  - buildLLMClient validation errors per provider + Claude route selection (Vertex / direct / ambiguous / unspecified / partial)
  - pingLLMClient mock success / Generate error / Session error
  - Action.RequiresHITL toggle
  - Action.Run LLM-disabled passthrough returns llm_analysis: disabled
  - Action.Configure propagates malformed --webfetch-llm-args as validation error
  - toolList.HITLToolNames aggregation, exclusion, and skip-when-no-interface
- Manual smoke in warren chat with each of the four provider examples
- Manual verification that an intentionally bad API key fails at start-up with provider/model logged (no secret leak)