### PR TITLE
fix(deps): upgrade react-router-dom to clear trivy CVEs

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,7 +44,7 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-markdown": "^10.1.0",
-    "react-router-dom": "^7.13.2",
+    "react-router-dom": "^7.15.0",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.5.0"
   },

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -93,8 +93,8 @@ importers:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.14)(react@19.2.4)
       react-router-dom:
-        specifier: ^7.13.2
-        version: 7.13.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: ^7.15.0
+        version: 7.17.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -3279,15 +3279,15 @@ packages:
       '@types/react':
         optional: true
 
-  react-router-dom@7.13.2:
-    resolution: {integrity: sha512-aR7SUORwTqAW0JDeiWF07e9SBE9qGpByR9I8kJT5h/FrBKxPMS6TiC7rmVO+gC0q52Bx7JnjWe8Z1sR9faN4YA==}
+  react-router-dom@7.17.0:
+    resolution: {integrity: sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
       react-dom: '>=18'
 
-  react-router@7.13.2:
-    resolution: {integrity: sha512-tX1Aee+ArlKQP+NIUd7SE6Li+CiGKwQtbS+FfRxPX6Pe4vHOo6nr9d++u5cwg+Z8K/x8tP+7qLmujDtfrAoUJA==}
+  react-router@7.17.0:
+    resolution: {integrity: sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -7628,13 +7628,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  react-router-dom@7.13.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  react-router-dom@7.17.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      react-router: 7.13.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react-router: 7.17.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  react-router@7.13.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  react-router@7.17.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       cookie: 1.1.1
       react: 19.2.4


### PR DESCRIPTION
## Summary

The scheduled `trivy` workflow started failing on 2026-06-04 because four
vulnerabilities were disclosed in `react-router` 7.13.2 (pulled in via
`react-router-dom`):

| CVE | Severity | Fixed in |
| --- | --- | --- |
| CVE-2026-34077 | HIGH | 7.14.0 |
| CVE-2026-42211 | HIGH | 7.14.2 |
| CVE-2026-42342 | HIGH | 7.15.0 |
| CVE-2026-40181 | MEDIUM | 7.14.1 |

## Change

Bump `react-router-dom` from `^7.13.2` to `^7.15.0` and refresh the lockfile,
which resolves to `react-router(-dom)` 7.17.0 — above every fixed version, so
all four advisories are cleared. This is a real upstream fix rather than a
`.trivyignore` suppression.

## Verification

- `pnpm run build` (tsc + vite build) passes.
- Diff is limited to `react-router(-dom)` entries in `package.json` /
  `pnpm-lock.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
