### PR TITLE
fix(agents): slack context explicit-zero + gollem v0.27.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/fatih/color v1.19.0
 	github.com/getsentry/sentry-go v0.44.1
 	github.com/go-chi/chi/v5 v5.2.5
-	github.com/gollem-dev/gollem v0.26.2-0.20260630002044-aed22083a5b0
+	github.com/gollem-dev/gollem v0.27.0
 	github.com/gollem-dev/tools/abusech v0.2.0
 	github.com/gollem-dev/tools/bigquery v0.2.0
 	github.com/gollem-dev/tools/github v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -218,8 +218,8 @@ github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63Y
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
-github.com/gollem-dev/gollem v0.26.2-0.20260630002044-aed22083a5b0 h1:8W3NXX/O2S1TQF7dTYQUER+H39cnny4V32DanPQyB+Y=
-github.com/gollem-dev/gollem v0.26.2-0.20260630002044-aed22083a5b0/go.mod h1:20atdewh0lJcT3JV7eD3VeemZqwLFJFO7cQsBFnOtdk=
+github.com/gollem-dev/gollem v0.27.0 h1:h2rMohrG5gjvIQdWHKDZzNbwL6M1VUj/VtIYiu2q4t4=
+github.com/gollem-dev/gollem v0.27.0/go.mod h1:20atdewh0lJcT3JV7eD3VeemZqwLFJFO7cQsBFnOtdk=
 github.com/gollem-dev/tools/abusech v0.2.0 h1:VxLz8IRIYrajTb6YyVR7D5g9fIAvmV7nkh8K10JJCYw=
 github.com/gollem-dev/tools/abusech v0.2.0/go.mod h1:sPSiX1y2ci+ne4SA+VSJ//rFMJ2kKj/ELIKDPF6CuIk=
 github.com/gollem-dev/tools/bigquery v0.2.0 h1:MsOaLHPNK5baVvjr7v/5JME7EXdhsq/Glm/JUvUA8ig=

--- a/pkg/agents/slack/tool.go
+++ b/pkg/agents/slack/tool.go
@@ -98,10 +98,14 @@ type getThreadMessagesInput struct {
 }
 
 type getContextMessagesInput struct {
-	Channel  string  `json:"channel" required:"true" description:"Channel ID"`
-	AroundTS string  `json:"around_ts" required:"true" description:"Timestamp of the message to get context around"`
-	Before   float64 `json:"before" description:"Number of messages before the timestamp (default: 10)"`
-	After    float64 `json:"after" description:"Number of messages after the timestamp (default: 10)"`
+	Channel  string `json:"channel" required:"true" description:"Channel ID"`
+	AroundTS string `json:"around_ts" required:"true" description:"Timestamp of the message to get context around"`
+	// Before/After are pointers so an omitted argument (nil → default 10) can be
+	// distinguished from an explicit 0 ("fetch nothing on this side"), which a
+	// plain value field would collapse into the default. The pointer is unwrapped
+	// to float64 for schema inference, so the wire type stays "number".
+	Before *float64 `json:"before" description:"Number of messages before the timestamp (default: 10)"`
+	After  *float64 `json:"after" description:"Number of messages after the timestamp (default: 10)"`
 }
 
 // Startup assertions: validate each tool's In/Out types form a valid schema at
@@ -242,15 +246,17 @@ func (t *internalTool) getContextMessages(ctx context.Context, in getContextMess
 		return nil, goerr.New("around_ts is required")
 	}
 
-	// A zero/absent count falls back to the documented default of 10.
+	// nil (argument omitted) falls back to the documented default of 10; an
+	// explicit value — including 0, meaning "fetch nothing on this side" — is
+	// honored as-is.
 	before := 10
-	if in.Before > 0 {
-		before = int(in.Before)
+	if in.Before != nil {
+		before = int(*in.Before)
 	}
 
 	after := 10
-	if in.After > 0 {
-		after = int(in.After)
+	if in.After != nil {
+		after = int(*in.After)
 	}
 
 	// Parse the timestamp

--- a/pkg/agents/slack/tool_test.go
+++ b/pkg/agents/slack/tool_test.go
@@ -224,6 +224,53 @@ func TestInternalTool_GetContextMessages(t *testing.T) {
 	gt.V(t, afterMsg["user_name"]).Equal("user2")
 }
 
+// TestInternalTool_GetContextMessages_ExplicitZeroSkipsSide guards the regression
+// where an explicit before=0 (meaning "fetch nothing before, only after") was
+// collapsed into the default of 10 by a `> 0` value check. The pointer-typed
+// field must let an explicit 0 skip that side while an omitted field defaults.
+func TestInternalTool_GetContextMessages_ExplicitZeroSkipsSide(t *testing.T) {
+	ctx := context.Background()
+
+	var beforeCalls, afterCalls int
+	slackClient := &domainmock.SlackClientMock{
+		GetConversationHistoryContextFunc: func(ctx context.Context, params *slackSDK.GetConversationHistoryParameters) (*slackSDK.GetConversationHistoryResponse, error) {
+			if params.Latest != "" {
+				beforeCalls++
+			}
+			if params.Oldest != "" {
+				afterCalls++
+			}
+			return &slackSDK.GetConversationHistoryResponse{
+				Messages: []slackSDK.Message{
+					{Msg: slackSDK.Msg{Timestamp: "1234567892.654321", Text: "ctx", Username: "u"}},
+				},
+			}, nil
+		},
+	}
+
+	tool := slackagent.NewInternalToolForTest(slackClient, 0)
+
+	result, err := tool.Run(ctx, "slack_get_context_messages", map[string]any{
+		"channel":   "C123456",
+		"around_ts": "1234567890",
+		"before":    float64(0),
+		"after":     float64(2),
+	})
+	gt.NoError(t, err)
+
+	// before=0 must skip the "before" fetch entirely; after=2 still runs.
+	gt.V(t, beforeCalls).Equal(0)
+	gt.V(t, afterCalls).Equal(1)
+
+	beforeMessages, ok := result["before_messages"].([]any)
+	gt.True(t, ok)
+	gt.V(t, len(beforeMessages)).Equal(0)
+
+	afterMessages, ok := result["after_messages"].([]any)
+	gt.True(t, ok)
+	gt.V(t, len(afterMessages)).Equal(1)
+}
+
 func TestInternalTool_DirectLimitEnforcement(t *testing.T) {
 	ctx := context.Background()
 

--- a/pkg/tool/bigquery/helper.go
+++ b/pkg/tool/bigquery/helper.go
@@ -335,8 +335,6 @@ func generateConfigWithFactory(ctx context.Context, cfg generateConfigInput, fac
 		gollem.WithToolSets(newConfigGeneratorTools(
 			bqClient,
 			cfg.ScanLimit,
-			cfg.TableDatasetID,
-			cfg.TableTableID,
 			outputPath,
 			tableMetadata,
 		)),
@@ -388,12 +386,10 @@ func generateConfigSchema() string {
 
 // configGeneratorTools implements gollem.ToolSet
 type configGeneratorTools struct {
-	bqClient       BigQueryClient
-	scanLimit      uint64
-	tableDatasetID string
-	tableTableID   string
-	outputPath     string
-	metadata       *bigquery.TableMetadata
+	bqClient   BigQueryClient
+	scanLimit  uint64
+	outputPath string
+	metadata   *bigquery.TableMetadata
 
 	tools gollem.ToolSet
 }
@@ -420,14 +416,12 @@ var (
 
 // newConfigGeneratorTools builds the configGeneratorTools and its type-safe tool
 // set. The bigquery_query description embeds the configured scan-size limit.
-func newConfigGeneratorTools(bqClient BigQueryClient, scanLimit uint64, tableDatasetID, tableTableID, outputPath string, metadata *bigquery.TableMetadata) *configGeneratorTools {
+func newConfigGeneratorTools(bqClient BigQueryClient, scanLimit uint64, outputPath string, metadata *bigquery.TableMetadata) *configGeneratorTools {
 	t := &configGeneratorTools{
-		bqClient:       bqClient,
-		scanLimit:      scanLimit,
-		tableDatasetID: tableDatasetID,
-		tableTableID:   tableTableID,
-		outputPath:     outputPath,
-		metadata:       metadata,
+		bqClient:   bqClient,
+		scanLimit:  scanLimit,
+		outputPath: outputPath,
+		metadata:   metadata,
 	}
 	queryDesc := fmt.Sprintf("Execute SQL query against BigQuery. Performs dry run to check scan size (limit: %s). Only use field names from the provided schema.", humanize.Bytes(scanLimit))
 	t.tools = toolset.New(

--- a/pkg/tool/bigquery/helper.go
+++ b/pkg/tool/bigquery/helper.go
@@ -332,14 +332,14 @@ func generateConfigWithFactory(ctx context.Context, cfg generateConfigInput, fac
 		gollem.WithLogger(logger),
 		gollem.WithContentBlockMiddleware(llm.NewCompactionMiddleware(llmClient, logger)),
 		gollem.WithContentStreamMiddleware(llm.NewCompactionStreamMiddleware(llmClient)),
-		gollem.WithToolSets(newConfigGeneratorTools(&configGeneratorTools{
-			bqClient:       bqClient,
-			scanLimit:      cfg.ScanLimit,
-			tableDatasetID: cfg.TableDatasetID,
-			tableTableID:   cfg.TableTableID,
-			outputPath:     outputPath,
-			metadata:       tableMetadata,
-		})),
+		gollem.WithToolSets(newConfigGeneratorTools(
+			bqClient,
+			cfg.ScanLimit,
+			cfg.TableDatasetID,
+			cfg.TableTableID,
+			outputPath,
+			tableMetadata,
+		)),
 	)
 
 	if _, err := agent.Execute(ctx, gollem.Text("Generate configuration")); err != nil {
@@ -420,8 +420,16 @@ var (
 
 // newConfigGeneratorTools builds the configGeneratorTools and its type-safe tool
 // set. The bigquery_query description embeds the configured scan-size limit.
-func newConfigGeneratorTools(t *configGeneratorTools) *configGeneratorTools {
-	queryDesc := fmt.Sprintf("Execute SQL query against BigQuery. Performs dry run to check scan size (limit: %s). Only use field names from the provided schema.", humanize.Bytes(t.scanLimit))
+func newConfigGeneratorTools(bqClient BigQueryClient, scanLimit uint64, tableDatasetID, tableTableID, outputPath string, metadata *bigquery.TableMetadata) *configGeneratorTools {
+	t := &configGeneratorTools{
+		bqClient:       bqClient,
+		scanLimit:      scanLimit,
+		tableDatasetID: tableDatasetID,
+		tableTableID:   tableTableID,
+		outputPath:     outputPath,
+		metadata:       metadata,
+	}
+	queryDesc := fmt.Sprintf("Execute SQL query against BigQuery. Performs dry run to check scan size (limit: %s). Only use field names from the provided schema.", humanize.Bytes(scanLimit))
 	t.tools = toolset.New(
 		gollem.MustNewTool("bigquery_query", queryDesc, t.executeBigQueryQuery),
 		gollem.MustNewTool("generate_config", "Generate the final YAML configuration. This validates the config against the actual schema and saves it to a file.", t.generateConfigOutput),


### PR DESCRIPTION
Follow-up to #226. Addresses review feedback on the typed-tool migration and picks up the tagged gollem release.

## Changes

### Fix: honor explicit `before`/`after` = 0 in the Slack context tool
`agents/slack` `slack_get_context_messages` regressed when the typed migration replaced the raw arg read with a `> 0` guard: an explicit `before: 0` (meaning "fetch nothing before, only after") was collapsed into the default of 10. A typed value field cannot distinguish an omitted argument from an explicit `0`.

- `Before` / `After` are now `*float64`: `nil` (omitted) → default 10, a non-nil value (including 0) is honored as-is.
- The pointer is unwrapped to `float64` for schema inference, so the wire type stays `number` — no schema change.
- Added `TestInternalTool_GetContextMessages_ExplicitZeroSkipsSide` covering the explicit-zero path.

(The `> 0` defaulting for `limit` / `count` / `page` elsewhere is intentional — 0 / negative counts are meaningless there, so it is a robustness improvement, not a regression.)

### Cleanup: bigquery config-tool constructor
`newConfigGeneratorTools` previously took a pre-built `*configGeneratorTools` and returned the same pointer ("a constructor taking its own output type"). It now takes the individual fields and constructs the value itself.

### Deps: gollem → v0.27.0
Moves off the `main` pseudo-version pulled in by #226 to the tagged `v0.27.0` release. The typed-tool / schema APIs are byte-for-byte identical to the pseudo-version, so this is a pin-to-release with no behavior change.

## Test
- `go vet ./...`, `go test ./...` — all pass.
- `golangci-lint run`, `gofmt -l` — clean.
