### PR TITLE
fix(policy): serve stale cache while refreshing GitHub policy in background

### DIFF
--- a/pkg/adapter/policy/export_test.go
+++ b/pkg/adapter/policy/export_test.go
@@ -1,0 +1,8 @@
+package policy
+
+// WaitRefresh blocks until all background refreshes triggered by Snapshot have
+// completed. It exists only for deterministic testing of the
+// stale-while-revalidate behaviour and is not part of the public API.
+func (s *GitHubSource) WaitRefresh() {
+	s.refreshWG.Wait()
+}

--- a/pkg/adapter/policy/github_source.go
+++ b/pkg/adapter/policy/github_source.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
@@ -65,8 +66,10 @@ type GitHubSource struct {
 	cachedFiles map[string]string
 	cachedSha   string
 	cachedAt    time.Time
-	// refreshing guarantees at most one background refresh runs at a time.
-	refreshing bool
+	// refreshing guarantees at most one background refresh runs at a time. It is
+	// an atomic so the check-and-set is a single atomic operation independent of
+	// s.mu (which protects the cached* fields).
+	refreshing atomic.Bool
 	// refreshWG tracks in-flight background refreshes so tests can await them
 	// deterministically; it has no effect on production behaviour.
 	refreshWG sync.WaitGroup
@@ -129,7 +132,7 @@ func (s *GitHubSource) Snapshot(ctx context.Context) (*Snapshot, error) {
 		}
 		// Cache is stale: refresh in the background and serve the existing
 		// snapshot immediately so the caller never blocks on GitHub.
-		s.triggerRefreshLocked(ctx)
+		s.triggerRefresh(ctx)
 		return s.snapshotLocked(), nil
 	}
 
@@ -153,34 +156,24 @@ func (s *GitHubSource) snapshotLocked() *Snapshot {
 	}
 }
 
-// triggerRefreshLocked starts a single background refresh unless one is already
-// running. It assumes s.mu is held. The refresh runs via async.Dispatch, which
-// detaches the request context (so the refresh is not cancelled when the
-// originating request completes) and reports a returned error via
-// errutil.Handle. The single-flight guard is always released via clearRefreshing,
+// triggerRefresh starts a single background refresh unless one is already
+// running. The single-flight guard is a CompareAndSwap on s.refreshing, so the
+// check-and-set is atomic and does not depend on holding s.mu. The refresh runs
+// via async.Dispatch, which detaches the request context (so the refresh is not
+// cancelled when the originating request completes) and reports a returned error
+// via errutil.Handle. The guard is always released via the deferred Store(false),
 // even if the refresh returns early or panics, so a failed refresh can never
 // permanently disable future refreshes.
-func (s *GitHubSource) triggerRefreshLocked(ctx context.Context) {
-	if s.refreshing {
-		return
+func (s *GitHubSource) triggerRefresh(ctx context.Context) {
+	if !s.refreshing.CompareAndSwap(false, true) {
+		return // a refresh is already in flight
 	}
-	s.refreshing = true
 	s.refreshWG.Add(1)
 	async.Dispatch(ctx, func(ctx context.Context) error {
 		defer s.refreshWG.Done()
-		defer s.clearRefreshing()
+		defer s.refreshing.Store(false)
 		return s.runRefresh(ctx)
 	})
-}
-
-// clearRefreshing releases the single-flight guard. It is invoked via defer so
-// the guard is cleared even when the refresh panics; otherwise a single
-// panicking refresh would leave refreshing stuck at true and block every future
-// refresh.
-func (s *GitHubSource) clearRefreshing() {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.refreshing = false
 }
 
 // runRefresh performs a background refresh without holding the mutex during the
@@ -189,7 +182,7 @@ func (s *GitHubSource) clearRefreshing() {
 // via errutil.Handle). cachedAt is stamped on both success and failure so a
 // failing GitHub backs off for a full TTL instead of being retried on every
 // alert. The single-flight guard (s.refreshing) is released by the caller via
-// clearRefreshing.
+// the deferred Store(false).
 func (s *GitHubSource) runRefresh(ctx context.Context) error {
 	s.mu.Lock()
 	prevSha := s.cachedSha

--- a/pkg/adapter/policy/github_source.go
+++ b/pkg/adapter/policy/github_source.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/go-github/v74/github"
 	"github.com/m-mizutani/goerr/v2"
 	"github.com/m-mizutani/opaq"
+	"github.com/secmon-lab/warren/pkg/utils/async"
 	"github.com/secmon-lab/warren/pkg/utils/errutil"
 )
 
@@ -45,8 +46,14 @@ type GitHubSourceOpts struct {
 
 // GitHubSource fetches Rego policy files from a GitHub repository's default
 // branch HEAD. Results are cached in memory for TTL; sha-based change detection
-// avoids re-fetching content when the branch HEAD has not moved. On any
-// fetch or validation failure, the previously known good snapshot is returned.
+// avoids re-fetching content when the branch HEAD has not moved.
+//
+// Once a snapshot has been cached, Snapshot follows a stale-while-revalidate
+// model: an expired cache is served immediately while a single background
+// refresh runs, so callers (e.g. the alert pipeline) never block on a slow or
+// failing GitHub fetch. A failed refresh keeps the previous snapshot and is
+// reported via errutil.Handle. Only the very first load (no cache yet) fetches
+// synchronously and propagates its error, since there is nothing to serve.
 type GitHubSource struct {
 	owner  string
 	repo   string
@@ -58,6 +65,11 @@ type GitHubSource struct {
 	cachedFiles map[string]string
 	cachedSha   string
 	cachedAt    time.Time
+	// refreshing guarantees at most one background refresh runs at a time.
+	refreshing bool
+	// refreshWG tracks in-flight background refreshes so tests can await them
+	// deterministically; it has no effect on production behaviour.
+	refreshWG sync.WaitGroup
 }
 
 // NewGitHubSource constructs a GitHubSource. If opts.Client is nil, App
@@ -102,65 +114,34 @@ func NewGitHubSource(opts GitHubSourceOpts) (*GitHubSource, error) {
 	}, nil
 }
 
-// Snapshot returns the current snapshot, fetching from GitHub if the cache is
-// stale. Concurrent callers serialise on the internal mutex so only one fetch
-// is in flight at a time.
+// Snapshot returns the current snapshot. When a cached snapshot exists it is
+// returned without blocking: a fresh cache is returned directly, and an expired
+// cache is returned as-is while a single background refresh is triggered
+// (stale-while-revalidate). Only the first load, when no cache exists yet,
+// fetches synchronously and may return an error.
 func (s *GitHubSource) Snapshot(ctx context.Context) (*Snapshot, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if s.cachedFiles != nil && time.Since(s.cachedAt) < s.ttl {
-		return s.snapshotLocked(), nil
-	}
-
-	repoInfo, _, err := s.client.Repositories.Get(ctx, s.owner, s.repo)
-	if err != nil {
-		return s.fallbackLocked(ctx, goerr.Wrap(err, "failed to fetch repo info",
-			goerr.V("owner", s.owner), goerr.V("repo", s.repo)))
-	}
-	defaultBranch := repoInfo.GetDefaultBranch()
-	if defaultBranch == "" {
-		return s.fallbackLocked(ctx, goerr.New("repository has no default branch",
-			goerr.V("owner", s.owner), goerr.V("repo", s.repo)))
-	}
-
-	branch, _, err := s.client.Repositories.GetBranch(ctx, s.owner, s.repo, defaultBranch, 0)
-	if err != nil {
-		return s.fallbackLocked(ctx, goerr.Wrap(err, "failed to fetch branch",
-			goerr.V("branch", defaultBranch)))
-	}
-	headSha := branch.GetCommit().GetSHA()
-	if headSha == "" {
-		return s.fallbackLocked(ctx, goerr.New("branch has no HEAD commit",
-			goerr.V("branch", defaultBranch)))
-	}
-
-	if s.cachedFiles != nil && headSha == s.cachedSha {
-		s.cachedAt = time.Now()
-		return s.snapshotLocked(), nil
-	}
-
-	files, err := s.fetchAllPaths(ctx, headSha)
-	if err != nil {
-		return s.fallbackLocked(ctx, goerr.Wrap(err, "failed to fetch policy files",
-			goerr.V("commit_sha", headSha)))
-	}
-
-	if err := validatePolicy(ctx, files); err != nil {
-		// Validation failures indicate a data-level problem (bad Rego, rule
-		// conflict, etc.) that will not self-heal on retry, so notify
-		// regardless of whether a cached snapshot is available.
-		wrapped := goerr.Wrap(err, "policy validation failed",
-			goerr.V("commit_sha", headSha))
-		errutil.Handle(ctx, wrapped)
-		if s.cachedFiles != nil {
+	if s.cachedFiles != nil {
+		if time.Since(s.cachedAt) < s.ttl {
 			return s.snapshotLocked(), nil
 		}
-		return nil, wrapped
+		// Cache is stale: refresh in the background and serve the existing
+		// snapshot immediately so the caller never blocks on GitHub.
+		s.triggerRefreshLocked(ctx)
+		return s.snapshotLocked(), nil
 	}
 
+	// First load: there is no cached snapshot to fall back to, so fetch
+	// synchronously and propagate any error to the caller (e.g. Prime fails
+	// at startup and the process exits before the HTTP server starts).
+	files, sha, err := s.fetchRemote(ctx, "")
+	if err != nil {
+		return nil, err
+	}
 	s.cachedFiles = files
-	s.cachedSha = headSha
+	s.cachedSha = sha
 	s.cachedAt = time.Now()
 	return s.snapshotLocked(), nil
 }
@@ -172,15 +153,100 @@ func (s *GitHubSource) snapshotLocked() *Snapshot {
 	}
 }
 
-// fallbackLocked decides what to return when a fetch step fails.
-// If a previous snapshot exists, the error is logged via errutil.Handle and
-// the cached snapshot is returned. Otherwise the error is returned.
-func (s *GitHubSource) fallbackLocked(ctx context.Context, err error) (*Snapshot, error) {
-	if s.cachedFiles != nil {
-		errutil.Handle(ctx, err)
-		return s.snapshotLocked(), nil
+// triggerRefreshLocked starts a single background refresh unless one is already
+// running. It assumes s.mu is held. The refresh runs via async.Dispatch, which
+// detaches the request context (so the refresh is not cancelled when the
+// originating request completes) and reports a returned error via
+// errutil.Handle.
+func (s *GitHubSource) triggerRefreshLocked(ctx context.Context) {
+	if s.refreshing {
+		return
 	}
-	return nil, err
+	s.refreshing = true
+	s.refreshWG.Add(1)
+	async.Dispatch(ctx, func(ctx context.Context) error {
+		defer s.refreshWG.Done()
+		return s.runRefresh(ctx)
+	})
+}
+
+// runRefresh performs a background refresh without holding the mutex during the
+// network fetch, then swaps in the result under a brief lock. On any failure it
+// keeps the previous snapshot and returns the error (reported by async.Dispatch
+// via errutil.Handle). cachedAt is stamped on both success and failure so a
+// failing GitHub backs off for a full TTL instead of being retried on every
+// alert.
+func (s *GitHubSource) runRefresh(ctx context.Context) error {
+	s.mu.Lock()
+	prevSha := s.cachedSha
+	s.mu.Unlock()
+
+	files, sha, fetchErr := s.fetchRemote(ctx, prevSha)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.refreshing = false
+	s.cachedAt = time.Now()
+	if fetchErr != nil {
+		return fetchErr
+	}
+	if files != nil { // nil files means the HEAD sha was unchanged.
+		s.cachedFiles = files
+		s.cachedSha = sha
+	}
+	return nil
+}
+
+// fetchRemote fetches the policy files from GitHub without touching the cache or
+// holding the mutex, so concurrent readers are never blocked by a slow fetch.
+// It returns (nil, headSha, nil) when prevSha matches the current HEAD (no
+// change). On any failure it returns a wrapped error and leaves the cache
+// untouched for the caller to preserve.
+func (s *GitHubSource) fetchRemote(ctx context.Context, prevSha string) (map[string]string, string, error) {
+	repoInfo, _, err := s.client.Repositories.Get(ctx, s.owner, s.repo)
+	if err != nil {
+		return nil, "", goerr.Wrap(err, "failed to fetch repo info",
+			goerr.T(errutil.TagGitHubError),
+			goerr.V("owner", s.owner), goerr.V("repo", s.repo))
+	}
+	defaultBranch := repoInfo.GetDefaultBranch()
+	if defaultBranch == "" {
+		return nil, "", goerr.New("repository has no default branch",
+			goerr.T(errutil.TagGitHubError),
+			goerr.V("owner", s.owner), goerr.V("repo", s.repo))
+	}
+
+	branch, _, err := s.client.Repositories.GetBranch(ctx, s.owner, s.repo, defaultBranch, 0)
+	if err != nil {
+		return nil, "", goerr.Wrap(err, "failed to fetch branch",
+			goerr.T(errutil.TagGitHubError),
+			goerr.V("branch", defaultBranch))
+	}
+	headSha := branch.GetCommit().GetSHA()
+	if headSha == "" {
+		return nil, "", goerr.New("branch has no HEAD commit",
+			goerr.T(errutil.TagGitHubError),
+			goerr.V("branch", defaultBranch))
+	}
+
+	if prevSha != "" && headSha == prevSha {
+		return nil, headSha, nil
+	}
+
+	files, err := s.fetchAllPaths(ctx, headSha)
+	if err != nil {
+		return nil, "", goerr.Wrap(err, "failed to fetch policy files",
+			goerr.T(errutil.TagGitHubError),
+			goerr.V("commit_sha", headSha))
+	}
+
+	if err := validatePolicy(ctx, files); err != nil {
+		return nil, "", goerr.Wrap(err, "policy validation failed",
+			goerr.T(errutil.TagValidation),
+			goerr.V("commit_sha", headSha))
+	}
+
+	return files, headSha, nil
 }
 
 func (s *GitHubSource) fetchAllPaths(ctx context.Context, sha string) (map[string]string, error) {

--- a/pkg/adapter/policy/github_source.go
+++ b/pkg/adapter/policy/github_source.go
@@ -157,7 +157,9 @@ func (s *GitHubSource) snapshotLocked() *Snapshot {
 // running. It assumes s.mu is held. The refresh runs via async.Dispatch, which
 // detaches the request context (so the refresh is not cancelled when the
 // originating request completes) and reports a returned error via
-// errutil.Handle.
+// errutil.Handle. The single-flight guard is always released via clearRefreshing,
+// even if the refresh returns early or panics, so a failed refresh can never
+// permanently disable future refreshes.
 func (s *GitHubSource) triggerRefreshLocked(ctx context.Context) {
 	if s.refreshing {
 		return
@@ -166,8 +168,19 @@ func (s *GitHubSource) triggerRefreshLocked(ctx context.Context) {
 	s.refreshWG.Add(1)
 	async.Dispatch(ctx, func(ctx context.Context) error {
 		defer s.refreshWG.Done()
+		defer s.clearRefreshing()
 		return s.runRefresh(ctx)
 	})
+}
+
+// clearRefreshing releases the single-flight guard. It is invoked via defer so
+// the guard is cleared even when the refresh panics; otherwise a single
+// panicking refresh would leave refreshing stuck at true and block every future
+// refresh.
+func (s *GitHubSource) clearRefreshing() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.refreshing = false
 }
 
 // runRefresh performs a background refresh without holding the mutex during the
@@ -175,7 +188,8 @@ func (s *GitHubSource) triggerRefreshLocked(ctx context.Context) {
 // keeps the previous snapshot and returns the error (reported by async.Dispatch
 // via errutil.Handle). cachedAt is stamped on both success and failure so a
 // failing GitHub backs off for a full TTL instead of being retried on every
-// alert.
+// alert. The single-flight guard (s.refreshing) is released by the caller via
+// clearRefreshing.
 func (s *GitHubSource) runRefresh(ctx context.Context) error {
 	s.mu.Lock()
 	prevSha := s.cachedSha
@@ -185,7 +199,6 @@ func (s *GitHubSource) runRefresh(ctx context.Context) error {
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.refreshing = false
 	s.cachedAt = time.Now()
 	if fetchErr != nil {
 		return fetchErr

--- a/pkg/adapter/policy/github_source_test.go
+++ b/pkg/adapter/policy/github_source_test.go
@@ -430,16 +430,47 @@ func TestGitHubSource_ConcurrentSnapshot_SerialisesFetch(t *testing.T) {
 	gt.True(t, maxInFlight.Load() <= 1)
 }
 
+// blockingTransport delays every HTTP round trip until release is closed while
+// blocked is set. It simulates a slow or hung GitHub on the client side, which
+// is fully thread-safe (unlike mutating the test server's handler at runtime).
+type blockingTransport struct {
+	blocked *atomic.Bool
+	release chan struct{}
+	base    http.RoundTripper
+}
+
+func (t *blockingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.blocked.Load() {
+		<-t.release
+	}
+	return t.base.RoundTrip(req)
+}
+
 func TestGitHubSource_StaleServedImmediately_NonBlocking(t *testing.T) {
 	mock := newMockGitHub(t, "sha-1", map[string]string{
 		"policies/ignore.rego": ghTestRego,
 	})
 
+	u, err := url.Parse(mock.server.URL + "/")
+	gt.NoError(t, err)
+
+	release := make(chan struct{})
+	var blocked atomic.Bool
+	gClient := github.NewClient(&http.Client{
+		Transport: &blockingTransport{
+			blocked: &blocked,
+			release: release,
+			base:    http.DefaultTransport,
+		},
+	})
+	gClient.BaseURL = u
+	gClient.UploadURL = u
+
 	src, err := policyadapter.NewGitHubSource(policyadapter.GitHubSourceOpts{
 		Owner:  "owner",
 		Repo:   "repo",
 		Paths:  []string{"policies"},
-		Client: mock.client(),
+		Client: gClient,
 		TTL:    time.Nanosecond, // immediately expire after the first load
 	})
 	gt.NoError(t, err)
@@ -449,16 +480,7 @@ func TestGitHubSource_StaleServedImmediately_NonBlocking(t *testing.T) {
 	gt.NoError(t, err)
 
 	// From now on, every GitHub call blocks until released, simulating a slow
-	// or hung GitHub. The background refresh will be stuck here.
-	release := make(chan struct{})
-	var blocked atomic.Bool
-	origHandler := mock.server.Config.Handler
-	mock.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if blocked.Load() {
-			<-release
-		}
-		origHandler.ServeHTTP(w, r)
-	})
+	// or hung GitHub. The background refresh will be stuck in RoundTrip.
 	blocked.Store(true)
 
 	// Let the TTL window pass so the next Snapshot sees a stale cache.

--- a/pkg/adapter/policy/github_source_test.go
+++ b/pkg/adapter/policy/github_source_test.go
@@ -497,3 +497,81 @@ func TestGitHubSource_StaleServedImmediately_NonBlocking(t *testing.T) {
 	close(release)
 	src.WaitRefresh()
 }
+
+// panicTransport panics on every round trip while shouldPanic is set, to
+// simulate an unexpected failure inside the background refresh goroutine.
+type panicTransport struct {
+	shouldPanic *atomic.Bool
+	base        http.RoundTripper
+}
+
+func (t *panicTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.shouldPanic.Load() {
+		panic("simulated transport panic")
+	}
+	return t.base.RoundTrip(req)
+}
+
+func TestGitHubSource_RefreshPanic_DoesNotWedgeSingleFlight(t *testing.T) {
+	mock := newMockGitHub(t, "sha-1", map[string]string{
+		"policies/ignore.rego": ghTestRego,
+	})
+
+	u, err := url.Parse(mock.server.URL + "/")
+	gt.NoError(t, err)
+
+	var shouldPanic atomic.Bool
+	gClient := github.NewClient(&http.Client{
+		Transport: &panicTransport{
+			shouldPanic: &shouldPanic,
+			base:        http.DefaultTransport,
+		},
+	})
+	gClient.BaseURL = u
+	gClient.UploadURL = u
+
+	src, err := policyadapter.NewGitHubSource(policyadapter.GitHubSourceOpts{
+		Owner:  "owner",
+		Repo:   "repo",
+		Paths:  []string{"policies"},
+		Client: gClient,
+		TTL:    time.Nanosecond, // immediately expire after the first load
+	})
+	gt.NoError(t, err)
+
+	// Warm the cache with a fast fetch.
+	first, err := src.Snapshot(context.Background())
+	gt.NoError(t, err)
+
+	// Make the next background refresh panic inside RoundTrip.
+	shouldPanic.Store(true)
+	mock.update("sha-2", map[string]string{
+		"policies/ignore.rego": ghTestRegoV2,
+	})
+	time.Sleep(2 * time.Millisecond)
+
+	// Stale snapshot is served; the triggered refresh panics in the background
+	// and is recovered by async.Dispatch.
+	snap, err := src.Snapshot(context.Background())
+	gt.NoError(t, err)
+	gt.Equal(t, snap.Version, first.Version)
+	src.WaitRefresh()
+
+	// After the panic, the single-flight guard must have been released: a
+	// subsequent (now healthy) refresh must run and apply the new sha. If the
+	// guard were wedged at true, this refresh would be skipped and the version
+	// would stay at sha-1.
+	shouldPanic.Store(false)
+	time.Sleep(2 * time.Millisecond)
+
+	stale, err := src.Snapshot(context.Background())
+	gt.NoError(t, err)
+	gt.Equal(t, stale.Version, first.Version) // still stale until refresh applies
+	src.WaitRefresh()
+
+	updated, err := src.Snapshot(context.Background())
+	gt.NoError(t, err)
+	gt.True(t, strings.Contains(updated.Version, "sha-2"))
+	gt.True(t, strings.Contains(updated.Files["github://owner/repo/policies/ignore.rego"], "from-github-v2"))
+	src.WaitRefresh()
+}

--- a/pkg/adapter/policy/github_source_test.go
+++ b/pkg/adapter/policy/github_source_test.go
@@ -200,9 +200,13 @@ func TestGitHubSource_RefreshesAfterTTL_SameSha(t *testing.T) {
 	// Wait a moment to ensure TTL window passes.
 	time.Sleep(2 * time.Millisecond)
 
+	// Stale cache is served immediately while a background refresh runs.
 	snap, err := src.Snapshot(context.Background())
 	gt.NoError(t, err)
 	gt.True(t, strings.Contains(snap.Version, "sha-1"))
+
+	// Await the background refresh deterministically.
+	src.WaitRefresh()
 
 	// repo + branch are re-fetched; contents must NOT be re-fetched (sha unchanged).
 	gt.Equal(t, mock.contentsHits, contentsBefore)
@@ -231,11 +235,22 @@ func TestGitHubSource_RefreshesAfterTTL_NewSha(t *testing.T) {
 
 	time.Sleep(2 * time.Millisecond)
 
+	// First post-expiry call serves the stale snapshot and triggers a refresh.
 	second, err := src.Snapshot(context.Background())
 	gt.NoError(t, err)
-	gt.NotEqual(t, first.Version, second.Version)
-	gt.True(t, strings.Contains(second.Version, "sha-2"))
-	gt.True(t, strings.Contains(second.Files["github://owner/repo/policies/ignore.rego"], "from-github-v2"))
+	gt.Equal(t, first.Version, second.Version)
+
+	src.WaitRefresh()
+
+	// Once the refresh has applied, the new sha is visible.
+	third, err := src.Snapshot(context.Background())
+	gt.NoError(t, err)
+	gt.NotEqual(t, first.Version, third.Version)
+	gt.True(t, strings.Contains(third.Version, "sha-2"))
+	gt.True(t, strings.Contains(third.Files["github://owner/repo/policies/ignore.rego"], "from-github-v2"))
+
+	// Drain the no-op refresh re-triggered by the read above.
+	src.WaitRefresh()
 }
 
 func TestGitHubSource_ValidationFailure_FallbackToCached(t *testing.T) {
@@ -262,11 +277,20 @@ func TestGitHubSource_ValidationFailure_FallbackToCached(t *testing.T) {
 
 	time.Sleep(2 * time.Millisecond)
 
+	// Stale snapshot is served immediately; the background refresh will fail.
 	snap, err := src.Snapshot(context.Background())
 	gt.NoError(t, err)
-	// Falls back to previous good snapshot.
 	gt.Equal(t, snap.Version, first.Version)
-	gt.True(t, strings.Contains(snap.Files["github://owner/repo/policies/ignore.rego"], "from-github\""))
+
+	src.WaitRefresh()
+
+	// The failed refresh keeps the previous good snapshot intact.
+	snap2, err := src.Snapshot(context.Background())
+	gt.NoError(t, err)
+	gt.Equal(t, snap2.Version, first.Version)
+	gt.True(t, strings.Contains(snap2.Files["github://owner/repo/policies/ignore.rego"], "from-github\""))
+
+	src.WaitRefresh()
 }
 
 func TestGitHubSource_RuntimeConflict_FallbackToCached(t *testing.T) {
@@ -297,10 +321,21 @@ x := 2
 
 	time.Sleep(2 * time.Millisecond)
 
+	// Stale snapshot is served immediately; the background refresh will fail
+	// the runtime conflict check.
 	snap, err := src.Snapshot(context.Background())
 	gt.NoError(t, err)
 	gt.Equal(t, snap.Version, first.Version)
-	gt.True(t, strings.Contains(snap.Files["github://owner/repo/policies/ignore.rego"], "from-github\""))
+
+	src.WaitRefresh()
+
+	// The failed refresh keeps the previous good snapshot intact.
+	snap2, err := src.Snapshot(context.Background())
+	gt.NoError(t, err)
+	gt.Equal(t, snap2.Version, first.Version)
+	gt.True(t, strings.Contains(snap2.Files["github://owner/repo/policies/ignore.rego"], "from-github\""))
+
+	src.WaitRefresh()
 }
 
 func TestGitHubSource_RuntimeConflict_NoCache_ReturnsError(t *testing.T) {
@@ -393,4 +428,50 @@ func TestGitHubSource_ConcurrentSnapshot_SerialisesFetch(t *testing.T) {
 	gt.Equal(t, mock.repoHits, 1)
 	// And no concurrent fetches inside the lock window.
 	gt.True(t, maxInFlight.Load() <= 1)
+}
+
+func TestGitHubSource_StaleServedImmediately_NonBlocking(t *testing.T) {
+	mock := newMockGitHub(t, "sha-1", map[string]string{
+		"policies/ignore.rego": ghTestRego,
+	})
+
+	src, err := policyadapter.NewGitHubSource(policyadapter.GitHubSourceOpts{
+		Owner:  "owner",
+		Repo:   "repo",
+		Paths:  []string{"policies"},
+		Client: mock.client(),
+		TTL:    time.Nanosecond, // immediately expire after the first load
+	})
+	gt.NoError(t, err)
+
+	// Warm the cache with a fast fetch.
+	first, err := src.Snapshot(context.Background())
+	gt.NoError(t, err)
+
+	// From now on, every GitHub call blocks until released, simulating a slow
+	// or hung GitHub. The background refresh will be stuck here.
+	release := make(chan struct{})
+	var blocked atomic.Bool
+	origHandler := mock.server.Config.Handler
+	mock.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if blocked.Load() {
+			<-release
+		}
+		origHandler.ServeHTTP(w, r)
+	})
+	blocked.Store(true)
+
+	// Let the TTL window pass so the next Snapshot sees a stale cache.
+	time.Sleep(2 * time.Millisecond)
+
+	// Snapshot MUST return the stale snapshot immediately even though the
+	// background refresh is blocked on the hung GitHub server. If Snapshot
+	// blocked on the fetch, this test would deadlock (release is still open).
+	snap, err := src.Snapshot(context.Background())
+	gt.NoError(t, err)
+	gt.Equal(t, snap.Version, first.Version)
+
+	// Release the blocked refresh and drain it.
+	close(release)
+	src.WaitRefresh()
 }


### PR DESCRIPTION
## Problem

When the GitHub policy cache TTL expires, `GitHubSource.Snapshot()` performs the full GitHub fetch (`Repositories.Get` → `GetBranch` → `GetContents` recursively) **while holding the internal mutex** and using the **request context**. When GitHub is slow or unhealthy, that single fetch holds the lock, so every concurrent alert request piles up on `Snapshot()`. While they wait, the Pub/Sub push deadline elapses and `r.Context()` is cancelled, so the downstream OPA evaluation fails with `eval_cancel_error: context canceled`.

This was observed in production as a thundering herd: Sentry **ARGUS-7P** logged 35 occurrences of `failed to evaluate ingest policy: ... eval_cancel_error: context canceled` within ~20 seconds (release `86e2287`).

## Fix

Rework `GitHubSource.Snapshot()` to a **stale-while-revalidate** model:

- **Fresh cache (within TTL)** → returned directly.
- **Stale cache (TTL expired)** → the existing snapshot is returned **immediately**, and a single background refresh is triggered. The alert pipeline never blocks on GitHub.
- The background refresh runs via `async.Dispatch` (detached context, panic recovery) and **does not hold the mutex during network I/O** — it only takes a brief lock to swap in the result.
- A **failed refresh keeps the previous snapshot** and reports the error via `errutil.Handle` (Sentry). `cachedAt` is stamped on success *and* failure so a failing GitHub backs off for a full TTL instead of being retried on every alert.
- Background refreshes are **singleton** (`refreshing` flag set/cleared under lock) — at most one runs at a time.
- **First load (no cache yet)** still fetches synchronously and propagates its error, since there is nothing to serve. Via `Prime` at startup this preserves fail-fast: if no policy can be loaded, the process exits **before the HTTP server starts listening**.

## Tests

- Updated the TTL-refresh / fallback tests to the new semantics (serve stale → `WaitRefresh()` → assert applied / preserved).
- Added `TestGitHubSource_StaleServedImmediately_NonBlocking`: warms the cache, then hangs the mock GitHub server and asserts `Snapshot()` returns the stale snapshot immediately (a regression for this bug — a blocking implementation would deadlock).
- `go vet`, `gofmt`, `golangci-lint` (0 issues), `gosec` (clean), and `go test ./pkg/adapter/policy/ -race` plus `cli/config` / `service/policy` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)