### PR TITLE
chore(deps): migrate gollem to gollem-dev org and upgrade to v0.26.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/fatih/color v1.19.0
 	github.com/getsentry/sentry-go v0.44.1
 	github.com/go-chi/chi/v5 v5.2.5
+	github.com/gollem-dev/gollem v0.26.0
 	github.com/google/go-github/v74 v74.0.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
@@ -21,7 +22,6 @@ require (
 	github.com/m-mizutani/clog v0.2.1
 	github.com/m-mizutani/fireconf v0.3.0
 	github.com/m-mizutani/goerr/v2 v2.0.1
-	github.com/m-mizutani/gollem v0.25.0
 	github.com/m-mizutani/gt v0.2.1
 	github.com/m-mizutani/harlog v0.0.3
 	github.com/m-mizutani/masq v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -218,6 +218,8 @@ github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63Y
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
+github.com/gollem-dev/gollem v0.26.0 h1:FIGZq1un1AWCXIU00VXdtJ3SPo5C2pwWj8jOc5z/yyY=
+github.com/gollem-dev/gollem v0.26.0/go.mod h1:qEZEgRi5g/tGoNQyLgq8uWfM7mhzCMkjdP2IZLSGSxM=
 github.com/google/flatbuffers v25.12.19+incompatible h1:haMV2JRRJCe1998HeW/p0X9UaMTK6SDo0ffLn2+DbLs=
 github.com/google/flatbuffers v25.12.19+incompatible/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
@@ -309,8 +311,6 @@ github.com/m-mizutani/fireconf v0.3.0 h1:SHWiNHcFhv8WLbG0LGiThHJfrfhgvTmiWzGj7By
 github.com/m-mizutani/fireconf v0.3.0/go.mod h1:6BC0xnXSSZQNAjLy2PC0QttFWjL7DCTxOHxTFrWS1ew=
 github.com/m-mizutani/goerr/v2 v2.0.1 h1:Z0XZiliOcCw/qoPR8dEle0xMQw781UmvlySbDHErU2U=
 github.com/m-mizutani/goerr/v2 v2.0.1/go.mod h1:Ax59zs+j3NmzB/mPLc1w3g4yIutdrwcY7cB6IRO18EU=
-github.com/m-mizutani/gollem v0.25.0 h1:TqFCugjhgQgsDfVmwr7V8V3Q0Rc8Igx5P1KFHtrEMn8=
-github.com/m-mizutani/gollem v0.25.0/go.mod h1:P1XLm5TS81vErrpu6hGhOL8UCkdXiFvQmSt+eayi8Hk=
 github.com/m-mizutani/gt v0.2.1 h1:mOl1PPIgEHoW2rQgqkfE31OGID06dO2uly8X8kvOEVY=
 github.com/m-mizutani/gt v0.2.1/go.mod h1:0MPYSfGBLmYjTduzADVmIqD58ELQ5IfBFiK/f0FmB3k=
 github.com/m-mizutani/harlog v0.0.3 h1:bL3i/xM3wWPsvoOOsuu/a4eaz+1yj1UyO7OPUzkWPyU=

--- a/pkg/adapter/trace/repository.go
+++ b/pkg/adapter/trace/repository.go
@@ -7,8 +7,8 @@ import (
 	"log/slog"
 
 	"cloud.google.com/go/storage"
+	"github.com/gollem-dev/gollem/trace"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem/trace"
 	"google.golang.org/api/option"
 )
 

--- a/pkg/adapter/trace/repository_test.go
+++ b/pkg/adapter/trace/repository_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
-	gollemtrace "github.com/m-mizutani/gollem/trace"
+	gollemtrace "github.com/gollem-dev/gollem/trace"
 	"github.com/m-mizutani/gt"
 	traceAdapter "github.com/secmon-lab/warren/pkg/adapter/trace"
 	"github.com/secmon-lab/warren/pkg/utils/logging"

--- a/pkg/agents/bigquery/agent.go
+++ b/pkg/agents/bigquery/agent.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/m-mizutani/gollem"
+	"github.com/gollem-dev/gollem"
 )
 
 // toolSet implements interfaces.ToolSet by wrapping the internalTool

--- a/pkg/agents/bigquery/export_test.go
+++ b/pkg/agents/bigquery/export_test.go
@@ -1,7 +1,7 @@
 package bigquery
 
 import (
-	"github.com/m-mizutani/gollem"
+	"github.com/gollem-dev/gollem"
 )
 
 // NewToolSetForTest creates a toolSet instance for testing with direct configuration

--- a/pkg/agents/bigquery/tool.go
+++ b/pkg/agents/bigquery/tool.go
@@ -7,9 +7,9 @@ import (
 
 	"cloud.google.com/go/bigquery"
 	"github.com/dustin/go-humanize"
+	"github.com/gollem-dev/gollem"
 	"github.com/google/uuid"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/types"
 	"github.com/secmon-lab/warren/pkg/utils/logging"
 	"github.com/secmon-lab/warren/pkg/utils/msg"

--- a/pkg/agents/falcon/agent.go
+++ b/pkg/agents/falcon/agent.go
@@ -3,7 +3,7 @@ package falcon
 import (
 	"context"
 
-	"github.com/m-mizutani/gollem"
+	"github.com/gollem-dev/gollem"
 )
 
 // toolSet implements interfaces.ToolSet for CrowdStrike Falcon.

--- a/pkg/agents/falcon/tool.go
+++ b/pkg/agents/falcon/tool.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/utils/logging"
 	"github.com/secmon-lab/warren/pkg/utils/msg"
 	"github.com/secmon-lab/warren/pkg/utils/safe"

--- a/pkg/agents/slack/agent.go
+++ b/pkg/agents/slack/agent.go
@@ -3,7 +3,7 @@ package slack
 import (
 	"context"
 
-	"github.com/m-mizutani/gollem"
+	"github.com/gollem-dev/gollem"
 )
 
 // toolSet implements interfaces.ToolSet by wrapping the internalTool.

--- a/pkg/agents/slack/export_test.go
+++ b/pkg/agents/slack/export_test.go
@@ -1,7 +1,7 @@
 package slack
 
 import (
-	"github.com/m-mizutani/gollem"
+	"github.com/gollem-dev/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 )
 

--- a/pkg/agents/slack/prompt.go
+++ b/pkg/agents/slack/prompt.go
@@ -3,7 +3,7 @@ package slack
 import (
 	_ "embed"
 
-	"github.com/m-mizutani/gollem"
+	"github.com/gollem-dev/gollem"
 )
 
 //go:embed prompt/system.md

--- a/pkg/agents/slack/tool.go
+++ b/pkg/agents/slack/tool.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	slackSDK "github.com/slack-go/slack"
 )

--- a/pkg/cli/config/claude.go
+++ b/pkg/cli/config/claude.go
@@ -3,8 +3,8 @@ package config
 import (
 	"context"
 
+	"github.com/gollem-dev/gollem/llm/claude"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem/llm/claude"
 	"github.com/urfave/cli/v3"
 )
 

--- a/pkg/cli/config/composite_llm.go
+++ b/pkg/cli/config/composite_llm.go
@@ -3,7 +3,7 @@ package config
 import (
 	"context"
 
-	"github.com/m-mizutani/gollem"
+	"github.com/gollem-dev/gollem"
 )
 
 type CompositeLLMClient struct {

--- a/pkg/cli/config/gemini.go
+++ b/pkg/cli/config/gemini.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"log/slog"
 
+	"github.com/gollem-dev/gollem/llm/gemini"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem/llm/gemini"
 	"github.com/urfave/cli/v3"
 )
 

--- a/pkg/cli/config/llm.go
+++ b/pkg/cli/config/llm.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"log/slog"
 
+	"github.com/gollem-dev/gollem"
+	"github.com/gollem-dev/gollem/llm/claude"
+	"github.com/gollem-dev/gollem/llm/gemini"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
-	"github.com/m-mizutani/gollem/llm/claude"
-	"github.com/m-mizutani/gollem/llm/gemini"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	"github.com/urfave/cli/v3"
 )

--- a/pkg/cli/config/mcp.go
+++ b/pkg/cli/config/mcp.go
@@ -6,9 +6,9 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/gollem-dev/gollem"
+	"github.com/gollem-dev/gollem/mcp"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
-	"github.com/m-mizutani/gollem/mcp"
 	helpertransport "github.com/secmon-lab/warren/pkg/service/mcp"
 	"github.com/urfave/cli/v3"
 	"gopkg.in/yaml.v3"

--- a/pkg/cli/config/noop_llm.go
+++ b/pkg/cli/config/noop_llm.go
@@ -3,7 +3,7 @@ package config
 import (
 	"context"
 
-	"github.com/m-mizutani/gollem"
+	"github.com/gollem-dev/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 )
 

--- a/pkg/cli/serve.go
+++ b/pkg/cli/serve.go
@@ -11,9 +11,9 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/gollem-dev/gollem"
+	"github.com/gollem-dev/gollem/trace"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
-	"github.com/m-mizutani/gollem/trace"
 
 	"github.com/secmon-lab/warren/pkg/adapter/storage"
 	traceAdapter "github.com/secmon-lab/warren/pkg/adapter/trace"

--- a/pkg/cli/utils.go
+++ b/pkg/cli/utils.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"log/slog"
 
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	"github.com/secmon-lab/warren/pkg/tool/abusech"
 	"github.com/secmon-lab/warren/pkg/tool/bigquery"

--- a/pkg/cli/utils_test.go
+++ b/pkg/cli/utils_test.go
@@ -5,7 +5,7 @@ import (
 	"log/slog"
 	"testing"
 
-	"github.com/m-mizutani/gollem"
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/gt"
 	"github.com/secmon-lab/warren/pkg/cli"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"

--- a/pkg/domain/interfaces/adaptor.go
+++ b/pkg/domain/interfaces/adaptor.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/m-mizutani/gollem"
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/opaq"
 	"github.com/secmon-lab/warren/pkg/domain/model/alert"
 	"github.com/secmon-lab/warren/pkg/domain/model/slack"

--- a/pkg/domain/interfaces/clients.go
+++ b/pkg/domain/interfaces/clients.go
@@ -1,6 +1,6 @@
 package interfaces
 
-import "github.com/m-mizutani/gollem"
+import "github.com/gollem-dev/gollem"
 
 type Clients struct {
 	repo    Repository

--- a/pkg/domain/interfaces/toolset.go
+++ b/pkg/domain/interfaces/toolset.go
@@ -3,7 +3,7 @@ package interfaces
 import (
 	"context"
 
-	"github.com/m-mizutani/gollem"
+	"github.com/gollem-dev/gollem"
 )
 
 // ToolSet extends gollem.ToolSet with Warren-specific metadata for planning.

--- a/pkg/domain/mock/interfaces.go
+++ b/pkg/domain/mock/interfaces.go
@@ -5,7 +5,7 @@ package mock
 
 import (
 	"context"
-	"github.com/m-mizutani/gollem"
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/opaq"
 	"github.com/secmon-lab/warren/pkg/domain/event"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"

--- a/pkg/domain/model/alert/alert.go
+++ b/pkg/domain/model/alert/alert.go
@@ -12,8 +12,8 @@ import (
 	"time"
 
 	"cloud.google.com/go/firestore"
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/model/lang"
 	"github.com/secmon-lab/warren/pkg/domain/model/prompt"
 	"github.com/secmon-lab/warren/pkg/domain/model/slack"

--- a/pkg/domain/model/alert/alert_test.go
+++ b/pkg/domain/model/alert/alert_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/m-mizutani/gollem"
-	gollem_mock "github.com/m-mizutani/gollem/mock"
+	"github.com/gollem-dev/gollem"
+	gollem_mock "github.com/gollem-dev/gollem/mock"
 	"github.com/m-mizutani/gt"
 	"github.com/secmon-lab/warren/pkg/domain/model/alert"
 	"github.com/secmon-lab/warren/pkg/domain/model/tag"

--- a/pkg/domain/model/alert/list.go
+++ b/pkg/domain/model/alert/list.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"cloud.google.com/go/firestore"
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/model/lang"
 	"github.com/secmon-lab/warren/pkg/domain/model/prompt"
 	"github.com/secmon-lab/warren/pkg/domain/model/slack"

--- a/pkg/domain/model/chat/context.go
+++ b/pkg/domain/model/chat/context.go
@@ -1,7 +1,7 @@
 package chat
 
 import (
-	"github.com/m-mizutani/gollem"
+	"github.com/gollem-dev/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/model/alert"
 	"github.com/secmon-lab/warren/pkg/domain/model/hitl"
 	"github.com/secmon-lab/warren/pkg/domain/model/session"

--- a/pkg/domain/model/ticket/ticket.go
+++ b/pkg/domain/model/ticket/ticket.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	"cloud.google.com/go/firestore"
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/model/alert"
 
 	"github.com/secmon-lab/warren/pkg/domain/model/lang"

--- a/pkg/service/command/core/core.go
+++ b/pkg/service/command/core/core.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	"github.com/secmon-lab/warren/pkg/domain/model/slack"
 	"github.com/secmon-lab/warren/pkg/domain/model/ticket"

--- a/pkg/service/command/service.go
+++ b/pkg/service/command/service.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"strings"
 
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	"github.com/secmon-lab/warren/pkg/domain/model/slack"
 	"github.com/secmon-lab/warren/pkg/service/command/abort"

--- a/pkg/service/knowledge/reflection.go
+++ b/pkg/service/knowledge/reflection.go
@@ -5,10 +5,10 @@ import (
 	_ "embed"
 	"encoding/json"
 
+	"github.com/gollem-dev/gollem"
+	"github.com/gollem-dev/gollem/trace"
 	"github.com/google/uuid"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
-	"github.com/m-mizutani/gollem/trace"
 	"github.com/secmon-lab/warren/pkg/domain/model/lang"
 	"github.com/secmon-lab/warren/pkg/domain/model/ticket"
 	"github.com/secmon-lab/warren/pkg/domain/types"

--- a/pkg/service/knowledge/service.go
+++ b/pkg/service/knowledge/service.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	"cloud.google.com/go/firestore"
+	"github.com/gollem-dev/gollem/trace"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem/trace"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	knowledgeModel "github.com/secmon-lab/warren/pkg/domain/model/knowledge"
 	"github.com/secmon-lab/warren/pkg/domain/types"

--- a/pkg/service/llm/ask.go
+++ b/pkg/service/llm/ask.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/utils/errutil"
 	"github.com/secmon-lab/warren/pkg/utils/logging"
 	"github.com/secmon-lab/warren/pkg/utils/msg"

--- a/pkg/service/llm/ask_test.go
+++ b/pkg/service/llm/ask_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/gollem-dev/gollem"
+	"github.com/gollem-dev/gollem/llm/gemini"
+	"github.com/gollem-dev/gollem/mock"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
-	"github.com/m-mizutani/gollem/llm/gemini"
-	"github.com/m-mizutani/gollem/mock"
 	"github.com/m-mizutani/gt"
 	"github.com/secmon-lab/warren/pkg/service/llm"
 )

--- a/pkg/service/llm/middleware.go
+++ b/pkg/service/llm/middleware.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"log/slog"
 
-	"github.com/m-mizutani/gollem"
-	"github.com/m-mizutani/gollem/middleware/compacter"
+	"github.com/gollem-dev/gollem"
+	"github.com/gollem-dev/gollem/middleware/compacter"
 	"github.com/secmon-lab/warren/pkg/utils/msg"
 )
 

--- a/pkg/service/llm/summary.go
+++ b/pkg/service/llm/summary.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/m-mizutani/gollem"
+	"github.com/gollem-dev/gollem"
 	"github.com/secmon-lab/warren/pkg/utils/msg"
 )
 

--- a/pkg/service/llm/summary_test.go
+++ b/pkg/service/llm/summary_test.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/m-mizutani/gollem/llm/gemini"
+	"github.com/gollem-dev/gollem/llm/gemini"
 	"github.com/m-mizutani/gt"
 	"github.com/secmon-lab/warren/pkg/service/llm"
 	"github.com/secmon-lab/warren/pkg/utils/msg"

--- a/pkg/service/storage/service.go
+++ b/pkg/service/storage/service.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	"github.com/secmon-lab/warren/pkg/domain/types"
 	"github.com/secmon-lab/warren/pkg/utils/errutil"

--- a/pkg/service/storage/service_test.go
+++ b/pkg/service/storage/service_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/m-mizutani/gollem"
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/gt"
 	adapter "github.com/secmon-lab/warren/pkg/adapter/storage"
 	"github.com/secmon-lab/warren/pkg/domain/types"

--- a/pkg/service/storage/session_history.go
+++ b/pkg/service/storage/session_history.go
@@ -6,8 +6,8 @@ import (
 
 	"context"
 
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/types"
 	"github.com/secmon-lab/warren/pkg/utils/safe"
 )

--- a/pkg/service/storage/session_history_test.go
+++ b/pkg/service/storage/session_history_test.go
@@ -3,7 +3,7 @@ package storage_test
 import (
 	"testing"
 
-	"github.com/m-mizutani/gollem"
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/gt"
 	adapterStorage "github.com/secmon-lab/warren/pkg/adapter/storage"
 	"github.com/secmon-lab/warren/pkg/domain/types"

--- a/pkg/tool/abusech/action.go
+++ b/pkg/tool/abusech/action.go
@@ -9,8 +9,8 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	"github.com/secmon-lab/warren/pkg/utils/errutil"
 	"github.com/secmon-lab/warren/pkg/utils/safe"

--- a/pkg/tool/base/action.go
+++ b/pkg/tool/base/action.go
@@ -5,8 +5,8 @@ import (
 	"log/slog"
 	"reflect"
 
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	"github.com/secmon-lab/warren/pkg/domain/model/ticket"
 	"github.com/secmon-lab/warren/pkg/domain/types"

--- a/pkg/tool/base/ticket_test.go
+++ b/pkg/tool/base/ticket_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/firestore"
-	"github.com/m-mizutani/gollem"
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/gt"
 	"github.com/secmon-lab/warren/pkg/domain/mock"
 	"github.com/secmon-lab/warren/pkg/domain/model/slack"

--- a/pkg/tool/bigquery/helper.go
+++ b/pkg/tool/bigquery/helper.go
@@ -12,9 +12,9 @@ import (
 
 	"cloud.google.com/go/bigquery"
 	"github.com/dustin/go-humanize"
+	"github.com/gollem-dev/gollem"
+	"github.com/gollem-dev/gollem/llm/gemini"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
-	"github.com/m-mizutani/gollem/llm/gemini"
 	"github.com/secmon-lab/warren/pkg/domain/model/prompt"
 	"github.com/secmon-lab/warren/pkg/service/llm"
 	"github.com/secmon-lab/warren/pkg/utils/logging"

--- a/pkg/tool/bigquery/tool.go
+++ b/pkg/tool/bigquery/tool.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/dustin/go-humanize"
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	"github.com/secmon-lab/warren/pkg/domain/model/bigquery"
 	"github.com/secmon-lab/warren/pkg/domain/types"

--- a/pkg/tool/github/action.go
+++ b/pkg/tool/github/action.go
@@ -11,9 +11,9 @@ import (
 	"time"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
+	"github.com/gollem-dev/gollem"
 	"github.com/google/go-github/v74/github"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	"github.com/secmon-lab/warren/pkg/utils/errutil"
 	"github.com/secmon-lab/warren/pkg/utils/logging"

--- a/pkg/tool/intune/action.go
+++ b/pkg/tool/intune/action.go
@@ -12,8 +12,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	"github.com/secmon-lab/warren/pkg/utils/errutil"
 	"github.com/secmon-lab/warren/pkg/utils/safe"

--- a/pkg/tool/ipdb/action.go
+++ b/pkg/tool/ipdb/action.go
@@ -9,8 +9,8 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	"github.com/secmon-lab/warren/pkg/utils/errutil"
 	"github.com/secmon-lab/warren/pkg/utils/safe"

--- a/pkg/tool/knowledge/tool.go
+++ b/pkg/tool/knowledge/tool.go
@@ -6,8 +6,8 @@ import (
 	"log/slog"
 	"strings"
 
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	knowledgeModel "github.com/secmon-lab/warren/pkg/domain/model/knowledge"
 	"github.com/secmon-lab/warren/pkg/domain/types"

--- a/pkg/tool/otx/action.go
+++ b/pkg/tool/otx/action.go
@@ -9,8 +9,8 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	"github.com/secmon-lab/warren/pkg/utils/errutil"
 	"github.com/secmon-lab/warren/pkg/utils/safe"

--- a/pkg/tool/shodan/action.go
+++ b/pkg/tool/shodan/action.go
@@ -9,8 +9,8 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	"github.com/secmon-lab/warren/pkg/utils/errutil"
 	"github.com/secmon-lab/warren/pkg/utils/safe"

--- a/pkg/tool/slack/action.go
+++ b/pkg/tool/slack/action.go
@@ -11,8 +11,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	"github.com/secmon-lab/warren/pkg/utils/errutil"
 	"github.com/secmon-lab/warren/pkg/utils/safe"

--- a/pkg/tool/urlscan/action.go
+++ b/pkg/tool/urlscan/action.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	"github.com/secmon-lab/warren/pkg/utils/clock"
 	"github.com/secmon-lab/warren/pkg/utils/errutil"

--- a/pkg/tool/vt/action.go
+++ b/pkg/tool/vt/action.go
@@ -9,8 +9,8 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	"github.com/secmon-lab/warren/pkg/utils/errutil"
 	"github.com/secmon-lab/warren/pkg/utils/safe"

--- a/pkg/tool/webfetch/action.go
+++ b/pkg/tool/webfetch/action.go
@@ -8,8 +8,8 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	"github.com/secmon-lab/warren/pkg/utils/errutil"
 	"github.com/secmon-lab/warren/pkg/utils/logging"

--- a/pkg/tool/webfetch/action_test.go
+++ b/pkg/tool/webfetch/action_test.go
@@ -6,9 +6,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/gollem-dev/gollem"
+	"github.com/gollem-dev/gollem/mock"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
-	"github.com/m-mizutani/gollem/mock"
 	"github.com/m-mizutani/gt"
 	"github.com/secmon-lab/warren/pkg/tool/webfetch"
 	"github.com/secmon-lab/warren/pkg/utils/errutil"

--- a/pkg/tool/webfetch/analyze.go
+++ b/pkg/tool/webfetch/analyze.go
@@ -6,8 +6,8 @@ import (
 	"encoding/json"
 	"strings"
 
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/model/prompt"
 	"github.com/secmon-lab/warren/pkg/utils/errutil"
 )

--- a/pkg/tool/webfetch/analyze_test.go
+++ b/pkg/tool/webfetch/analyze_test.go
@@ -6,10 +6,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/gollem-dev/gollem"
+	"github.com/gollem-dev/gollem/llm/gemini"
+	"github.com/gollem-dev/gollem/mock"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
-	"github.com/m-mizutani/gollem/llm/gemini"
-	"github.com/m-mizutani/gollem/mock"
 	"github.com/m-mizutani/gt"
 	"github.com/secmon-lab/warren/pkg/tool/webfetch"
 	"github.com/secmon-lab/warren/pkg/utils/errutil"

--- a/pkg/tool/webfetch/export_test.go
+++ b/pkg/tool/webfetch/export_test.go
@@ -3,7 +3,7 @@ package webfetch
 import (
 	"net/http"
 
-	"github.com/m-mizutani/gollem"
+	"github.com/gollem-dev/gollem"
 )
 
 // Extract is the test-only export of the package-private extract function.

--- a/pkg/tool/webfetch/llmflag.go
+++ b/pkg/tool/webfetch/llmflag.go
@@ -5,11 +5,11 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/gollem-dev/gollem"
+	"github.com/gollem-dev/gollem/llm/claude"
+	"github.com/gollem-dev/gollem/llm/gemini"
+	"github.com/gollem-dev/gollem/llm/openai"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
-	"github.com/m-mizutani/gollem/llm/claude"
-	"github.com/m-mizutani/gollem/llm/gemini"
-	"github.com/m-mizutani/gollem/llm/openai"
 	"github.com/secmon-lab/warren/pkg/utils/errutil"
 )
 

--- a/pkg/tool/webfetch/llmflag_test.go
+++ b/pkg/tool/webfetch/llmflag_test.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/gollem-dev/gollem"
+	"github.com/gollem-dev/gollem/mock"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
-	"github.com/m-mizutani/gollem/mock"
 	"github.com/m-mizutani/gt"
 	"github.com/secmon-lab/warren/pkg/tool/webfetch"
 	"github.com/secmon-lab/warren/pkg/utils/errutil"

--- a/pkg/tool/whois/action.go
+++ b/pkg/tool/whois/action.go
@@ -5,9 +5,9 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/gollem-dev/gollem"
 	whoislib "github.com/likexian/whois"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	"github.com/urfave/cli/v3"
 )

--- a/pkg/usecase/alert_pipeline.go
+++ b/pkg/usecase/alert_pipeline.go
@@ -6,8 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/event"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	"github.com/secmon-lab/warren/pkg/domain/model/alert"

--- a/pkg/usecase/alert_pipeline_test.go
+++ b/pkg/usecase/alert_pipeline_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/m-mizutani/gollem"
-	gollem_mock "github.com/m-mizutani/gollem/mock"
+	"github.com/gollem-dev/gollem"
+	gollem_mock "github.com/gollem-dev/gollem/mock"
 	"github.com/m-mizutani/gt"
 	"github.com/m-mizutani/opaq"
 	"github.com/secmon-lab/warren/pkg/domain/mock"

--- a/pkg/usecase/alert_test.go
+++ b/pkg/usecase/alert_test.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"cloud.google.com/go/firestore"
-	"github.com/m-mizutani/gollem"
-	gollem_mock "github.com/m-mizutani/gollem/mock"
+	"github.com/gollem-dev/gollem"
+	gollem_mock "github.com/gollem-dev/gollem/mock"
 	"github.com/m-mizutani/gt"
 	"github.com/m-mizutani/opaq"
 	"github.com/secmon-lab/warren/pkg/domain/mock"

--- a/pkg/usecase/chat.go
+++ b/pkg/usecase/chat.go
@@ -5,8 +5,8 @@ import (
 	_ "embed"
 	"errors"
 
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	"github.com/secmon-lab/warren/pkg/domain/model/alert"
 	chatModel "github.com/secmon-lab/warren/pkg/domain/model/chat"

--- a/pkg/usecase/chat/aster/aster.go
+++ b/pkg/usecase/chat/aster/aster.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gollem-dev/gollem"
+	"github.com/gollem-dev/gollem/trace"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
-	"github.com/m-mizutani/gollem/trace"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	chatModel "github.com/secmon-lab/warren/pkg/domain/model/chat"
 	"github.com/secmon-lab/warren/pkg/domain/model/hitl"

--- a/pkg/usecase/chat/aster/aster_test.go
+++ b/pkg/usecase/chat/aster/aster_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/m-mizutani/gt"
 	adapter "github.com/secmon-lab/warren/pkg/adapter/storage"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"

--- a/pkg/usecase/chat/aster/budget.go
+++ b/pkg/usecase/chat/aster/budget.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/m-mizutani/gollem"
+	"github.com/gollem-dev/gollem"
 )
 
 // BudgetStatus represents the current state of the action budget.

--- a/pkg/usecase/chat/aster/budget_test.go
+++ b/pkg/usecase/chat/aster/budget_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/m-mizutani/gollem"
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/gt"
 	"github.com/secmon-lab/warren/pkg/usecase/chat/aster"
 )

--- a/pkg/usecase/chat/aster/exec.go
+++ b/pkg/usecase/chat/aster/exec.go
@@ -7,9 +7,9 @@ import (
 	"sync"
 	"unicode/utf8"
 
+	"github.com/gollem-dev/gollem"
+	"github.com/gollem-dev/gollem/trace"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
-	"github.com/m-mizutani/gollem/trace"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	chatModel "github.com/secmon-lab/warren/pkg/domain/model/chat"
 	"github.com/secmon-lab/warren/pkg/domain/model/hitl"

--- a/pkg/usecase/chat/aster/export_test.go
+++ b/pkg/usecase/chat/aster/export_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	"github.com/secmon-lab/warren/pkg/domain/model/hitl"
 	knowledgeModel "github.com/secmon-lab/warren/pkg/domain/model/knowledge"

--- a/pkg/usecase/chat/aster/hitl.go
+++ b/pkg/usecase/chat/aster/hitl.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/model/hitl"
 	slackModel "github.com/secmon-lab/warren/pkg/domain/model/slack"
 	"github.com/secmon-lab/warren/pkg/domain/types"

--- a/pkg/usecase/chat/aster/hitl_test.go
+++ b/pkg/usecase/chat/aster/hitl_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/m-mizutani/gollem"
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/gt"
 	"github.com/secmon-lab/warren/pkg/domain/model/hitl"
 	"github.com/secmon-lab/warren/pkg/domain/types"

--- a/pkg/usecase/chat/aster/plan.go
+++ b/pkg/usecase/chat/aster/plan.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/gollem-dev/gollem"
+	"github.com/gollem-dev/gollem/trace"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
-	"github.com/m-mizutani/gollem/trace"
 	"github.com/secmon-lab/warren/pkg/domain/types"
 	knowledgeTool "github.com/secmon-lab/warren/pkg/tool/knowledge"
 	"github.com/secmon-lab/warren/pkg/utils/logging"

--- a/pkg/usecase/chat/aster/plan_test.go
+++ b/pkg/usecase/chat/aster/plan_test.go
@@ -6,8 +6,8 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/m-mizutani/gollem"
-	gollemtrace "github.com/m-mizutani/gollem/trace"
+	"github.com/gollem-dev/gollem"
+	gollemtrace "github.com/gollem-dev/gollem/trace"
 	"github.com/m-mizutani/gt"
 	"github.com/secmon-lab/warren/pkg/domain/mock"
 	chatModel "github.com/secmon-lab/warren/pkg/domain/model/chat"

--- a/pkg/usecase/chat/aster/prompt.go
+++ b/pkg/usecase/chat/aster/prompt.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	"github.com/secmon-lab/warren/pkg/domain/model/alert"
 	knowledgeModel "github.com/secmon-lab/warren/pkg/domain/model/knowledge"

--- a/pkg/usecase/chat/behavior_test.go
+++ b/pkg/usecase/chat/behavior_test.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/m-mizutani/gollem"
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/gt"
 	"github.com/m-mizutani/opaq"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"

--- a/pkg/usecase/chat/bluebell/bluebell.go
+++ b/pkg/usecase/chat/bluebell/bluebell.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gollem-dev/gollem"
+	"github.com/gollem-dev/gollem/trace"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
-	"github.com/m-mizutani/gollem/trace"
 	"github.com/secmon-lab/warren/pkg/cli/config"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	chatModel "github.com/secmon-lab/warren/pkg/domain/model/chat"

--- a/pkg/usecase/chat/bluebell/bluebell_test.go
+++ b/pkg/usecase/chat/bluebell/bluebell_test.go
@@ -8,8 +8,8 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/m-mizutani/gt"
 	"github.com/secmon-lab/warren/pkg/cli/config"
 	"github.com/secmon-lab/warren/pkg/domain/mock"

--- a/pkg/usecase/chat/bluebell/budget.go
+++ b/pkg/usecase/chat/bluebell/budget.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/m-mizutani/gollem"
+	"github.com/gollem-dev/gollem"
 )
 
 // BudgetStatus represents the current state of the action budget.

--- a/pkg/usecase/chat/bluebell/exec.go
+++ b/pkg/usecase/chat/bluebell/exec.go
@@ -7,9 +7,9 @@ import (
 	"sync"
 	"unicode/utf8"
 
+	"github.com/gollem-dev/gollem"
+	"github.com/gollem-dev/gollem/trace"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
-	"github.com/m-mizutani/gollem/trace"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	chatModel "github.com/secmon-lab/warren/pkg/domain/model/chat"
 	"github.com/secmon-lab/warren/pkg/domain/model/hitl"

--- a/pkg/usecase/chat/bluebell/hitl.go
+++ b/pkg/usecase/chat/bluebell/hitl.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/model/hitl"
 	slackModel "github.com/secmon-lab/warren/pkg/domain/model/slack"
 	"github.com/secmon-lab/warren/pkg/domain/types"

--- a/pkg/usecase/chat/bluebell/plan.go
+++ b/pkg/usecase/chat/bluebell/plan.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/gollem-dev/gollem"
+	"github.com/gollem-dev/gollem/trace"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
-	"github.com/m-mizutani/gollem/trace"
 	"github.com/secmon-lab/warren/pkg/domain/types"
 	knowledgeTool "github.com/secmon-lab/warren/pkg/tool/knowledge"
 	"github.com/secmon-lab/warren/pkg/utils/logging"

--- a/pkg/usecase/chat/bluebell/plan_test.go
+++ b/pkg/usecase/chat/bluebell/plan_test.go
@@ -6,8 +6,8 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/m-mizutani/gollem"
-	gollemtrace "github.com/m-mizutani/gollem/trace"
+	"github.com/gollem-dev/gollem"
+	gollemtrace "github.com/gollem-dev/gollem/trace"
 	"github.com/m-mizutani/gt"
 	"github.com/secmon-lab/warren/pkg/domain/mock"
 	chatModel "github.com/secmon-lab/warren/pkg/domain/model/chat"

--- a/pkg/usecase/chat/bluebell/prompt.go
+++ b/pkg/usecase/chat/bluebell/prompt.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	"github.com/secmon-lab/warren/pkg/domain/model/alert"
 	knowledgeModel "github.com/secmon-lab/warren/pkg/domain/model/knowledge"

--- a/pkg/usecase/chat/bluebell/selector.go
+++ b/pkg/usecase/chat/bluebell/selector.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/cli/config"
 	chatModel "github.com/secmon-lab/warren/pkg/domain/model/chat"
 	"github.com/secmon-lab/warren/pkg/domain/model/prompt"

--- a/pkg/usecase/chat/bluebell/selector_test.go
+++ b/pkg/usecase/chat/bluebell/selector_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/m-mizutani/gollem"
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/gt"
 	"github.com/secmon-lab/warren/pkg/cli/config"
 	"github.com/secmon-lab/warren/pkg/domain/mock"

--- a/pkg/usecase/chat/history.go
+++ b/pkg/usecase/chat/history.go
@@ -3,8 +3,8 @@ package chat
 import (
 	"context"
 
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/types"
 	"github.com/secmon-lab/warren/pkg/service/storage"
 	"github.com/secmon-lab/warren/pkg/utils/logging"

--- a/pkg/usecase/chat/history_test.go
+++ b/pkg/usecase/chat/history_test.go
@@ -3,7 +3,7 @@ package chat_test
 import (
 	"testing"
 
-	"github.com/m-mizutani/gollem"
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/gt"
 	adapter "github.com/secmon-lab/warren/pkg/adapter/storage"
 	"github.com/secmon-lab/warren/pkg/domain/types"

--- a/pkg/usecase/chat_test.go
+++ b/pkg/usecase/chat_test.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/m-mizutani/gt"
 	"github.com/m-mizutani/opaq"
 	"github.com/secmon-lab/warren/pkg/adapter/storage"

--- a/pkg/usecase/diagnosis/missing_alert_metadata.go
+++ b/pkg/usecase/diagnosis/missing_alert_metadata.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	alertmodel "github.com/secmon-lab/warren/pkg/domain/model/alert"
 	diagnosismodel "github.com/secmon-lab/warren/pkg/domain/model/diagnosis"

--- a/pkg/usecase/diagnosis/missing_embedding.go
+++ b/pkg/usecase/diagnosis/missing_embedding.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	diagnosismodel "github.com/secmon-lab/warren/pkg/domain/model/diagnosis"
 	"github.com/secmon-lab/warren/pkg/domain/types"

--- a/pkg/usecase/generate_comment_test.go
+++ b/pkg/usecase/generate_comment_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/m-mizutani/gt"
 	"github.com/secmon-lab/warren/pkg/domain/mock"
 	"github.com/secmon-lab/warren/pkg/domain/model/alert"

--- a/pkg/usecase/migration/bundle_v0_16_0_test.go
+++ b/pkg/usecase/migration/bundle_v0_16_0_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/m-mizutani/gollem"
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/gt"
 	adapterStorage "github.com/secmon-lab/warren/pkg/adapter/storage"
 	sessModel "github.com/secmon-lab/warren/pkg/domain/model/session"

--- a/pkg/usecase/migration/history_scope_test.go
+++ b/pkg/usecase/migration/history_scope_test.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/m-mizutani/gollem"
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/gt"
 	adapterStorage "github.com/secmon-lab/warren/pkg/adapter/storage"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"

--- a/pkg/usecase/refine.go
+++ b/pkg/usecase/refine.go
@@ -7,8 +7,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/model/alert"
 	"github.com/secmon-lab/warren/pkg/domain/model/lang"
 	"github.com/secmon-lab/warren/pkg/domain/model/prompt"

--- a/pkg/usecase/refine_test.go
+++ b/pkg/usecase/refine_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/m-mizutani/gollem"
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/gt"
 	"github.com/secmon-lab/warren/pkg/domain/mock"
 	"github.com/secmon-lab/warren/pkg/domain/model/alert"

--- a/pkg/usecase/slack_itx_block_comment_test.go
+++ b/pkg/usecase/slack_itx_block_comment_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/m-mizutani/gollem"
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/gt"
 	"github.com/secmon-lab/warren/pkg/domain/mock"
 	"github.com/secmon-lab/warren/pkg/domain/model/alert"

--- a/pkg/usecase/slack_itx_block_test.go
+++ b/pkg/usecase/slack_itx_block_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gollem-dev/gollem"
+	gollem_mock "github.com/gollem-dev/gollem/mock"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
-	gollem_mock "github.com/m-mizutani/gollem/mock"
 	"github.com/m-mizutani/gt"
 	"github.com/newmo-oss/go-caller"
 	"github.com/secmon-lab/warren/pkg/domain/mock"

--- a/pkg/usecase/slack_itx_submit.go
+++ b/pkg/usecase/slack_itx_submit.go
@@ -6,8 +6,8 @@ import (
 	"encoding/json"
 	"strconv"
 
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/secmon-lab/warren/pkg/domain/model/alert"
 	"github.com/secmon-lab/warren/pkg/domain/model/lang"
 	"github.com/secmon-lab/warren/pkg/domain/model/prompt"

--- a/pkg/usecase/slack_itx_submit_test.go
+++ b/pkg/usecase/slack_itx_submit_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 	"github.com/m-mizutani/gt"
 	"github.com/secmon-lab/warren/pkg/domain/mock"
 	"github.com/secmon-lab/warren/pkg/domain/model/alert"

--- a/pkg/usecase/ticket_test.go
+++ b/pkg/usecase/ticket_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/m-mizutani/gollem"
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/gt"
 	"github.com/secmon-lab/warren/pkg/domain/mock"
 	"github.com/secmon-lab/warren/pkg/domain/model/alert"

--- a/pkg/usecase/usecase.go
+++ b/pkg/usecase/usecase.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"time"
 
+	"github.com/gollem-dev/gollem"
+	"github.com/gollem-dev/gollem/trace"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
-	"github.com/m-mizutani/gollem/trace"
 	"github.com/m-mizutani/opaq"
 	"github.com/secmon-lab/warren/pkg/domain/interfaces"
 	"github.com/secmon-lab/warren/pkg/domain/model/slack"

--- a/pkg/utils/embedding/embedding.go
+++ b/pkg/utils/embedding/embedding.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 
 	"cloud.google.com/go/firestore"
+	"github.com/gollem-dev/gollem"
 	"github.com/m-mizutani/goerr/v2"
-	"github.com/m-mizutani/gollem"
 )
 
 const (

--- a/pkg/utils/test/llm.go
+++ b/pkg/utils/test/llm.go
@@ -3,8 +3,8 @@ package test
 import (
 	"testing"
 
-	"github.com/m-mizutani/gollem"
-	"github.com/m-mizutani/gollem/llm/gemini"
+	"github.com/gollem-dev/gollem"
+	"github.com/gollem-dev/gollem/llm/gemini"
 )
 
 func NewGeminiClient(t *testing.T) gollem.LLMClient {


### PR DESCRIPTION
## Summary

The gollem library has moved from `github.com/m-mizutani/gollem` to `github.com/gollem-dev/gollem` (organization migration). This PR updates all import paths to the new module path and bumps the version from v0.25.0 to v0.26.0.

Per the [v0.26.0 release notes](https://github.com/gollem-dev/gollem/releases/tag/v0.26.0), this is a **path-only migration with no API or behavioral changes** — code compiles and behaves exactly as before.

## Changes

- Replaced the import path `github.com/m-mizutani/gollem` → `github.com/gollem-dev/gollem` across **108 Go files** (including subpackages `trace`, `mock`, `llm/gemini`, `llm/claude`, `llm/openai`, `mcp`, `middleware/compacter`).
- Updated `go.mod` require to the new path at `v0.26.0` and ran `go mod tidy` to sync `go.sum`.
- Re-formatted import blocks with `gofmt` (the new path sorts before the old `m-mizutani` grouping).

## Verification

- `go vet ./...` — no errors
- `go test ./...` — all pass (72 packages ok, 0 failures)
- `golangci-lint run ./...` — 0 issues
- `gosec` — only pre-existing findings, none introduced by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)