### PR TITLE
ci: add cicd-sensor runtime security action to all workflows

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -12,6 +12,9 @@ jobs:
     permissions:
       actions: write
     steps:
+      - name: Run cicd-sensor
+        uses: cicd-sensor/cicd-sensor-action@6ee257338e68af2b279b321b3346fe5f385aa498 # v0.0.29
+
       - name: Setup environment
         run: |
           echo "Starting daily cache cleanup..."

--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -16,6 +16,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Run cicd-sensor
+        uses: cicd-sensor/cicd-sensor-action@6ee257338e68af2b279b321b3346fe5f385aa498 # v0.0.29
+
       - name: Checkout code
         uses: actions/checkout@v4
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,6 +14,9 @@ jobs:
     timeout-minutes: 15
 
     steps:
+      - name: Run cicd-sensor
+        uses: cicd-sensor/cicd-sensor-action@6ee257338e68af2b279b321b3346fe5f385aa498 # v0.0.29
+
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -19,6 +19,9 @@ jobs:
     env:
       GO111MODULE: on
     steps:
+      - name: Run cicd-sensor
+        uses: cicd-sensor/cicd-sensor-action@6ee257338e68af2b279b321b3346fe5f385aa498 # v0.0.29
+
       - name: Checkout Source
         uses: actions/checkout@v4
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,9 @@ jobs:
       security-events: write
     runs-on: ubuntu-latest
     steps:
+      - name: Run cicd-sensor
+        uses: cicd-sensor/cicd-sensor-action@6ee257338e68af2b279b321b3346fe5f385aa498 # v0.0.29
+
       - uses: actions/checkout@v4
 
       - name: Set up Go

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,9 @@ jobs:
       packages: write
 
     steps:
+      - name: Run cicd-sensor
+        uses: cicd-sensor/cicd-sensor-action@6ee257338e68af2b279b321b3346fe5f385aa498 # v0.0.29
+
       - name: checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,9 @@ jobs:
       packages: write
 
     steps:
+      - name: Run cicd-sensor
+        uses: cicd-sensor/cicd-sensor-action@6ee257338e68af2b279b321b3346fe5f385aa498 # v0.0.29
+
       - name: checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Run cicd-sensor
+        uses: cicd-sensor/cicd-sensor-action@6ee257338e68af2b279b321b3346fe5f385aa498 # v0.0.29
+
       - name: Checkout upstream repo
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -15,6 +15,9 @@ jobs:
       contents: read
 
     steps:
+      - name: Run cicd-sensor
+        uses: cicd-sensor/cicd-sensor-action@6ee257338e68af2b279b321b3346fe5f385aa498 # v0.0.29
+
       - name: Checkout upstream repo
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:


### PR DESCRIPTION
## Summary
- Add `cicd-sensor/cicd-sensor-action` (pinned to commit `6ee2573` / `v0.0.29`) as the first step of every job across all 9 GitHub Actions workflows (`cache-cleanup`, `codegen`, `e2e`, `gosec`, `lint`, `publish`, `release`, `test`, `trivy`).
- `cicd-sensor` is an eBPF-powered runtime security sensor for CI/CD that monitors process ancestry on the runner to detect supply-chain attacks (e.g. credential access from package-manager processes) and produces forensic evidence per pipeline run.
- No extra permissions or secrets are required for the basic, install-only integration. All runners are `ubuntu-latest` (currently Ubuntu 24.04), which satisfies the kernel-version requirement (5.15+ amd64).

## Rationale
- Adds defense-in-depth coverage at the CI runtime layer, complementing the existing static security checks (`gosec`, `trivy`).
- Pinned by commit SHA per supply-chain-hygiene best practice; the `# v0.0.29` comment records the human-readable tag.

## Test plan
- [ ] Confirm the `Run cicd-sensor` step appears and succeeds at the top of every job once the workflows run on this branch.
- [ ] Verify that downstream steps (checkout, setup-go, build, etc.) still complete as before with no measurable slowdown.
- [ ] After merge, monitor the next push/PR run for any sensor-emitted findings.